### PR TITLE
evmzero: RETURNDATACOPY errors when reading out-of-bounds

### DIFF
--- a/cpp/vm/evmzero/evmzero.cc
+++ b/cpp/vm/evmzero/evmzero.cc
@@ -29,6 +29,8 @@ evmc_status_code ToEvmcStatusCode(RunState state) {
       return EVMC_STACK_OVERFLOW;
     case RunState::kErrorJump:
       return EVMC_BAD_JUMP_DESTINATION;
+    case RunState::kErrorReturnDataCopyOutOfBounds:
+      return EVMC_INVALID_MEMORY_ACCESS;
     case RunState::kErrorCall:
       return EVMC_CALL_DEPTH_EXCEEDED;
     case RunState::kErrorCreate:

--- a/cpp/vm/evmzero/interpreter.h
+++ b/cpp/vm/evmzero/interpreter.h
@@ -23,6 +23,7 @@ enum class RunState {
   kErrorStackUnderflow,
   kErrorStackOverflow,
   kErrorJump,
+  kErrorReturnDataCopyOutOfBounds,
   kErrorCall,
   kErrorCreate,
   kErrorStaticCall,

--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -2324,54 +2324,27 @@ TEST(InterpreterTest, RETURNDATACOPY) {
       .gas_after = 4,
       .stack_before = {3, 1, 2},
       .memory_before{0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
-      .memory_after{0x0A, 0x0B, 0x00, 0x00, 0x00, 0x0F},
-  });
-
-  RunInterpreterTest({
-      .code = {op::RETURNDATACOPY},
-      .state_after = RunState::kDone,
-      .gas_before = 10,
-      .gas_after = 4,
-      .stack_before = {3, 1, 2},
-      .memory_before{0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
       .memory_after{0x0A, 0x0B, 0x02, 0x03, 0x04, 0x0F},
       .last_call_data{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
   });
 }
 
-TEST(InterpreterTest, RETURNDATACOPY_ZeroSize) {
+TEST(InterpreterTest, RETURNDATACOPY_OutOfBounds) {
   RunInterpreterTest({
       .code = {op::RETURNDATACOPY},
-      .state_after = RunState::kDone,
+      .state_after = RunState::kErrorReturnDataCopyOutOfBounds,
       .gas_before = 10,
-      .gas_after = 7,
-      .stack_before = {0, 1, 2},
-  });
-}
-
-TEST(InterpreterTest, RETURNDATACOPY_OutOfBytes) {
-  RunInterpreterTest({
-      .code = {op::RETURNDATACOPY},
-      .state_after = RunState::kDone,
-      .gas_before = 10,
-      .gas_after = 4,
       .stack_before = {3, 1, 2},
       .memory_before{0x0A, 0x0B, 0x0C},
-      .memory_after{0x0A, 0x0B, 0x02, 0x00, 0x00},
       .last_call_data{0x01, 0x02},
   });
-}
 
-TEST(InterpreterTest, RETURNDATACOPY_OutOfBytes_WriteZero) {
   RunInterpreterTest({
       .code = {op::RETURNDATACOPY},
-      .state_after = RunState::kDone,
+      .state_after = RunState::kErrorReturnDataCopyOutOfBounds,
       .gas_before = 10,
-      .gas_after = 4,
-      .stack_before = {3, 1, 2},
-      .memory_before{0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
-      .memory_after{0x0A, 0x0B, 0x02, 0x00, 0x00, 0x0F},
-      .last_call_data{0x01, 0x02},
+      .stack_before = {0, 1, 2},
+      .memory_before{0x0A, 0x0B, 0x0C},
   });
 }
 


### PR DESCRIPTION
Return data must not be access out-of-bounds.
An error is triggered on out-of-bounds access.

---

**Integration Test Note:**
An integration test should cover that accessing return data out-of-bounds results in an error.
This should also happen when the `size` parameter for RETURNDATACOPY is 0.

Block: 27747189