### PR TITLE
Consolidate test infrastructure

### DIFF
--- a/go/vm/instruction_info.go
+++ b/go/vm/instruction_info.go
@@ -1,4 +1,4 @@
-package vm
+package vm_test
 
 import (
 	"fmt"
@@ -13,6 +13,13 @@ const (
 	Istanbul Revision = 1
 	Berlin   Revision = 2
 	London   Revision = 3
+
+	LatestRevision = London
+
+	// Chain config for hardforks
+	ISTANBUL_FORK = 00
+	BERLIN_FORK   = 10
+	LONDON_FORK   = 20
 )
 
 func (r Revision) String() string {
@@ -25,6 +32,18 @@ func (r Revision) String() string {
 		return "London"
 	}
 	return "Unknown"
+}
+
+func (r Revision) GetForkBlock() int64 {
+	switch r {
+	case Istanbul:
+		return ISTANBUL_FORK
+	case Berlin:
+		return BERLIN_FORK
+	case London:
+		return LONDON_FORK
+	}
+	panic(fmt.Sprintf("unknown revision: %v", r))
 }
 
 // revisions lists all revisions covered by the tests in this package.

--- a/go/vm/invalid_instructions_test.go
+++ b/go/vm/invalid_instructions_test.go
@@ -1,4 +1,4 @@
-package vm
+package vm_test
 
 import (
 	"fmt"
@@ -10,14 +10,13 @@ import (
 
 func TestInterpreterDetectsInvalidInstruction(t *testing.T) {
 	for _, rev := range revisions {
-		evm := newTestEVM(rev)
-		for _, variant := range variants {
+		for _, variant := range Variants {
+			evm := GetCleanEVM(rev, variant, nil)
 			// LFVM currently does not support detection of invalid codes!
 			// TODO: fix this
 			if strings.Contains(variant, "lfvm") {
 				continue
 			}
-			interpreter := vm.NewInterpreter(variant, evm, vm.Config{})
 			instructions := getInstructions(rev)
 			for i := 0; i < 256; i++ {
 				op := vm.OpCode(i)
@@ -28,7 +27,7 @@ func TestInterpreterDetectsInvalidInstruction(t *testing.T) {
 				t.Run(fmt.Sprintf("%s-%s-%s", variant, rev, op), func(t *testing.T) {
 					code := []byte{byte(op), byte(vm.STOP)}
 					input := []byte{}
-					if err := runCode(interpreter, code, input); !isInvalidOpCodeError(err) {
+					if _, err := evm.Run(code, input); !isInvalidOpCodeError(err) {
 						t.Errorf("failed to identify invalid OpCode %v as invalid instruction, got %v", op, err)
 					}
 				})


### PR DESCRIPTION
This PR merges the two different EVM / Interpreter handling methods `getCleanEVM` and `newTestEVM` into a single `GetCleanEVM` function and consolidates related infrastructure.