### PR TITLE
evmzero: Fix FillValidJumpTargetsUpTo being called with index >= code size

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -1280,13 +1280,18 @@ bool Context::CheckStackOverflow(uint64_t slots_needed) noexcept {
 }
 
 bool Context::CheckJumpDest(uint64_t index) noexcept {
-  FillValidJumpTargetsUpTo(index);
-  if (index >= code.size() || !valid_jump_targets[index]) [[unlikely]] {
+  if (index >= code.size()) [[unlikely]] {
     state = RunState::kErrorJump;
     return false;
-  } else {
-    return true;
   }
+
+  FillValidJumpTargetsUpTo(index);
+  if (!valid_jump_targets[index]) [[unlikely]] {
+    state = RunState::kErrorJump;
+    return false;
+  }
+
+  return true;
 }
 
 void Context::FillValidJumpTargetsUpTo(uint64_t index) noexcept {

--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -3467,6 +3467,15 @@ TEST(InterpreterTest, JUMP_Invalid) {
   });
 }
 
+TEST(InterpreterTest, JUMP_OutOfCode) {
+  RunInterpreterTest({
+      .code = {op::JUMP},
+      .state_after = RunState::kErrorJump,
+      .gas_before = 5000,
+      .stack_before = {3},
+  });
+}
+
 TEST(InterpreterTest, JUMP_OutOfGas) {
   RunInterpreterTest({
       .code = {op::JUMP},


### PR DESCRIPTION
The assertion inside `FillValidJumpTargetsUpTo` was triggered during a Tosca test.

This PR fixes the call to `FillValidJumpTargetsUpTo` and adds a dedicated test for this.