### PR TITLE
evmc: Fix not forwarding read only flag for nested calls

### DIFF
--- a/go/common/evmc_bridge.go
+++ b/go/common/evmc_bridge.go
@@ -125,7 +125,7 @@ func (e *EvmcInterpreter) Run(contract *vm.Contract, input []byte, readOnly bool
 		Context:   &host_ctx,
 		Revision:  revision,
 		Kind:      evmc.Call,
-		Static:    readOnly,
+		Static:    e.readOnly,
 		Depth:     e.evm.Depth - 1,
 		Gas:       gasBefore,
 		Recipient: evmc.Address(contract.Address()),


### PR DESCRIPTION
Correctly forward read only flags to nested interpreter invocations.

---
**Integration Test Note:**
Integration tests should check that nested calls of STATICCALL are read only (i.e. static).
Apart from CALL, CALLCODE, and DELEGATECALL, this might also be relevant for CREATE and CREATE2.

Block: 21983927