### PR TITLE
Add support for basic operators to Word (using intx)

### DIFF
--- a/.github/workflows/cpp-osx.yml
+++ b/.github/workflows/cpp-osx.yml
@@ -31,5 +31,5 @@ jobs:
 
     - name: Run C++ tests
       working-directory: ./cpp
-      run: bazel test --test_output=errors //...
+      run: bazel test --verbose_failures --test_output=errors //...
 

--- a/cpp/.bazelrc
+++ b/cpp/.bazelrc
@@ -2,6 +2,7 @@ build --cxxopt=-std=c++20
 build --cxxopt=-Wpedantic
 build --cxxopt=-Wall
 build --cxxopt=-Wextra
+build --cxxopt=-Wtype-limits
 build --cxxopt=-Wconversion
 build --cxxopt=-Wsign-conversion
 build --cxxopt=-Wdouble-promotion

--- a/cpp/WORKSPACE
+++ b/cpp/WORKSPACE
@@ -20,3 +20,11 @@ http_archive(
     strip_prefix = "abseil-cpp-b971ac5250ea8de900eae9f95e06548d14cd95fe",
     urls = ["https://github.com/abseil/abseil-cpp/archive/b971ac5250ea8de900eae9f95e06548d14cd95fe.zip"],
 )
+
+http_archive(
+    name = "com_github_chfast_intx",
+    build_file = "@//third_party/intx:intx.BUILD",
+    sha256 = "2e65da2b49d400910d19004e402ffc9321e07384d6c483dba341b6f12811ca0c",
+    strip_prefix = "intx-bc106fa0ab5b7dad2d7f78b08168382ed5eabee8",
+    urls = ["https://github.com/chfast/intx/archive/bc106fa0ab5b7dad2d7f78b08168382ed5eabee8.zip"],
+)

--- a/cpp/common/BUILD
+++ b/cpp/common/BUILD
@@ -6,6 +6,9 @@ cc_library(
     srcs = ["word.cc"],
     hdrs = ["word.h"],
     visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_chfast_intx//:intx",
+    ],
 )
 
 cc_test(

--- a/cpp/common/word.cc
+++ b/cpp/common/word.cc
@@ -1,8 +1,8 @@
 #include "common/word.h"
 
-#include <array>
-#include <cstdint>
-#include <ostream>
+#include <memory>
+
+#include "intx/intx.hpp"
 
 namespace tosca {
 
@@ -10,20 +10,157 @@ static_assert(std::is_trivial_v<Word>);
 static_assert(std::is_trivially_assignable_v<Word, Word>);
 static_assert(sizeof(Word) == 32);
 
+#ifndef __APPLE__  // std::endian not available on OSX
+static_assert(std::endian::native == std::endian::little, "Only supporting little-endian systems so far");
+#endif
+
+// Cannot use std::bit_cast on OSX as of 2023-04-24, using reinterpret_cast
+// instead.
+static Word FromUint256(intx::uint256 v) { return reinterpret_cast<Word&>(v); }
+static intx::uint256 ToUint256(Word v) { return reinterpret_cast<intx::uint256&>(v); }
+static_assert(sizeof(intx::uint256) == sizeof(Word));
+
 Word::Word(std::initializer_list<const std::uint8_t> list) {
-  for (std::size_t i = 0; i < list.size() && i < data_.size(); i++) {
-    data_[i] = static_cast<std::byte>(std::data(list)[i]);
+  auto dst = data_.begin();
+  auto src = std::rbegin(list);
+  for (; dst != data_.end() && src != std::rend(list); ++dst, ++src) {
+    *dst = static_cast<std::byte>(*src);
   }
-  for (std::size_t i = list.size(); i < data_.size(); i++) {
-    data_[i] = std::byte(0);
+  std::fill(dst, data_.end(), std::byte{0});
+}
+
+std::byte Word::operator[](std::uint8_t offset) const {
+  if (offset < data_.size()) {
+    return data_[(data_.size() - 1u) - offset];
+  } else {
+    return std::byte{0};
   }
+}
+
+std::byte Word::operator[](const Word& offset) const {
+  const auto size = static_cast<std::uint8_t>(data_.size());
+
+  if (offset < Word{size}) {
+    return data_[(size - 1u) - static_cast<std::uint8_t>(offset.data_[0])];
+  } else {
+    return std::byte{0};
+  }
+}
+
+std::strong_ordering Word::operator<=>(const Word& other) const {
+  for (std::size_t i = data_.size() - 1; i > 0; --i) {
+    if (data_[i] != other.data_[i]) {
+      return data_[i] <=> other.data_[i];
+    }
+  }
+  return data_[0] <=> other.data_[0];
+}
+
+Word Word::operator+(const Word& other) const {
+  auto a = ToUint256(*this);
+  auto b = ToUint256(other);
+  return FromUint256(a + b);
+}
+
+Word Word::operator-(const Word& other) const {
+  auto a = ToUint256(*this);
+  auto b = ToUint256(other);
+  return FromUint256(a - b);
+}
+
+Word Word::operator*(const Word& other) const {
+  auto a = ToUint256(*this);
+  auto b = ToUint256(other);
+  return FromUint256(a * b);
+}
+
+Word Word::operator/(const Word& denom) const {
+  if (denom == Word{0}) {
+    return Word{0};
+  }
+
+  auto a = ToUint256(*this);
+  auto b = ToUint256(denom);
+  return FromUint256(a / b);
+}
+
+Word Word::operator%(const Word& denom) const {
+  if (denom == Word{0}) {
+    return Word{0};
+  }
+
+  auto a = ToUint256(*this);
+  auto b = ToUint256(denom);
+  return FromUint256(a % b);
+}
+
+Word Word::operator<<(const Word& shift) const {
+  auto a = ToUint256(*this);
+  auto b = ToUint256(shift);
+  return FromUint256(a << b);
+}
+
+Word Word::operator>>(const Word& shift) const {
+  auto a = ToUint256(*this);
+  auto b = ToUint256(shift);
+  return FromUint256(a >> b);
+}
+
+Word Word::operator|(const Word& other) const {
+  auto a = ToUint256(*this);
+  auto b = ToUint256(other);
+  return FromUint256(a | b);
+}
+
+Word Word::operator&(const Word& other) const {
+  auto a = ToUint256(*this);
+  auto b = ToUint256(other);
+  return FromUint256(a & b);
+}
+
+Word Word::operator^(const Word& other) const {
+  auto a = ToUint256(*this);
+  auto b = ToUint256(other);
+  return FromUint256(a ^ b);
+}
+
+Word Word::operator~() const {
+  auto a = ToUint256(*this);
+  return FromUint256(~a);
+}
+
+Word Word::SignedDiv(const Word& denom) const {
+  if (denom == Word{0}) {
+    return Word{0};
+  }
+
+  auto a = ToUint256(*this);
+  auto b = ToUint256(denom);
+  return FromUint256(intx::sdivrem(a, b).quot);
+}
+
+Word Word::SignedMod(const Word& denom) const {
+  if (denom == Word{0}) {
+    return Word{0};
+  }
+
+  auto a = ToUint256(*this);
+  auto b = ToUint256(denom);
+  return FromUint256(intx::sdivrem(a, b).rem);
+}
+
+Word Word::Exp(const Word& exponent) const {
+  auto a = ToUint256(*this);
+  auto b = ToUint256(exponent);
+  return FromUint256(intx::exp(a, b));
 }
 
 std::ostream& operator<<(std::ostream& out, const Word& word) {
   constexpr auto toSymbol = [](char x) -> char { return x < 10 ? '0' + x : 'A' + x - 10; };
-  for (auto cur : word.data_) {
-    out << toSymbol(static_cast<char>(cur >> 4));
-    out << toSymbol(static_cast<char>(cur) & 0xF);
+
+  for (auto it = word.data_.rbegin(); it != word.data_.rend(); ++it) {
+    out << toSymbol(static_cast<char>(*it >> 4));
+    out << toSymbol(static_cast<char>(*it) & 0xF);
   }
   return out;
 }

--- a/cpp/common/word.h
+++ b/cpp/common/word.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <compare>
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
@@ -8,14 +9,17 @@
 
 namespace tosca {
 
-// A Word is a single 32-byte fixed-size byte vector without numerical interpretation. Words are trivial objects of
-// fixed size that can be serialized by copying their byte pattern.
+// A Word is a single 32-byte fixed-size byte vector representing an unsigned
+// 256 bit integer. Words are trivial objects of fixed size that can be
+// serialized by copying their byte pattern.
 //
-// By default, new instances are not initialized. Thus, when defining a local variable
+// By default, new instances are not initialized. Thus, when defining a local
+// variable
 //
 //   Word word;  // the value is undefined
 //
-// the value is not defined. If zero-initialization is desired, an empty initializer list can be added:
+// the value is not defined. If zero-initialization is desired, an empty
+// initializer list can be added:
 //
 //   Word word{};  // the value is zero
 //
@@ -24,19 +28,48 @@ class Word {
  public:
   Word() = default;
 
-  // A convenience constructor supporting integer literals for initializing word. Elements not listed in the initializer
-  // will be initialized with zero. Elements exceeding the 32 entry limit will be ignored.
+  // A convenience constructor supporting integer literals for initializing
+  // word. Elements not listed in the initializer will be initialized with zero.
+  // The given sequence ends with the least significant byte. Elements beyond
+  // the most significant byte (32) are ignored.
   Word(std::initializer_list<const std::uint8_t> list);
 
-  // Supports equality comparison. Note: since words do not exhibit a numerical interpretation, the less-than order
-  // would not be well defined.
-  bool operator==(const Word&) const = default;
+  // Byte offset starting from the most significant byte. Returns 0 on
+  // out-of-bounds access.
+  std::byte operator[](std::uint8_t) const;
+  std::byte operator[](const Word&) const;
 
-  // Prints a word as a hax string in upper case.
+  bool operator==(const Word&) const = default;
+  std::strong_ordering operator<=>(const Word& other) const;
+
+  Word operator+(const Word&) const;
+  Word operator-(const Word&) const;
+  Word operator*(const Word&) const;
+
+  // If the denominator is 0, the result will be 0.
+  Word operator/(const Word&) const;
+  Word operator%(const Word&) const;
+  Word SignedDiv(const Word&) const;
+  Word SignedMod(const Word&) const;
+
+  Word operator<<(const Word&) const;
+  Word operator>>(const Word&) const;
+  Word operator|(const Word&) const;
+  Word operator&(const Word&) const;
+  Word operator^(const Word&) const;
+  Word operator~() const;
+
+  Word Exp(const Word&) const;
+
+  // Prints a word as a hex string in upper case.
   friend std::ostream& operator<<(std::ostream&, const Word&);
+
+  static const Word kMax;
 
  private:
   std::array<std::byte, 32> data_;
 };
+
+inline const Word Word::kMax = ~Word{0};
 
 }  // namespace tosca

--- a/cpp/common/word_test.cc
+++ b/cpp/common/word_test.cc
@@ -1,5 +1,6 @@
 #include "common/word.h"
 
+#include <compare>
 #include <type_traits>
 
 #include "gmock/gmock.h"
@@ -8,18 +9,50 @@
 namespace tosca {
 namespace {
 
+using ::testing::Eq;
 using ::testing::PrintToString;
 using ::testing::StrEq;
 
-TEST(Word, PrintProducesHexString) {
-  Word word{1, 2, 3, 0xAF};
-  EXPECT_THAT(PrintToString(word), StrEq("010203AF00000000000000000000000000000000000000000000000000000000"));
+TEST(Word, Zero) {
+  Word zero{};
+  EXPECT_EQ(zero, Word{0});
 }
 
-TEST(Word, CanBeEqualtiyCompared) {
-  Word w0{};
-  Word w1{1};
-  Word w2{2};
+TEST(Word, Max) {
+  Word all_bits_set{
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+  };
+
+  EXPECT_EQ(Word::kMax, all_bits_set);
+}
+
+TEST(Word, CanAccessBytes) {
+  Word w_ff{0xFF};
+  Word w_ff00{0xFF, 0x00};
+
+  EXPECT_EQ(w_ff[Word{31}], std::byte{0xFF});
+  EXPECT_EQ(w_ff00[Word{30}], std::byte{0xFF});
+
+  // EVM requires: If the byte offset is out of range, the result is 0.
+  EXPECT_EQ(w_ff00[Word{42}], std::byte{0});
+}
+
+TEST(Word, PrintProducesHexString) {
+  Word word{0xAF, 3, 2, 1};
+  EXPECT_THAT(PrintToString(word), StrEq("00000000000000000000000000000000000000000000000000000000AF030201"));
+}
+
+TEST(Word, CheckEndianness) {
+  Word word{2, 1};
+  word = word + Word{1};
+  EXPECT_THAT(word, Eq(Word{2, 2}));
+}
+
+TEST(Word, CanBeEqualityCompared) {
+  Word w0{0};
+  Word w1{2, 2};
+  Word w2{3, 1};
 
   EXPECT_EQ(w0, w0);
   EXPECT_EQ(w1, w1);
@@ -28,6 +61,184 @@ TEST(Word, CanBeEqualtiyCompared) {
   EXPECT_NE(w0, w1);
   EXPECT_NE(w0, w2);
   EXPECT_NE(w1, w2);
+}
+
+TEST(Word, CanBeLessCompared) {
+  Word w0{0};
+  Word w1{2, 2};
+  Word w2{3, 1};
+
+  EXPECT_LT(w0, w1);
+  EXPECT_LT(w0, w2);
+  EXPECT_LT(w0, w2);
+
+  EXPECT_FALSE(w0 < w0);
+  EXPECT_FALSE(w1 < w0);
+  EXPECT_FALSE(w2 < w0);
+  EXPECT_FALSE(w2 < w1);
+}
+TEST(Word, CanBeLessEqCompared) {
+  Word w0{0};
+  Word w1{2, 2};
+  Word w2{3, 1};
+
+  EXPECT_LE(w0, w0);
+  EXPECT_LE(w0, w1);
+  EXPECT_LE(w0, w2);
+  EXPECT_LE(w0, w2);
+
+  EXPECT_FALSE(w1 <= w0);
+  EXPECT_FALSE(w2 <= w0);
+  EXPECT_FALSE(w2 <= w1);
+}
+
+TEST(Word, CanBeGreaterCompared) {
+  Word w0{0};
+  Word w1{2, 2};
+  Word w2{3, 1};
+
+  EXPECT_GT(w1, w0);
+  EXPECT_GT(w2, w0);
+  EXPECT_GT(w2, w0);
+
+  EXPECT_FALSE(w0 > w0);
+  EXPECT_FALSE(w0 > w1);
+  EXPECT_FALSE(w0 > w2);
+  EXPECT_FALSE(w1 > w2);
+}
+
+TEST(Word, CanBeGreaterEqCompared) {
+  Word w0{0};
+  Word w1{2, 2};
+  Word w2{3, 1};
+
+  EXPECT_GE(w0, w0);
+  EXPECT_GE(w1, w0);
+  EXPECT_GE(w2, w0);
+  EXPECT_GE(w2, w0);
+
+  EXPECT_FALSE(w0 >= w1);
+  EXPECT_FALSE(w0 >= w2);
+  EXPECT_FALSE(w1 >= w2);
+}
+
+TEST(Word, CanBeSpaceShipCompared) {
+  Word w0{0};
+  Word w1{2, 2};
+
+  EXPECT_EQ(w0 <=> w0, std::strong_ordering::equal);
+  EXPECT_EQ(w0 <=> w1, std::strong_ordering::less);
+  EXPECT_EQ(w1 <=> w0, std::strong_ordering::greater);
+}
+
+TEST(Word, CanBeAdded) { EXPECT_EQ(Word{2} + Word{3}, Word{5}); }
+
+TEST(Word, CanOverflowWhenAdded) { EXPECT_EQ(Word::kMax + Word{2}, Word{1}); }
+
+TEST(Word, CanBeSubtracted) { EXPECT_EQ(Word{3} - Word{2}, Word{1}); }
+
+TEST(Word, CanUnderflowWhenSubtracted) { EXPECT_EQ(Word{0} - Word{1}, Word::kMax); }
+
+TEST(Word, CanBeMultiplied) { EXPECT_EQ(Word{2} * Word{3}, Word{6}); }
+
+TEST(Word, CanOverflowWhenMultiplied) { EXPECT_EQ(Word::kMax * Word{2}, Word::kMax - Word{1}); }
+
+TEST(Word, CanBeDivided) {
+  Word w24{24};
+
+  EXPECT_EQ(w24 / Word{8}, Word{3});  // no remainder
+  EXPECT_EQ(w24 / Word{5}, Word{4});  // remainder
+}
+
+TEST(Word, CanBeDividedByZero) {
+  // EVM requires: If the denominator is 0, the result will be 0.
+  EXPECT_EQ(Word{42} / Word{0}, Word{0});
+}
+
+TEST(Word, CanBeSignedIntegerDivided) {
+  Word w24{24};
+
+  EXPECT_EQ(w24.SignedDiv(Word{8}), Word{3});  // no remainder
+  EXPECT_EQ(w24.SignedDiv(Word{5}), Word{4});  // remainder
+
+  EXPECT_EQ((Word::kMax - Word{1}).SignedDiv(Word::kMax), Word{2});
+}
+
+TEST(Word, CanBeSignedIntegerDividedByZero) {
+  // EVM requires: If the denominator is 0, the result will be 0.
+  EXPECT_EQ(Word{42}.SignedDiv(Word{0}), Word{0});
+}
+
+TEST(Word, CanUseModulo) {
+  Word w24{24};
+
+  EXPECT_EQ(w24 % Word{8}, Word{0});  // no remainder
+  EXPECT_EQ(w24 % Word{5}, Word{4});  // remainder
+}
+
+TEST(Word, CanUseModuloWithZero) {
+  // EVM requires: If the denominator is 0, the result will be 0.
+  EXPECT_EQ(Word{42} % Word{0}, Word{0});
+}
+
+TEST(Word, CanUseSignedIntegerModulo) {
+  Word w24{24};
+
+  EXPECT_EQ(w24.SignedMod(Word{8}), Word{0});  // no remainder
+  EXPECT_EQ(w24.SignedMod(Word{5}), Word{4});  // remainder
+
+  Word wx = Word::kMax - Word{7};
+  Word wy = Word::kMax - Word{2};
+  EXPECT_EQ(wx.SignedMod(wy), Word::kMax - Word{1});
+}
+
+TEST(Word, CanUseSignedIntegerModuloWithZero) {
+  // EVM requires: If the denominator is 0, the result will be 0.
+  EXPECT_EQ(Word{42}.SignedMod(Word{0}), Word{0});
+}
+
+TEST(Word, CanBeExponentiated) { EXPECT_EQ(Word{10}.Exp(Word{2}), Word{100}); }
+
+TEST(Word, CanBeShiftedLeft) {
+  EXPECT_EQ(Word{0xF} << Word{4}, Word{0xF0});
+
+  // EVM: requires: If shift is bigger than 255, returns 0.
+  Word big_shift{1, 0};
+  EXPECT_EQ(Word::kMax << big_shift, Word{0});
+}
+
+TEST(Word, CanBeShiftedRight) {
+  Word w{0xF0};
+  EXPECT_EQ(w >> Word{4}, Word{0xF});
+
+  // EVM: requires: If shift is bigger than 255, returns 0.
+  Word big_shift{1, 0};
+  EXPECT_EQ(Word::kMax << big_shift, Word{0});
+}
+
+TEST(Word, CanBeBitwiseORed) {
+  EXPECT_EQ(Word{0xF0} | Word{0x0F}, Word{0xFF});
+  EXPECT_EQ(Word{0xFF} | Word{0xFF}, Word{0xFF});
+}
+
+TEST(Word, CanBeBitwiseANDed) {
+  EXPECT_EQ(Word{0x0F} & Word{0x0F}, Word{0x0F});
+  EXPECT_EQ(Word{0xFF} & Word{0x00}, Word{0x00});
+}
+
+TEST(Word, CanBeBitwiseXORed) {
+  EXPECT_EQ(Word{0xF0} ^ Word{0x0F}, Word{0xFF});
+  EXPECT_EQ(Word{0xFF} ^ Word{0xFF}, Word{0x00});
+}
+
+TEST(Word, CanBeBitwiseNOTed) {
+  Word all_bits_set{
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+  };
+
+  EXPECT_EQ(~Word{0}, all_bits_set);
+  EXPECT_EQ(~all_bits_set, Word{0});
 }
 
 }  // namespace

--- a/cpp/third_party/intx/BUILD
+++ b/cpp/third_party/intx/BUILD
@@ -1,0 +1,6 @@
+licenses(["notice"])
+
+exports_files(
+    ["intx.BUILD"],
+    visibility = ["//visibility:public"],
+)

--- a/cpp/third_party/intx/intx.BUILD
+++ b/cpp/third_party/intx/intx.BUILD
@@ -1,0 +1,6 @@
+cc_library(
+    name = "intx",
+    hdrs = ["include/intx/intx.hpp"],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Uses [intx](https://github.com/chfast/intx) as *backend*.

surpasses #11 

ref #12 