### PR TITLE
evmzero: Only RETURN and REVERT return data

### DIFF
--- a/cpp/vm/evmzero/evmzero.cc
+++ b/cpp/vm/evmzero/evmzero.cc
@@ -13,12 +13,14 @@ evmc_status_code ToEvmcStatusCode(RunState state) {
       return EVMC_FAILURE;
     case RunState::kDone:
       return EVMC_SUCCESS;
+    case RunState::kReturn:
+      return EVMC_SUCCESS;
     case RunState::kRevert:
       return EVMC_REVERT;
     case RunState::kInvalid:
       return EVMC_INVALID_INSTRUCTION;
     case RunState::kErrorOpcode:
-      return EVMC_INVALID_INSTRUCTION;
+      return EVMC_UNDEFINED_INSTRUCTION;
     case RunState::kErrorGas:
       return EVMC_OUT_OF_GAS;
     case RunState::kErrorStackUnderflow:

--- a/cpp/vm/evmzero/interpreter.h
+++ b/cpp/vm/evmzero/interpreter.h
@@ -15,6 +15,7 @@ namespace tosca::evmzero {
 enum class RunState {
   kRunning,
   kDone,
+  kReturn,
   kRevert,
   kInvalid,
   kErrorOpcode,
@@ -26,6 +27,8 @@ enum class RunState {
   kErrorCreate,
   kErrorStaticCall,
 };
+
+bool IsSuccess(RunState);
 
 const char* ToString(RunState);
 std::ostream& operator<<(std::ostream&, RunState);

--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -87,14 +87,12 @@ void RunInterpreterTest(const InterpreterTestDescription& desc) {
 
   ASSERT_EQ(ctx.state, desc.state_after);
 
-  if (ctx.state == RunState::kDone || ctx.state == RunState::kRevert) {
+  if (IsSuccess(ctx.state)) {
     EXPECT_EQ(ctx.gas, desc.gas_after);
     EXPECT_EQ(ctx.gas_refunds, desc.gas_refund_after);
     EXPECT_EQ(ctx.stack, desc.stack_after);
     EXPECT_EQ(ctx.memory, desc.memory_after);
-    if (!desc.return_data.empty()) {
-      EXPECT_EQ(ctx.return_data, desc.return_data);
-    }
+    EXPECT_EQ(ctx.return_data, desc.return_data);
   }
 }
 
@@ -106,6 +104,17 @@ TEST(InterpreterTest, STOP) {
       .state_after = RunState::kDone,
       .gas_before = 7,
       .gas_after = 7,
+  });
+}
+
+TEST(InterpreterTest, STOP_NoReturnData) {
+  RunInterpreterTest({
+      .code = {op::STOP},
+      .state_after = RunState::kDone,
+      .gas_before = 7,
+      .gas_after = 7,
+      .last_call_data = {0xFF},
+      .return_data = {},
   });
 }
 
@@ -4009,7 +4018,7 @@ TEST(InterpreterTest, LOG0_StaticCallViolation) {
 TEST(InterpreterTest, RETURN) {
   RunInterpreterTest({
       .code = {op::RETURN},
-      .state_after = RunState::kDone,
+      .state_after = RunState::kReturn,
       .gas_before = 10,
       .gas_after = 10,
       .stack_before = {2, 1},
@@ -4022,7 +4031,7 @@ TEST(InterpreterTest, RETURN) {
 TEST(InterpreterTest, RETURN_GrowMemory) {
   RunInterpreterTest({
       .code = {op::RETURN},
-      .state_after = RunState::kDone,
+      .state_after = RunState::kReturn,
       .gas_before = 10,
       .gas_after = 7,
       .stack_before = {3, 1},


### PR DESCRIPTION
Only RETURN and REVERT instructions yield return data. Other forms of termination leave the return data buffer empty.

---
**Integration Test Note:**
Integration tests could check that there is no return data (RETURNDATASIZE == 0) after a nested call terminated with an error or STOP.