### PR TITLE
Export EVM versions in a single file and fix inter-call refund tracking

### DIFF
--- a/go/common/evmc_bridge.go
+++ b/go/common/evmc_bridge.go
@@ -350,13 +350,6 @@ func (ctx *HostContext) Call(kind evmc.CallKind, recipient evmc.Address, sender 
 	// Documentation of the parameters can be found here: t.ly/yhxC
 	toAddr := common.Address(codeAddress)
 
-	// Clear the current refund (it is tracked within the interpreter internally).
-	state := ctx.evm.StateDB
-
-	// TODO: try to remove this refund backup and restore.
-	refundBackup := state.GetRefund()
-	state.SubRefund(refundBackup)
-
 	var returnGas uint64
 	switch kind {
 	case evmc.Call:
@@ -383,10 +376,6 @@ func (ctx *HostContext) Call(kind evmc.CallKind, recipient evmc.Address, sender 
 		panic(fmt.Sprintf("unsupported call kind: %v", kind))
 	}
 	gasLeft = int64(returnGas)
-
-	gasRefund = int64(state.GetRefund())
-	state.SubRefund(uint64(gasRefund))
-	state.AddRefund(refundBackup)
 
 	if err != nil {
 		// translate vm errors to evmc errors

--- a/go/vm/vm.go
+++ b/go/vm/vm.go
@@ -1,0 +1,12 @@
+package vm
+
+// These are the officially exported EVM variants provided
+// by this package. Other VM implementations may be present
+// in this repository, but they are not (yet) intended for
+// external use.
+
+import (
+	_ "github.com/Fantom-foundation/Tosca/go/vm/evmone"
+	_ "github.com/Fantom-foundation/Tosca/go/vm/evmzero"
+	_ "github.com/Fantom-foundation/Tosca/go/vm/lfvm"
+)


### PR DESCRIPTION
This PR
 - introduces a package importing all VMs to be exported to client applications like Aida or Opera
 - removes an obsolete refund backup mechanism