### PR TITLE
Add TOSCA_ASSERT macro

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 project(tosca)
 
 option(TOSCA_ASAN "Enable AddressSanitizer for Tosca targets.")
+option(TOSCA_ASSERT "Enable Tosca specific assertions.")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 enable_testing()
@@ -21,6 +22,7 @@ function(tosca_add_compile_flags target)
     $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall -Wextra -Wpedantic -Wtype-limits -Wconversion -Wsign-conversion -Wdouble-promotion -g>
     $<$<CXX_COMPILER_ID:GNU>:-Wno-missing-field-initializers -fdiagnostics-color>
     $<$<CXX_COMPILER_ID:Clang,AppleClang>:-fcolor-diagnostics>)
+  target_compile_definitions(${target} PRIVATE $<$<BOOL:TOSCA_ASSERT>:TOSCA_ASSERT_ENABLED>)
   target_include_directories(${target} PRIVATE ${PROJECT_SOURCE_DIR})
 endfunction()
 

--- a/cpp/common/assert.h
+++ b/cpp/common/assert.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdio>
+
+#include "common/macros.h"
+
+#if TOSCA_ASSERT_ENABLED
+#define TOSCA_ASSERT(condition)                                                                \
+  do {                                                                                         \
+    if (!(condition)) [[unlikely]] {                                                           \
+      ::std::fprintf(stderr, "%s:%d: Assertion failed: %s\n", __FILE__, __LINE__, #condition); \
+      TOSCA_DEBUG_BREAK();                                                                     \
+    }                                                                                          \
+  } while (0)
+#else
+#define TOSCA_ASSERT(condition)
+#endif

--- a/cpp/common/macros.h
+++ b/cpp/common/macros.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstdlib>
+
+#ifdef __clang__
+#define TOSCA_DEBUG_BREAK() __builtin_debugtrap()
+#elif __GNUC__
+#define TOSCA_DEBUG_BREAK() __builtin_trap()
+#elif _MSC_VER
+#define TOSCA_DEBUG_BREAK() __debugbreak()
+#else
+#define TOSCA_DEBUG_BREAK() ::std::abort()
+#endif

--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -3,6 +3,7 @@
 #include <bit>
 #include <cstdio>
 
+#include "common/assert.h"
 #include "vm/evmzero/opcodes.h"
 
 namespace tosca::evmzero {
@@ -1301,7 +1302,7 @@ void Context::FillValidJumpTargetsUpTo(uint64_t index) noexcept {
   }
 
   if (index >= code.size()) [[unlikely]] {
-    assert(false);
+    TOSCA_ASSERT(false);
     return;
   }
 

--- a/cpp/vm/evmzero/memory.h
+++ b/cpp/vm/evmzero/memory.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <algorithm>
-#include <cassert>
 #include <cstdint>
 #include <initializer_list>
 #include <ostream>

--- a/cpp/vm/evmzero/stack.cc
+++ b/cpp/vm/evmzero/stack.cc
@@ -5,7 +5,7 @@
 namespace tosca::evmzero {
 
 Stack::Stack(std::initializer_list<uint256_t> elements) {
-  assert(elements.size() <= stack_.size());
+  TOSCA_ASSERT(elements.size() <= stack_.size());
   std::copy(elements.begin(), elements.end(), stack_.begin());
   position_ = elements.size();
 }

--- a/cpp/vm/evmzero/stack.h
+++ b/cpp/vm/evmzero/stack.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <array>
-#include <cassert>
 #include <cstdint>
 #include <initializer_list>
 #include <ostream>
 
+#include "common/assert.h"
 #include "vm/evmzero/uint256.h"
 
 namespace tosca::evmzero {
@@ -20,18 +20,18 @@ class Stack {
   uint64_t GetMaxSize() const { return stack_.size(); }
 
   void Push(uint256_t value) {
-    assert(position_ < stack_.size());
+    TOSCA_ASSERT(position_ < stack_.size());
     stack_[position_++] = value;
   }
 
   uint256_t Pop() {
-    assert(position_ > 0);
+    TOSCA_ASSERT(position_ > 0);
     return stack_[--position_];
   }
 
   // Accesses elements starting from the top; index 0 is the top element.
   uint256_t& operator[](size_t index) {
-    assert(index < position_);
+    TOSCA_ASSERT(index < position_);
     return stack_[position_ - 1 - index];
   }
   const uint256_t& operator[](size_t index) const { return const_cast<Stack&>(*this)[index]; }


### PR DESCRIPTION
This PR replaces the use of `assert` with a custom, macro `TOSCA_ASSERT`.

- `TOSCA_ASSERT` can be enabled/disabled independently from `assert`.
  This allows us to disable assertions in third-party code, while keeping them enabled in Tosca.
- `TOSCA_ASSERT` uses debug break. Debug break terminates the program when no debugger is attached, but lets you continue execution while debugging. This is preferred to always aborting execution.

- - -

Furthermore, this PR reorganizes the Makefile slightly.

- Always use `tosca-cpp` rule to build evmzero, but variables are used to determine build type, assertions, and ASAN.
- Assertions are only disabled for benchmarking
- Removed the `help` rule because it wasn't used
- No longer suppresses evmzero CMake call.
  Having the CMake call visible in CI is helpful for debugging, and to check whether we are using the wanted configuration.