### PR TITLE
Fix stack requirement info of SWAP instructions in tests

### DIFF
--- a/go/vm/test/instruction_info.go
+++ b/go/vm/test/instruction_info.go
@@ -90,7 +90,7 @@ func getInstanbulInstructions() map[vm.OpCode]InstructionInfo {
 	}
 
 	swap := func(x int) StackUsage {
-		return StackUsage{popped: x, pushed: x}
+		return StackUsage{popped: x + 1, pushed: x + 1}
 	}
 
 	res := map[vm.OpCode]InstructionInfo{


### PR DESCRIPTION
Fixes the meta information associated to SWAP instructions which have been reporting one element too little touched on the stack.