### PR TITLE
evmzero: Calculate hash directly from memory

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -428,11 +428,7 @@ static void sha3(Context& ctx) noexcept {
   if (!ctx.ApplyGasCost(6 * minimum_word_size)) [[unlikely]]
     return;
 
-  std::vector<uint8_t> buffer(size);
-  ctx.memory.WriteTo(buffer, offset);
-
-  auto hash = ethash::keccak256(buffer.data(), buffer.size());
-  ctx.stack.Push(ToUint256(hash));
+  ctx.stack.Push(ctx.memory.CalculateHash(offset, size));
   ctx.pc++;
 }
 

--- a/cpp/vm/evmzero/memory.h
+++ b/cpp/vm/evmzero/memory.h
@@ -7,6 +7,10 @@
 #include <span>
 #include <vector>
 
+#include <ethash/keccak.hpp>
+
+#include "vm/evmzero/uint256.h"
+
 namespace tosca::evmzero {
 
 // This data structure is used as the interpreter's memory during execution.
@@ -44,6 +48,13 @@ class Memory {
   void WriteTo(std::span<uint8_t> buffer, uint64_t memory_offset) {
     Grow(memory_offset, buffer.size());
     std::copy_n(memory_.data() + memory_offset, buffer.size(), buffer.data());
+  }
+
+  // Calculates the keccak256 hash of the given memory segement. Grows memory
+  // automatically, unless size == 0.
+  uint256_t CalculateHash(uint64_t offset, uint64_t size) {
+    Grow(offset, size);
+    return ToUint256(ethash::keccak256(memory_.data() + offset, size));
   }
 
   // Grow memory to accommodate offset + size bytes. Memory is not grown when

--- a/cpp/vm/evmzero/memory_test.cc
+++ b/cpp/vm/evmzero/memory_test.cc
@@ -138,6 +138,29 @@ TEST(MemoryTest, WriteTo_ZeroSize) {
   EXPECT_EQ(memory.GetSize(), 0);
 }
 
+TEST(MemoryTest, CalculateHash) {
+  Memory memory = {0xFF, 0xFF, 0xFF, 0xFF};
+
+  auto hash = memory.CalculateHash(0, 4);
+  EXPECT_EQ(hash, uint256_t(0x79A1BC8F0BB2C238, 0x9522D0CF0F73282C, 0x46EF02C2223570DA, 0x29045A592007D0C2));
+}
+
+TEST(MemoryTest, CalculateHash_ZeroSize) {
+  Memory memory = {0xFF, 0xFF, 0xFF, 0xFF};
+
+  auto hash = memory.CalculateHash(4, 0);
+  EXPECT_EQ(hash, uint256_t(0x7BFAD8045D85A470, 0xE500B653CA82273B, 0x927E7DB2DCC703C0, 0xC5D2460186F7233C));
+  EXPECT_EQ(memory.GetSize(), 32);
+}
+
+TEST(MemoryTest, CalculateHash_Grow) {
+  Memory memory;
+
+  auto hash = memory.CalculateHash(0, 4);
+  EXPECT_EQ(hash, uint256_t(0x64633A4ACBD3244C, 0xF7685EBD40E852B1, 0x55364C7B4BBF0BB7, 0xE8E77626586F73B9));
+  EXPECT_EQ(memory.GetSize(), 32);
+}
+
 TEST(MemoryTest, Grow) {
   Memory memory;
   memory.Grow(0, 16);


### PR DESCRIPTION
This PR moves the hash calculation into the memory module, removing the need to copy memory into a local buffer for hash calculation.

Currently the interface of the hashing library only exposes a function that takes a single memory span, without any option to combine multiple spans / hashes. Currently this is not a problem as the interpreter's memory is contiguous, but this may cause problems when extending the memory module to keep the interpreter's memory stored in non-contiguous chunks.