### PR TITLE
Add unit test verifying that invalid instructions are detected

### DIFF
--- a/go/common/evmc_bridge.go
+++ b/go/common/evmc_bridge.go
@@ -149,9 +149,9 @@ func (e *EvmcInterpreter) Run(contract *vm.Contract, input []byte, readOnly bool
 		case evmc.Error(C.EVMC_OUT_OF_GAS):
 			err = vm.ErrOutOfGas
 		case evmc.Error(C.EVMC_INVALID_INSTRUCTION):
-			err = vm.ErrInvalidCode
+			err = &vm.ErrInvalidOpCode{}
 		case evmc.Error(C.EVMC_UNDEFINED_INSTRUCTION):
-			err = vm.ErrInvalidCode
+			err = &vm.ErrInvalidOpCode{}
 		case evmc.Error(C.EVMC_BAD_JUMP_DESTINATION):
 			err = vm.ErrInvalidJump
 		}

--- a/go/vm/instruction_info.go
+++ b/go/vm/instruction_info.go
@@ -1,0 +1,211 @@
+package vm
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+// Revision references a EVM specification version.
+type Revision int
+
+const (
+	Istanbul Revision = 1
+	Berlin   Revision = 2
+	London   Revision = 3
+)
+
+func (r Revision) String() string {
+	switch r {
+	case Istanbul:
+		return "Istanbul"
+	case Berlin:
+		return "Berlin"
+	case London:
+		return "London"
+	}
+	return "Unknown"
+}
+
+// revisions lists all revisions covered by the tests in this package.
+var revisions = []Revision{Istanbul, Berlin, London}
+
+// InstructionInfo contains meta-information about instructions used for
+// generating test cases.
+type InstructionInfo struct {
+	// add information as needed
+}
+
+// getInstructions returns a map of OpCodes for the respective revision.
+func getInstructions(revision Revision) map[vm.OpCode]InstructionInfo {
+	switch revision {
+	case Istanbul:
+		return getInstanbulInstructions()
+	case Berlin:
+		return getBerlinInstructions()
+	case London:
+		return getLondonInstructions()
+	}
+	panic(fmt.Sprintf("unknown revision: %v", revision))
+}
+
+func getInstanbulInstructions() map[vm.OpCode]InstructionInfo {
+	res := map[vm.OpCode]InstructionInfo{
+		vm.STOP:           {},
+		vm.ADD:            {},
+		vm.MUL:            {},
+		vm.SUB:            {},
+		vm.DIV:            {},
+		vm.SDIV:           {},
+		vm.MOD:            {},
+		vm.SMOD:           {},
+		vm.ADDMOD:         {},
+		vm.MULMOD:         {},
+		vm.EXP:            {},
+		vm.SIGNEXTEND:     {},
+		vm.LT:             {},
+		vm.GT:             {},
+		vm.SLT:            {},
+		vm.SGT:            {},
+		vm.EQ:             {},
+		vm.ISZERO:         {},
+		vm.AND:            {},
+		vm.XOR:            {},
+		vm.OR:             {},
+		vm.NOT:            {},
+		vm.SHL:            {},
+		vm.SHR:            {},
+		vm.SAR:            {},
+		vm.BYTE:           {},
+		vm.SHA3:           {},
+		vm.ADDRESS:        {},
+		vm.BALANCE:        {},
+		vm.ORIGIN:         {},
+		vm.CALLER:         {},
+		vm.CALLVALUE:      {},
+		vm.CALLDATALOAD:   {},
+		vm.CALLDATASIZE:   {},
+		vm.CALLDATACOPY:   {},
+		vm.CODESIZE:       {},
+		vm.CODECOPY:       {},
+		vm.GASPRICE:       {},
+		vm.EXTCODESIZE:    {},
+		vm.EXTCODECOPY:    {},
+		vm.RETURNDATASIZE: {},
+		vm.RETURNDATACOPY: {},
+		vm.EXTCODEHASH:    {},
+		vm.BLOCKHASH:      {},
+		vm.COINBASE:       {},
+		vm.TIMESTAMP:      {},
+		vm.NUMBER:         {},
+		vm.DIFFICULTY:     {},
+		vm.GASLIMIT:       {},
+		vm.CHAINID:        {},
+		vm.SELFBALANCE:    {},
+		vm.POP:            {},
+		vm.MLOAD:          {},
+		vm.MSTORE:         {},
+		vm.MSTORE8:        {},
+		vm.SLOAD:          {},
+		vm.SSTORE:         {},
+		vm.JUMP:           {},
+		vm.JUMPI:          {},
+		vm.PC:             {},
+		vm.MSIZE:          {},
+		vm.GAS:            {},
+		vm.JUMPDEST:       {},
+		vm.PUSH1:          {},
+		vm.PUSH2:          {},
+		vm.PUSH3:          {},
+		vm.PUSH4:          {},
+		vm.PUSH5:          {},
+		vm.PUSH6:          {},
+		vm.PUSH7:          {},
+		vm.PUSH8:          {},
+		vm.PUSH9:          {},
+		vm.PUSH10:         {},
+		vm.PUSH11:         {},
+		vm.PUSH12:         {},
+		vm.PUSH13:         {},
+		vm.PUSH14:         {},
+		vm.PUSH15:         {},
+		vm.PUSH16:         {},
+		vm.PUSH17:         {},
+		vm.PUSH18:         {},
+		vm.PUSH19:         {},
+		vm.PUSH20:         {},
+		vm.PUSH21:         {},
+		vm.PUSH22:         {},
+		vm.PUSH23:         {},
+		vm.PUSH24:         {},
+		vm.PUSH25:         {},
+		vm.PUSH26:         {},
+		vm.PUSH27:         {},
+		vm.PUSH28:         {},
+		vm.PUSH29:         {},
+		vm.PUSH30:         {},
+		vm.PUSH31:         {},
+		vm.PUSH32:         {},
+		vm.DUP1:           {},
+		vm.DUP2:           {},
+		vm.DUP3:           {},
+		vm.DUP4:           {},
+		vm.DUP5:           {},
+		vm.DUP6:           {},
+		vm.DUP7:           {},
+		vm.DUP8:           {},
+		vm.DUP9:           {},
+		vm.DUP10:          {},
+		vm.DUP11:          {},
+		vm.DUP12:          {},
+		vm.DUP13:          {},
+		vm.DUP14:          {},
+		vm.DUP15:          {},
+		vm.DUP16:          {},
+		vm.SWAP1:          {},
+		vm.SWAP2:          {},
+		vm.SWAP3:          {},
+		vm.SWAP4:          {},
+		vm.SWAP5:          {},
+		vm.SWAP6:          {},
+		vm.SWAP7:          {},
+		vm.SWAP8:          {},
+		vm.SWAP9:          {},
+		vm.SWAP10:         {},
+		vm.SWAP11:         {},
+		vm.SWAP12:         {},
+		vm.SWAP13:         {},
+		vm.SWAP14:         {},
+		vm.SWAP15:         {},
+		vm.SWAP16:         {},
+		vm.LOG0:           {},
+		vm.LOG1:           {},
+		vm.LOG2:           {},
+		vm.LOG3:           {},
+		vm.LOG4:           {},
+		vm.CREATE:         {},
+		vm.CALL:           {},
+		vm.CALLCODE:       {},
+		vm.RETURN:         {},
+		vm.DELEGATECALL:   {},
+		vm.CREATE2:        {},
+		vm.STATICCALL:     {},
+		vm.REVERT:         {},
+		vm.SELFDESTRUCT:   {},
+	}
+	return res
+}
+
+func getBerlinInstructions() map[vm.OpCode]InstructionInfo {
+	// Berlin only modifies gas computations.
+	// https://eips.ethereum.org/EIPS/eip-2929
+	return getInstanbulInstructions()
+}
+
+func getLondonInstructions() map[vm.OpCode]InstructionInfo {
+	res := getBerlinInstructions()
+	// One additional instruction: BASEFEE
+	// https://eips.ethereum.org/EIPS/eip-3198
+	res[vm.BASEFEE] = InstructionInfo{}
+	return res
+}

--- a/go/vm/invalid_instructions_test.go
+++ b/go/vm/invalid_instructions_test.go
@@ -1,0 +1,74 @@
+package vm
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+func TestInterpreterDetectsInvalidInstruction(t *testing.T) {
+	for _, rev := range revisions {
+		evm := newTestEVM(rev)
+		for _, variant := range variants {
+			// LFVM currently does not support detection of invalid codes!
+			// TODO: fix this
+			if strings.Contains(variant, "lfvm") {
+				continue
+			}
+			interpreter := vm.NewInterpreter(variant, evm, vm.Config{})
+			instructions := getInstructions(rev)
+			for i := 0; i < 256; i++ {
+				op := vm.OpCode(i)
+				_, exits := instructions[op]
+				if exits {
+					continue
+				}
+				t.Run(fmt.Sprintf("%s-%s-%s", variant, rev, op), func(t *testing.T) {
+					code := []byte{byte(op), byte(vm.STOP)}
+					input := []byte{}
+					if err := runCode(interpreter, code, input); !isInvalidOpCodeError(err) {
+						t.Errorf("failed to identify invalid OpCode %v as invalid instruction, got %v", op, err)
+					}
+				})
+			}
+		}
+	}
+}
+
+func isInvalidOpCodeError(err error) bool {
+	_, ok := err.(*vm.ErrInvalidOpCode)
+	return ok
+}
+
+func runCode(interpreter vm.EVMInterpreter, code []byte, input []byte) error {
+	const initialGas = math.MaxInt64
+
+	// Create a dummy contract using the code hash as a address. This is required
+	// to avoid all tests using the same cached LFVM byte code.
+	addr := vm.AccountRef{}
+	contract := vm.NewContract(addr, addr, big.NewInt(0), initialGas)
+	contract.Code = code
+	contract.CodeHash = getSha256Hash(code)
+
+	// TODO: remove this once code caching is code-hash based.
+	var codeAddr common.Address
+	copy(codeAddr[:], contract.CodeHash[:])
+	contract.CodeAddr = &codeAddr
+
+	_, err := interpreter.Run(contract, input, false)
+	return err
+}
+
+func getSha256Hash(code []byte) common.Hash {
+	hasher := sha256.New()
+	hasher.Write(code)
+	var hash common.Hash
+	hasher.Sum(hash[0:0])
+	return hash
+}

--- a/go/vm/vm_test.go
+++ b/go/vm/vm_test.go
@@ -83,28 +83,6 @@ func TestExamples_ComputesCorrectGasPrice(t *testing.T) {
 	}
 }
 
-type Revision int
-
-const (
-	Istanbul Revision = 1
-	Berlin   Revision = 2
-	London   Revision = 3
-)
-
-var revisions = []Revision{Istanbul, Berlin, London}
-
-func (r Revision) String() string {
-	switch r {
-	case Istanbul:
-		return "Istanbul"
-	case Berlin:
-		return "Berlin"
-	case London:
-		return "London"
-	}
-	return "Unknown"
-}
-
 func newTestEVM(r Revision) *vm.EVM {
 	// Configure the block numbers for revision changes.
 	chainConfig := params.AllEthashProtocolChanges
@@ -121,8 +99,13 @@ func newTestEVM(r Revision) *vm.EVM {
 
 	blockCtxt := vm.BlockContext{
 		BlockNumber: big.NewInt(int64(block)),
+		Time:        big.NewInt(1000),
+		Difficulty:  big.NewInt(1),
+		GasLimit:    1 << 63,
 	}
-	txCtxt := vm.TxContext{}
+	txCtxt := vm.TxContext{
+		GasPrice: big.NewInt(1),
+	}
 	config := vm.Config{}
 	return vm.NewEVM(blockCtxt, txCtxt, nil, chainConfig, config)
 }


### PR DESCRIPTION
Adds some tests verifying that invalid instructions are detected by the EVM implementations as defined by the EVM specification revisions.

As part of this, it was discovered that the LFVM implementation does not report invalid instructions correctly. Implementations are currently excluded from testing, until this issue is fixed.