### PR TITLE
evmzero: Remove JUMPI condition narrowing

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -928,7 +928,7 @@ static void jumpi(Context& ctx) noexcept {
   if (!ctx.ApplyGasCost(10)) [[unlikely]]
     return;
   uint64_t counter = static_cast<uint64_t>(ctx.stack.Pop());
-  uint64_t b = static_cast<uint64_t>(ctx.stack.Pop());
+  uint256_t b = ctx.stack.Pop();
   if (b != 0) {
     if (!ctx.CheckJumpDest(counter)) [[unlikely]]
       return;

--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -3575,6 +3575,20 @@ TEST(InterpreterTest, JUMPI) {
   });
 }
 
+TEST(InterpreterTest, JUMPI_LargeCondition) {
+  RunInterpreterTest({
+      .code = {op::JUMPI,      //
+               op::PUSH1, 24,  //
+               op::JUMPDEST,   //
+               op::PUSH1, 42},
+      .state_after = RunState::kDone,
+      .gas_before = 5000,
+      .gas_after = 4986,
+      .stack_before = {uint256_t(1) << 80, 3},
+      .stack_after = {42},
+  });
+}
+
 TEST(InterpreterTest, JUMPI_Invalid) {
   RunInterpreterTest({
       .code = {op::PUSH4, op::JUMPDEST, op::JUMPDEST, op::JUMPDEST, op::JUMPDEST,  //


### PR DESCRIPTION
**Integration Test Note:**
Integration tests should cover the JUMPI instruction with a condition of `0x10000000000000000`.
(Narrowing this value to `uin64_t` yields 0.)

Block: 5365974_0