### PR TITLE
evmzero: Keep gas on revert

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -56,10 +56,6 @@ InterpreterResult Interpret(const InterpreterArgs& args) {
 
   internal::RunInterpreter<LoggingEnabled>(ctx);
 
-  if (ctx.state != RunState::kDone) {
-    ctx.gas = 0;
-  }
-
   return {
       .state = ctx.state,
       .remaining_gas = ctx.gas,
@@ -1553,6 +1549,10 @@ void RunInterpreter(Context& ctx) {
       default:
         ctx.state = RunState::kErrorOpcode;
     }
+  }
+
+  if (ctx.state != RunState::kDone && ctx.state != RunState::kRevert) {
+    ctx.gas = 0;
   }
 }
 


### PR DESCRIPTION
The corresponding if-statement is moved from `Interpret` into `RunInterpreter` such that this is also covered by the C++ unit tests.

---

**Integration Test Note:**
Integration tests should cover whether the remaining gas value is kept or set to zero.

Block: 4600000_0