### PR TITLE
evmzero: Reserve valid jump targets buffer

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -1480,6 +1480,8 @@ void RunInterpreter(Context& ctx) {
   // of the last instructions is a PUSH with too few arguments.
   ctx.code.resize(ctx.code.size() + 32, op::STOP);
 
+  ctx.valid_jump_targets.reserve(ctx.code.size());
+
   while (ctx.state == RunState::kRunning) {
     if constexpr (LoggingEnabled) {
       // log format: <op>, <gas>, <top-of-stack>\n


### PR DESCRIPTION
Reserving space for the valid jump targets buffer appears to yield a speedup of ~ 2%.

I also tried using resize here, and only writing the true values to the buffer in `FillValidJumpTargetsUpTo`, but that appears to be slower.