### PR TITLE
evmzero: Fix cold access costs in SSTORE

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -909,11 +909,7 @@ static void sstore(Context& ctx) noexcept {
 
   int64_t dynamic_gas_cost = 800;
   if (ctx.revision >= EVMC_BERLIN) {
-    if (key_is_warm) {
-      dynamic_gas_cost = 100;
-    } else {
-      dynamic_gas_cost = 2200;
-    }
+    dynamic_gas_cost = 100;
   }
 
   const auto storage_status = ctx.host->set_storage(ctx.message->recipient, ToEvmcBytes(key), ToEvmcBytes(value));
@@ -929,6 +925,10 @@ static void sstore(Context& ctx) noexcept {
     } else {
       dynamic_gas_cost = 5000;
     }
+  }
+
+  if (ctx.revision >= EVMC_BERLIN && !key_is_warm) {
+    dynamic_gas_cost += 2100;
   }
 
   if (!ctx.ApplyGasCost(dynamic_gas_cost)) [[unlikely]]

--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -3616,7 +3616,7 @@ TEST(InterpreterTest, SSTORE_BerlinRevision_StorageModified) {
   RunInterpreterTest({
       .code = {op::SSTORE},
       .state_after = RunState::kDone,
-      .gas_before = 3000,
+      .gas_before = 5100,
       .gas_after = 100,
       .stack_before = {32, 16},
       .message = {.recipient = evmc::address(0x42)},
@@ -3635,7 +3635,7 @@ TEST(InterpreterTest, SSTORE_BerlinRevision_StorageDeleted) {
   RunInterpreterTest({
       .code = {op::SSTORE},
       .state_after = RunState::kDone,
-      .gas_before = 3000,
+      .gas_before = 5100,
       .gas_after = 100,
       .gas_refund_after = 15000,
       .stack_before = {32, 16},


### PR DESCRIPTION
The cold access costs are applied in addition to other costs.

---

**Integration Test Note:**
Integration tests should cover the various combinations of storage access types (e.g. `EVMC_STORAGE_MODIFIED_DELETED`) and warm/cold access.

Block: 37455224