### PR TITLE
evmzero: Write call result data only when size > 0

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -1284,7 +1284,10 @@ static void call_impl(Context& ctx) noexcept {
   const evmc::Result result = ctx.host->call(msg);
   ctx.return_data.assign(result.output_data, result.output_data + result.output_size);
 
-  ctx.memory.ReadFromWithSize(ctx.return_data, output_offset, output_size);
+  ctx.memory.Grow(output_offset, output_size);
+  if (ctx.return_data.size() > 0) {
+    ctx.memory.ReadFromWithSize(ctx.return_data, output_offset, output_size);
+  }
 
   if (!ctx.ApplyGasCost(msg.gas - result.gas_left)) [[unlikely]]
     return;

--- a/cpp/vm/evmzero/memory.h
+++ b/cpp/vm/evmzero/memory.h
@@ -46,12 +46,8 @@ class Memory {
     std::copy_n(memory_.data() + memory_offset, buffer.size(), buffer.data());
   }
 
-  uint8_t& operator[](size_t index) { return memory_[index]; }
-  const uint8_t& operator[](size_t index) const { return memory_[index]; }
-
-  bool operator==(const Memory&) const = default;
-
- private:
+  // Grow memory to accommodate offset + size bytes. Memory is not grown when
+  // size == 0.
   void Grow(uint64_t offset, uint64_t size) {
     if (size != 0) {
       const auto new_size = offset + size;
@@ -61,6 +57,12 @@ class Memory {
     }
   }
 
+  uint8_t& operator[](size_t index) { return memory_[index]; }
+  const uint8_t& operator[](size_t index) const { return memory_[index]; }
+
+  bool operator==(const Memory&) const = default;
+
+ private:
   std::vector<uint8_t> memory_;
 };
 

--- a/cpp/vm/evmzero/memory_test.cc
+++ b/cpp/vm/evmzero/memory_test.cc
@@ -138,6 +138,24 @@ TEST(MemoryTest, WriteTo_ZeroSize) {
   EXPECT_EQ(memory.GetSize(), 0);
 }
 
+TEST(MemoryTest, Grow) {
+  Memory memory;
+  memory.Grow(0, 16);
+  EXPECT_EQ(memory.GetSize(), 32);
+
+  memory.Grow(32, 16);
+  EXPECT_EQ(memory.GetSize(), 64);
+
+  memory.Grow(0, 16);
+  EXPECT_EQ(memory.GetSize(), 64);
+}
+
+TEST(MemoryTest, Grow_ZeroSize) {
+  Memory memory;
+  memory.Grow(128, 0);
+  EXPECT_EQ(memory.GetSize(), 0);
+}
+
 TEST(MemoryTest, Subscript) {
   Memory memory = {1, 2, 3};
 


### PR DESCRIPTION
It appears that memory writes are handled differently when copying return data to memory after a call.

Specifically:
- Memory is always grown, regardless of return data size.
- Memory is only written to when return data size > 0; regardless of the `output_size` parameter.

Because of this, we now need access to the memory module's `Grow` function.

---

**Integration Test Note:**
Integration tests should check that memory is only written by a call when return data size > 0.
This is independent of the `output_size` parameter; specifically the memory is *not* written with null-bytes when return data size == 0.
However, memory needs grown regardless.

Block: 25263201