### PR TITLE
Add basic debugging experience for C++

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -6,7 +6,7 @@
     - Ubuntu/Debian package: `golang-go`
 - C/C++ toolchain (+ standard library) supporting C++20, Clang >= 14 recommended
     - Ubuntu/Debian package: `clang`
-    - Recommended: install `clang-format` and `clangd` for development
+    - Recommended: install `clang-format`, `clangd`, and `gdb` for development
 - [Bazel](https://bazel.build/)
     - Install Bazelisk via Go¹:
       ```
@@ -41,6 +41,21 @@ Open the `cpp` subdirectory in VSCode:
 - Install recommended extensions: press `F1` → *Show Recommended Extensions*
 - Generate `compile_commands.json`: press `F1` → *Generate Compilation Database*
 
+### Build / Run in VSCode
+
+Some tasks are defined in [`task.json`](cpp/.vscode/tasks.json) to ease building and testing during development.
+Tasks can be run via `F1` → *Tasks: Run …*
+
+### Debug in VSCode
+
+The debugging targets are defined in [`launch.json`](cpp/.vscode/launch.json).
+`gdb` must be installed for this to work.
+
+Right now, this is only used to debug unit tests.
+With a unit test file open (e.g. `word_test.cc`), set a break point and press `F5`.
+
+### Build / Run Manually
+
 To build different configurations, invoke Bazel in the `cpp` subdirectory:
 
 ```bash
@@ -62,3 +77,5 @@ bazel test //common/...
 # Run individual test or binary
 bazel run //common:word_test
 ```
+
+> Note: VSCode's multi-root workspace feature does not play nice with these extensions.

--- a/cpp/.vscode/extensions.json
+++ b/cpp/.vscode/extensions.json
@@ -4,6 +4,7 @@
         "stackbuild.bazel-stack-vscode",
         "stackbuild.bazel-stack-vscode-cc",
         "llvm-vs-code-extensions.vscode-clangd",
-        "xaver.clang-format"
+        "xaver.clang-format",
+        "webfreak.debug"
     ]
 }

--- a/cpp/.vscode/launch.json
+++ b/cpp/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Current File w/ GDB",
+            "preLaunchTask": "Build Debug",
+            "type": "gdb",
+            "request": "launch",
+            "target": "${workspaceFolder}/bazel-bin/${relativeFileDirname}/${fileBasenameNoExtension}",
+            "cwd": "${workspaceRoot}",
+            "valuesFormatting": "parseText"
+        }
+    ]
+}

--- a/cpp/.vscode/tasks.json
+++ b/cpp/.vscode/tasks.json
@@ -1,0 +1,48 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build Debug",
+            "type": "shell",
+            "command": "bazel build -c dbg //...",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Test Debug",
+            "dependsOn": "Build Debug",
+            "type": "shell",
+            "command": "bazel test -c dbg //...",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": true
+            },
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        },
+    ]
+}


### PR DESCRIPTION
This PR adds some rudimentary debugging experience for the C++ module(s).

We currently leverage GDB via the [Native Debug](https://marketplace.visualstudio.com/items?itemName=webfreak.debug) extension.

The [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extension could be used as an alternative if we encounter issues with Native Debug.

---

I tried using [Delve](https://github.com/go-delve/delve) for debugging Go, but it appears as if you cannot debug across FFI boundaries with it. Go programs can still be debugged with GDB; although, this is not recommended as GDB does not understand all of Go's internals and may therefore not work correctly.

Using GDB and dlv in combination for the same process is not possible (as far as I can tell), since both use ptrace for debugging -- which cannot be shared.

ref #6 