### PR TITLE
Add support for evmone basic and advanced mode

### DIFF
--- a/go/vm/evmone/evmone_test.go
+++ b/go/vm/evmone/evmone_test.go
@@ -7,6 +7,12 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
+var variants = []string{
+	"evmone",
+	"evmone-basic",
+	"evmone-advanced",
+}
+
 func TestFib10(t *testing.T) {
 	const arg = 10
 
@@ -15,21 +21,29 @@ func TestFib10(t *testing.T) {
 	// compute expected value
 	wanted := example.RunReference(arg)
 
-	interpreter := NewInterpreter(&vm.EVM{}, vm.Config{})
+	for _, variant := range variants {
+		t.Run(variant, func(t *testing.T) {
+			interpreter := vm.NewInterpreter(variant, &vm.EVM{}, vm.Config{})
 
-	got, err := example.RunOn(interpreter, arg)
-	if err != nil {
-		t.Fatalf("running the fib example failed: %v", err)
-	}
+			got, err := example.RunOn(interpreter, arg)
+			if err != nil {
+				t.Fatalf("running the fib example failed: %v", err)
+			}
 
-	if got.Result != wanted {
-		t.Fatalf("unexpected result, wanted %v, got %v", wanted, got.Result)
+			if got.Result != wanted {
+				t.Fatalf("unexpected result, wanted %v, got %v", wanted, got.Result)
+			}
+		})
 	}
 }
 
 func BenchmarkNewEvmcInterpreter(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		NewInterpreter(&vm.EVM{}, vm.Config{})
+	for _, variant := range variants {
+		b.Run(variant, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				vm.NewInterpreter(variant, &vm.EVM{}, vm.Config{})
+			}
+		})
 	}
 }
 
@@ -43,16 +57,20 @@ func benchmarkFib(b *testing.B, arg int) {
 	// compute expected value
 	wanted := example.RunReference(arg)
 
-	interpreter := NewInterpreter(&vm.EVM{}, vm.Config{})
+	for _, variant := range variants {
+		b.Run(variant, func(b *testing.B) {
+			interpreter := vm.NewInterpreter(variant, &vm.EVM{}, vm.Config{})
 
-	for i := 0; i < b.N; i++ {
-		got, err := example.RunOn(interpreter, arg)
-		if err != nil {
-			b.Fatalf("running the fib example failed: %v", err)
-		}
+			for i := 0; i < b.N; i++ {
+				got, err := example.RunOn(interpreter, arg)
+				if err != nil {
+					b.Fatalf("running the fib example failed: %v", err)
+				}
 
-		if wanted != got.Result {
-			b.Fatalf("unexpected result, wanted %d, got %d", wanted, got)
-		}
+				if wanted != got.Result {
+					b.Fatalf("unexpected result, wanted %d, got %d", wanted, got)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR introduces two distinct evmone modes: `evmone-basic` and `evmone-advanced` by registering them as extra factories.

It also adds a benchmark comparing the various supported EVM versions for the Fib example. The results on my system look as follows:
```
BenchmarkFib10/geth-12                   2895      422383 ns/op       826 B/op        13 allocs/op
BenchmarkFib10/lfvm-12                   7520      166658 ns/op      3853 B/op        15 allocs/op
BenchmarkFib10/lfvm-si-12                6930      172562 ns/op      3848 B/op        15 allocs/op
BenchmarkFib10/evmone-12                27763       39508 ns/op       608 B/op        13 allocs/op
BenchmarkFib10/evmone-basic-12          27714       39165 ns/op       608 B/op        13 allocs/op
BenchmarkFib10/evmone-advanced-12       16215       66627 ns/op       608 B/op        13 allocs/op
```

Looks like the basic mode is way faster for Fib than the advanced mode.