### PR TITLE
evmzero: Use std::vector for Stack implementation

### DIFF
--- a/cpp/vm/evmzero/stack.cc
+++ b/cpp/vm/evmzero/stack.cc
@@ -4,7 +4,9 @@
 
 namespace tosca::evmzero {
 
-Stack::Stack(std::initializer_list<uint256_t> elements) {
+Stack::Stack() : stack_(1024) {}
+
+Stack::Stack(std::initializer_list<uint256_t> elements) : Stack() {
   TOSCA_ASSERT(elements.size() <= stack_.size());
   std::copy(elements.begin(), elements.end(), stack_.begin());
   position_ = elements.size();

--- a/cpp/vm/evmzero/stack.h
+++ b/cpp/vm/evmzero/stack.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <array>
 #include <cstdint>
 #include <initializer_list>
 #include <ostream>
+#include <vector>
 
 #include "common/assert.h"
 #include "vm/evmzero/uint256.h"
@@ -13,7 +13,7 @@ namespace tosca::evmzero {
 // This data structure is used as the interpreter's stack during execution.
 class Stack {
  public:
-  Stack() = default;
+  Stack();
   Stack(std::initializer_list<uint256_t>);
 
   uint64_t GetSize() const { return position_; }
@@ -40,7 +40,7 @@ class Stack {
   friend bool operator!=(const Stack&, const Stack&);
 
  private:
-  std::array<uint256_t, 1024> stack_;
+  std::vector<uint256_t> stack_;
   uint64_t position_ = 0;
 };
 


### PR DESCRIPTION
Currently the interpreter's stack is not located on the heap. This causes a stack overflow on certain blocks when there are too many nested calls.

This PR moves the interpreter's stack to the heap.

---

**Integration Test Note:**
Integration tests should check whether the maximum call depth is correctly handled. This should also cover problems due to excessive stack usage by the interpreter.

Running out of stack space.
Block: 37672597+