### PR TITLE
evmc: GetCodeHash returns 0 when account does not exist

### DIFF
--- a/go/common/evmc_bridge.go
+++ b/go/common/evmc_bridge.go
@@ -270,7 +270,11 @@ func (ctx *HostContext) GetCodeSize(addr evmc.Address) int {
 }
 
 func (ctx *HostContext) GetCodeHash(addr evmc.Address) evmc.Hash {
-	return evmc.Hash(ctx.interpreter.evm.StateDB.GetCodeHash((common.Address)(addr)))
+	if ctx.interpreter.evm.StateDB.Exist((common.Address)(addr)) {
+		return evmc.Hash(ctx.interpreter.evm.StateDB.GetCodeHash((common.Address)(addr)))
+	} else {
+		return evmc.Hash{0}
+	}
 }
 
 func (ctx *HostContext) GetCode(addr evmc.Address) []byte {

--- a/go/vm/test/dynamic_gas.go
+++ b/go/vm/test/dynamic_gas.go
@@ -158,6 +158,7 @@ func gasDynamicAccountAccess(revision Revision) []*DynGasTest {
 		expectedGas := getAccessCost(revision, test.addrInAccessList, false)
 		stackValues := []*big.Int{address.Hash().Big()}
 		mockCalls := func(mockStateDB *vm_mock.MockStateDB) {
+			mockStateDB.EXPECT().Exist(address).AnyTimes().Return(true)
 			mockStateDB.EXPECT().AddressInAccessList(address).AnyTimes().Return(inAccessList)
 			mockStateDB.EXPECT().AddAddressToAccessList(address).AnyTimes()
 			mockStateDB.EXPECT().GetCodeSize(address).AnyTimes().Return(0)

--- a/go/vm/test/verify_gas_test.go
+++ b/go/vm/test/verify_gas_test.go
@@ -21,6 +21,7 @@ func TestStaticGas(t *testing.T) {
 	mockStateDB.EXPECT().GetCodeSize(gomock.Any()).AnyTimes().Return(0)
 	mockStateDB.EXPECT().Empty(gomock.Any()).AnyTimes().Return(true)
 	// evmone needs following in addition to geth and lfvm
+	mockStateDB.EXPECT().Exist(gomock.Any()).AnyTimes().Return(true)
 	mockStateDB.EXPECT().GetRefund().AnyTimes().Return(uint64(0))
 	mockStateDB.EXPECT().SubRefund(gomock.Any()).AnyTimes()
 	mockStateDB.EXPECT().AddRefund(gomock.Any()).AnyTimes()


### PR DESCRIPTION
**Integration Test Note:**
Integration test should cover that EXTCODEHASH on an non-existing account results in 0.

Block: 19433279