### PR TITLE
Split VM loading from interpreter creation

### DIFF
--- a/go/vm/evmone/evmone.go
+++ b/go/vm/evmone/evmone.go
@@ -6,16 +6,28 @@ package evmone
 import "C"
 
 import (
+	"fmt"
+
 	"github.com/Fantom-foundation/Tosca/go/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
-func NewInterpreter(evm *vm.EVM, cfg vm.Config) vm.EVMInterpreter {
+var evmone *common.EvmcVM
+
+func init() {
 	// In the CGO instructions at the top of this file the build directory
 	// of the evmone project is added to the rpath of the resulting library.
 	// This way, the libevmone.so file can be found during runtime, even if
 	// the LD_LIBRARY_PATH is not set accordingly.
-	return common.NewEVMCInterpreter("libevmone.so", evm, cfg)
+	vm, err := common.LoadEvmcVM("libevmone.so")
+	if err != nil {
+		panic(fmt.Errorf("failed to load evmone library: %s", err))
+	}
+	evmone = vm
+}
+
+func NewInterpreter(evm *vm.EVM, cfg vm.Config) vm.EVMInterpreter {
+	return common.NewEvmcInterpreter(evmone, evm, cfg)
 }
 
 func init() {

--- a/go/vm/evmone/evmone_test.go
+++ b/go/vm/evmone/evmone_test.go
@@ -27,6 +27,12 @@ func TestFib10(t *testing.T) {
 	}
 }
 
+func BenchmarkNewEvmcInterpreter(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewInterpreter(&vm.EVM{}, vm.Config{})
+	}
+}
+
 func BenchmarkFib10(b *testing.B) {
 	benchmarkFib(b, 10)
 }


### PR DESCRIPTION
This change has two effects:
- it speeds up the creation of interpreters by a factor of ~40 (4511ns => 103 ns), leading to a ~7% throughput increase in Aida
- fixes a memory leak since created VM instances have not been released