### PR TITLE
evmzero: Fix SAR implementation

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -395,17 +395,15 @@ static void sar(Context& ctx) noexcept {
   uint256_t value = ctx.stack.Pop();
   const bool is_negative = ToByteArrayLe(value)[31] & 0b1000'0000;
 
-  if (shift > 31) {
-    shift = 31;
+  if (shift <= 255) {
+    value >>= shift;
+    if (is_negative) {
+      value |= (kUint256Max << (255 - shift));
+    }
+    ctx.stack.Push(value);
+  } else {
+    ctx.stack.Push(0);
   }
-
-  value >>= shift;
-
-  if (is_negative) {
-    value |= (kUint256Max << (31 - shift));
-  }
-
-  ctx.stack.Push(value);
   ctx.pc++;
 }
 

--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -1205,6 +1205,15 @@ TEST(InterpreterTest, SHL) {
       .state_after = RunState::kDone,
       .gas_before = 7,
       .gas_after = 4,
+      .stack_before = {kUint256Max, 100},
+      .stack_after = {kUint256Max << 100},
+  });
+
+  RunInterpreterTest({
+      .code = {op::SHL},
+      .state_after = RunState::kDone,
+      .gas_before = 7,
+      .gas_after = 4,
       .stack_before = {7, 256},
       .stack_after = {0},
   });
@@ -1254,6 +1263,15 @@ TEST(InterpreterTest, SHR) {
       .state_after = RunState::kDone,
       .gas_before = 7,
       .gas_after = 4,
+      .stack_before = {kUint256Max, 100},
+      .stack_after = {kUint256Max >> 100},
+  });
+
+  RunInterpreterTest({
+      .code = {op::SHR},
+      .state_after = RunState::kDone,
+      .gas_before = 7,
+      .gas_after = 4,
       .stack_before = {kUint256Max, 256},
       .stack_after = {0},
   });
@@ -1296,6 +1314,33 @@ TEST(InterpreterTest, SAR) {
       .gas_after = 4,
       .stack_before = {kUint256Max - 0xF, 4},
       .stack_after = {kUint256Max},
+  });
+
+  RunInterpreterTest({
+      .code = {op::SAR},
+      .state_after = RunState::kDone,
+      .gas_before = 7,
+      .gas_after = 4,
+      .stack_before = {uint256_t{0, 0, 1}, 128},
+      .stack_after = {1},
+  });
+
+  RunInterpreterTest({
+      .code = {op::SAR},
+      .state_after = RunState::kDone,
+      .gas_before = 7,
+      .gas_after = 4,
+      .stack_before = {kUint256Max, 100},
+      .stack_after = {kUint256Max},
+  });
+
+  RunInterpreterTest({
+      .code = {op::SAR},
+      .state_after = RunState::kDone,
+      .gas_before = 7,
+      .gas_after = 4,
+      .stack_before = {kUint256Max, 256},
+      .stack_after = {0},
   });
 }
 


### PR DESCRIPTION
**Integration Test Note:**
Integration tests should cover that SAR is implemented correctly.
In this case, the shift parameter was capped at 31, instead of 255.

Block: 21741779