### PR TITLE
evmzero: Fix SSTORE dynamic gas calculation for StorageDeleted case

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -866,7 +866,7 @@ static void sstore(Context& ctx) noexcept {
   if (storage_status == EVMC_STORAGE_ADDED) {
     dynamic_gas_cost = 20000;
   }
-  if (storage_status == EVMC_STORAGE_MODIFIED) {
+  if (storage_status == EVMC_STORAGE_MODIFIED || storage_status == EVMC_STORAGE_DELETED) {
     if (ctx.revision >= EVMC_BERLIN) {
       dynamic_gas_cost = 2900;
     } else {


### PR DESCRIPTION
This fixes the following test case for evmzero:
```
TestDynamicGas/evmzero/Istanbul/SSTORE/Slot_1,_current_1,_new_0
```

It also fixes the naming schema of of the refund tests to be inline with other SSTORE tests.