### PR TITLE
evmzero: Tweak FillValidJumpTargetsUpTo implementation

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -1410,12 +1410,9 @@ bool Context::CheckJumpDest(uint256_t index_u256) noexcept {
 }
 
 void Context::FillValidJumpTargetsUpTo(uint64_t index) noexcept {
-  if (index < valid_jump_targets.size()) [[likely]] {
-    return;
-  }
+  TOSCA_ASSERT(index < code.size());
 
-  if (index >= code.size()) [[unlikely]] {
-    TOSCA_ASSERT(false);
+  if (index < valid_jump_targets.size()) [[likely]] {
     return;
   }
 


### PR DESCRIPTION
This PR removes an early-exit branch from `FillValidJumpTargetsUpTo` that is unnecessary.

The speedup is very minor, still, `FillValidJumpTargetsUpTo` is performance critical.