### PR TITLE
evmzero: Add additional STOP bytes to prevent continuous end-of-code checks

### DIFF
--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -4130,10 +4130,11 @@ TEST(InterpreterTest, PUSH_OutOfGas) {
 
 TEST(InterpreterTest, PUSH_OutOfBytes) {
   RunInterpreterTest({
-      .code = {op::PUSH4, 0xFF, 0xFF, /* 0 byte added for test */},
+      .code = {op::PUSH4, 0xFF, 0xFF},
       .state_after = RunState::kDone,
       .gas_before = 10,
       .gas_after = 7,
+      .stack_after = {0xFFFF0000},
   });
 }
 


### PR DESCRIPTION
```
block range = 40000000 40100000

base:
substate-cli replay: 1281.58 blk/s, 15237.70 tx/s, 2836.05 Mgas/s
substate-cli replay done in 1m18.029s

stop-bytes:
substate-cli replay: 1306.88 blk/s, 15538.47 tx/s, 2892.03 Mgas/s
substate-cli replay done in 1m16.519s
```

---

```
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Tosca/go/vm/test
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
                             │   base.txt   │           stop-bytes.txt           │
                             │    sec/op    │    sec/op     vs base              │
Inc/1/evmzero-16               3.880µ ±  1%   4.005µ ±  1%  +3.22% (p=0.002 n=6)
Inc/10/evmzero-16              3.945µ ±  2%   3.994µ ±  1%       ~ (p=0.065 n=6)
Fib/1/evmzero-16               4.019µ ±  1%   4.187µ ±  2%  +4.18% (p=0.002 n=6)
Fib/5/evmzero-16               9.558µ ±  2%   9.643µ ±  1%       ~ (p=0.063 n=6)
Fib/10/evmzero-16              72.42µ ±  2%   70.77µ ±  1%  -2.28% (p=0.002 n=6)
Fib/15/evmzero-16              764.3µ ± 14%   745.5µ ±  0%  -2.45% (p=0.002 n=6)
Fib/20/evmzero-16              8.281m ±  1%   8.169m ±  2%  -1.35% (p=0.037 n=6)
Sha3/1/evmzero-16              2.352µ ±  1%   2.457µ ±  0%  +4.44% (p=0.002 n=6)
Sha3/10/evmzero-16             5.161µ ±  1%   5.322µ ±  1%  +3.11% (p=0.002 n=6)
Sha3/100/evmzero-16            32.59µ ±  0%   32.81µ ±  0%  +0.66% (p=0.002 n=6)
Sha3/1000/evmzero-16           308.7µ ±  6%   308.3µ ±  6%       ~ (p=1.000 n=6)
Arith/1/evmzero-16             4.175µ ±  2%   4.186µ ±  5%       ~ (p=0.485 n=6)
Arith/10/evmzero-16            6.458µ ±  0%   6.602µ ±  1%  +2.24% (p=0.002 n=6)
Arith/100/evmzero-16           29.05µ ±  0%   29.27µ ±  0%  +0.76% (p=0.002 n=6)
Arith/280/evmzero-16           74.73µ ±  0%   75.08µ ±  0%  +0.47% (p=0.002 n=6)
Memory/1/evmzero-16            5.400µ ±  2%   5.516µ ±  1%  +2.15% (p=0.015 n=6)
Memory/10/evmzero-16           8.123µ ±  1%   8.353µ ±  5%  +2.83% (p=0.002 n=6)
Memory/100/evmzero-16          34.00µ ±  0%   34.94µ ± 13%  +2.77% (p=0.002 n=6)
Memory/1000/evmzero-16         293.3µ ±  0%   302.2µ ±  1%  +3.03% (p=0.002 n=6)
Memory/10000/evmzero-16        2.910m ±  0%   2.977m ±  5%  +2.30% (p=0.002 n=6)
Analysis/jumpdest/evmzero-16   66.02µ ±  0%   66.60µ ±  1%  +0.89% (p=0.002 n=6)
Analysis/stop/evmzero-16       65.88µ ±  0%   66.52µ ±  1%  +0.97% (p=0.002 n=6)
Analysis/push1/evmzero-16      70.80µ ±  1%   71.36µ ±  0%  +0.80% (p=0.015 n=6)
Analysis/push32/evmzero-16     54.82µ ±  1%   55.56µ ±  2%  +1.35% (p=0.009 n=6)
geomean                        36.93µ         37.42µ        +1.33%
```