### PR TITLE
Add SHA3 instruction benchmark

### DIFF
--- a/go/examples/sha3.go
+++ b/go/examples/sha3.go
@@ -1,0 +1,71 @@
+package examples
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"golang.org/x/crypto/sha3"
+)
+
+func GetSha3Example() Example {
+	// Implement a loop computing x iterative hashes.
+	code := []byte{
+		// Parse the input parameter.
+		byte(vm.PUSH1), 4,
+		byte(vm.CALLDATALOAD),
+
+		// Implement the loop header.
+		byte(vm.JUMPDEST),
+		byte(vm.DUP1),
+		byte(vm.ISZERO),
+		byte(vm.PUSH1), 24,
+		byte(vm.JUMPI),
+
+		// Compute one hash step.
+		byte(vm.PUSH1), 32,
+		byte(vm.PUSH1), 0,
+		byte(vm.SHA3),
+		byte(vm.PUSH1), 0,
+		byte(vm.MSTORE),
+
+		// Decrement loop iterator.
+		byte(vm.PUSH1), 1,
+		byte(vm.SWAP1),
+		byte(vm.SUB),
+
+		// Jump back to start of the loop.
+		byte(vm.PUSH1), 3,
+		byte(vm.JUMP),
+
+		byte(vm.JUMPDEST),
+
+		// Mask out everything but the last byte.
+		byte(vm.PUSH1), 0,
+		byte(vm.MLOAD),
+		byte(vm.PUSH1), 255,
+		byte(vm.AND),
+		byte(vm.PUSH1), 0,
+		byte(vm.MSTORE),
+
+		// Return the result.
+		byte(vm.PUSH1), 32,
+		byte(vm.PUSH1), 0,
+		byte(vm.RETURN),
+	}
+
+	return Example{
+		Name:      "sha3",
+		code:      code,
+		reference: sha3Ref,
+	}
+}
+
+func sha3Ref(x int) int {
+	var hash common.Hash
+	hasher := sha3.NewLegacyKeccak256()
+	for i := 0; i < x; i++ {
+		hasher.Reset()
+		hasher.Write(hash[:])
+		hasher.Sum(hash[0:0])
+	}
+	return int(hash[31])
+}

--- a/go/vm/vm_test.go
+++ b/go/vm/vm_test.go
@@ -18,6 +18,7 @@ var (
 		"geth",
 		"lfvm",
 		"lfvm-si",
+		"lfvm-no-sha-cache",
 		"evmone",
 		"evmone-basic",
 		"evmone-advanced",
@@ -28,6 +29,7 @@ var (
 	testExamples = []examples.Example{
 		examples.GetIncrementExample(),
 		examples.GetFibExample(),
+		examples.GetSha3Example(),
 	}
 )
 
@@ -143,6 +145,14 @@ func BenchmarkFib(b *testing.B) {
 	}
 }
 
+func BenchmarkSha3(b *testing.B) {
+	args := []int{1, 10, 100, 1000}
+	for _, i := range args {
+		b.Run(fmt.Sprintf("%d", i), func(b *testing.B) {
+			benchmark(b, examples.GetSha3Example(), i)
+		})
+	}
+}
 func benchmark(b *testing.B, example examples.Example, arg int) {
 	// compute expected value
 	wanted := example.RunReference(arg)


### PR DESCRIPTION
Adds a benchmark targeting the performance of the SHA3 instruction.

Initial results (lower is better):
![image](https://github.com/Fantom-foundation/Tosca/assets/4097849/f3bfc79f-1677-4a1d-8569-f038df1e8026)


Like in real-world contracts, the SHA3 instruction frequently re-computing the hashes of the same input value (the sequence of hashes processed is deterministic). This results in the high performance results of the LFVM variants where hash-caching is enabled.