### PR TITLE
evmzero: Assign return data after CREATE, CREATE2 only upon revert

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -1179,7 +1179,9 @@ static void create_impl(Context& ctx) noexcept {
   };
 
   const evmc::Result result = ctx.host->call(msg);
-  ctx.return_data.assign(result.output_data, result.output_data + result.output_size);
+  if (result.status_code == EVMC_REVERT) {
+    ctx.return_data.assign(result.output_data, result.output_data + result.output_size);
+  }
 
   if (!ctx.ApplyGasCost(msg.gas - result.gas_left)) [[unlikely]]
     return;


### PR DESCRIPTION
**Integration Test Note:**
Integration tests should cover that return data is not populated on CREATE and CREATE2 unless the invocation reverts.

Block: 5396939