### PR TITLE
evmzero: Use int64_t for gas due to evmc

### DIFF
--- a/cpp/vm/evmzero/evmzero.cc
+++ b/cpp/vm/evmzero/evmzero.cc
@@ -78,8 +78,8 @@ class VM : public evmc_vm {
 
     return {
         .status_code = ToEvmcStatusCode(interpreter_result.state),
-        .gas_left = static_cast<int64_t>(interpreter_result.remaining_gas),
-        .gas_refund = static_cast<int64_t>(interpreter_result.refunded_gas),
+        .gas_left = interpreter_result.remaining_gas,
+        .gas_refund = interpreter_result.refunded_gas,
         .output_data = output_data,
         .output_size = interpreter_result.return_data.size(),
         .release = [](const evmc_result* result) { delete[] result->output_data; },

--- a/cpp/vm/evmzero/interpreter.h
+++ b/cpp/vm/evmzero/interpreter.h
@@ -40,8 +40,8 @@ struct InterpreterArgs {
 
 struct InterpreterResult {
   RunState state = RunState::kDone;
-  uint64_t remaining_gas = 0;
-  uint64_t refunded_gas = 0;
+  int64_t remaining_gas = 0;
+  int64_t refunded_gas = 0;
   std::vector<uint8_t> return_data;
 };
 
@@ -54,8 +54,8 @@ struct Context {
   bool is_static_call = false;
 
   uint64_t pc = 0;
-  uint64_t gas = 100000000000llu;
-  uint64_t gas_refunds = 0;
+  int64_t gas = std::numeric_limits<int64_t>::max();
+  int64_t gas_refunds = 0;
 
   std::vector<uint8_t> code;
   std::vector<uint8_t> return_data;
@@ -74,12 +74,12 @@ struct Context {
   bool CheckStaticCallConformance() noexcept;
   bool CheckStackAvailable(uint64_t elements_needed) noexcept;
   bool CheckStackOverflow(uint64_t slots_needed) noexcept;
-  bool ApplyGasCost(uint64_t gas_cost) noexcept;
+  bool ApplyGasCost(int64_t gas_cost) noexcept;
 
   bool CheckJumpDest(uint64_t index) noexcept;
   void FillValidJumpTargetsUpTo(uint64_t index) noexcept;
 
-  uint64_t MemoryExpansionCost(uint64_t new_size) noexcept;
+  int64_t MemoryExpansionCost(uint64_t new_size) noexcept;
 };
 
 void RunInterpreter(Context&);

--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -49,10 +49,10 @@ struct InterpreterTestDescription {
   RunState state_after = RunState::kDone;
   bool is_static_call = false;
 
-  uint64_t gas_before = 0;
-  uint64_t gas_after = 0;
-  uint64_t gas_refund_before = 0;
-  uint64_t gas_refund_after = 0;
+  int64_t gas_before = 0;
+  int64_t gas_after = 0;
+  int64_t gas_refund_before = 0;
+  int64_t gas_refund_after = 0;
 
   Stack stack_before;
   Stack stack_after;


### PR DESCRIPTION
Since evmc handles gas as signed integer, evmzero should do the same. This way we don't have to do conversions back and forth.