### PR TITLE
C++: Disable missing initializer warning for GCC

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -19,7 +19,7 @@ function(tosca_add_compile_flags target)
   target_compile_options(${target} PRIVATE
     $<$<CXX_COMPILER_ID:MSVC>:/MP /W4 /external:W0>
     $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall -Wextra -Wpedantic -Wtype-limits -Wconversion -Wsign-conversion -Wdouble-promotion -g>
-    $<$<CXX_COMPILER_ID:GNU>:-fdiagnostics-color>
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-missing-field-initializers -fdiagnostics-color>
     $<$<CXX_COMPILER_ID:Clang,AppleClang>:-fcolor-diagnostics>)
   target_include_directories(${target} PRIVATE ${PROJECT_SOURCE_DIR})
 endfunction()

--- a/cpp/vm/evmzero/interpreter.h
+++ b/cpp/vm/evmzero/interpreter.h
@@ -32,7 +32,7 @@ struct InterpreterArgs {
 struct InterpreterResult {
   RunState state = RunState::kDone;
   uint64_t remaining_gas = 0;
-  std::vector<uint8_t> return_data = {};
+  std::vector<uint8_t> return_data;
 };
 
 InterpreterResult Interpret(const InterpreterArgs&);
@@ -45,12 +45,12 @@ struct Context {
   uint64_t pc = 0;
   uint64_t gas = 100000000000llu;
 
-  std::vector<uint8_t> code = {};
-  std::vector<uint8_t> return_data = {};
-  std::vector<uint8_t> valid_jump_targets = {};
+  std::vector<uint8_t> code;
+  std::vector<uint8_t> return_data;
+  std::vector<uint8_t> valid_jump_targets;
 
-  Memory memory = {};
-  Stack stack = {};
+  Memory memory;
+  Stack stack;
 
   bool CheckStackAvailable(uint64_t elements_needed) noexcept;
   bool CheckStackOverflow(uint64_t slots_needed) noexcept;

--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -15,8 +15,8 @@ struct InterpreterTestDescription {
   uint64_t gas_before = 0;
   uint64_t gas_after = 0;
 
-  Stack stack_before = {};
-  Stack stack_after = {};
+  Stack stack_before;
+  Stack stack_after;
 };
 
 void RunInterpreterTest(const InterpreterTestDescription& desc) {


### PR DESCRIPTION
`-Wmissing-field-initializers` is included with `-Wextra` and causes GCC to emit warnings even though fields are properly initialized.

Clang does not emit such a warning.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96868