### PR TITLE
Inline frequently used utility functions

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -1367,7 +1367,7 @@ bool Context::CheckStaticCallConformance() noexcept {
   }
 }
 
-bool Context::CheckStackAvailable(uint64_t elements_needed) noexcept {
+inline bool Context::CheckStackAvailable(uint64_t elements_needed) noexcept {
   if (stack.GetSize() < elements_needed) [[unlikely]] {
     state = RunState::kErrorStackUnderflow;
     return false;
@@ -1376,7 +1376,7 @@ bool Context::CheckStackAvailable(uint64_t elements_needed) noexcept {
   }
 }
 
-bool Context::CheckStackOverflow(uint64_t slots_needed) noexcept {
+inline bool Context::CheckStackOverflow(uint64_t slots_needed) noexcept {
   if (stack.GetMaxSize() - stack.GetSize() < slots_needed) [[unlikely]] {
     state = RunState::kErrorStackOverflow;
     return false;
@@ -1460,7 +1460,7 @@ Context::MemoryExpansionCostResult Context::MemoryExpansionCost(uint256_t offset
   };
 }
 
-bool Context::ApplyGasCost(int64_t gas_cost) noexcept {
+inline bool Context::ApplyGasCost(int64_t gas_cost) noexcept {
   TOSCA_ASSERT(gas_cost >= 0);
 
   if (gas < gas_cost) [[unlikely]] {


### PR DESCRIPTION
This PR moves frequently used utility functions from the *.cc file to the *.h file, reducing benchmark runtimes by up to ~38%:
```
name                         old time/op  new time/op  delta
Inc/1/evmzero-4              8.31µs ± 5%  7.08µs ± 5%  -14.76%  (p=0.008 n=5+5)
Inc/10/evmzero-4             8.36µs ± 3%  6.98µs ± 4%  -16.47%  (p=0.008 n=5+5)
Fib/1/evmzero-4              7.99µs ± 6%  7.08µs ± 5%  -11.33%  (p=0.008 n=5+5)
Fib/5/evmzero-4              28.1µs ± 4%  20.6µs ± 6%  -26.63%  (p=0.008 n=5+5)
Fib/10/evmzero-4              257µs ± 7%   163µs ± 6%  -36.35%  (p=0.008 n=5+5)
Fib/15/evmzero-4             2.79ms ± 4%  1.75ms ± 2%  -37.31%  (p=0.008 n=5+5)
Fib/20/evmzero-4             29.3ms ± 7%  19.5ms ± 3%  -33.24%  (p=0.008 n=5+5)
Sha3/1/evmzero-4             4.09µs ±13%  3.77µs ± 5%     ~     (p=0.056 n=5+5)
Sha3/10/evmzero-4            9.68µs ± 7%  8.86µs ± 2%   -8.52%  (p=0.008 n=5+5)
Sha3/100/evmzero-4           62.6µs ± 2%  58.3µs ± 3%   -6.93%  (p=0.008 n=5+5)
Sha3/1000/evmzero-4           621µs ± 6%   593µs ± 3%     ~     (p=0.095 n=5+5)
Arith/1/evmzero-4            9.23µs ± 5%  7.41µs ± 4%  -19.76%  (p=0.008 n=5+5)
Arith/10/evmzero-4           17.8µs ± 4%  12.8µs ± 8%  -28.04%  (p=0.008 n=5+5)
Arith/100/evmzero-4           107µs ± 7%    69µs ±10%  -35.15%  (p=0.008 n=5+5)
Arith/280/evmzero-4           285µs ± 4%   175µs ± 4%  -38.56%  (p=0.008 n=5+5)
Memory/1/evmzero-4           12.5µs ± 2%  10.0µs ± 2%  -20.35%  (p=0.008 n=5+5)
Memory/10/evmzero-4          22.7µs ± 8%  16.6µs ± 8%  -27.05%  (p=0.008 n=5+5)
Memory/100/evmzero-4          119µs ± 3%    75µs ± 3%  -36.79%  (p=0.008 n=5+5)
Memory/1000/evmzero-4        1.15ms ± 1%  0.71ms ± 6%  -38.82%  (p=0.016 n=4+5)
Memory/10000/evmzero-4       10.5ms ± 6%   6.7ms ± 9%  -35.80%  (p=0.008 n=5+5)
Analysis/jumpdest/evmzero-4   108µs ± 3%   106µs ± 1%     ~     (p=0.222 n=5+5)
Analysis/stop/evmzero-4       106µs ± 0%   107µs ± 4%     ~     (p=0.413 n=4+5)
Analysis/push1/evmzero-4      114µs ± 0%   114µs ± 1%     ~     (p=0.690 n=5+5)
Analysis/push32/evmzero-4    84.1µs ± 1%  85.2µs ± 4%     ~     (p=0.222 n=5+5)
```