### PR TITLE
Force the execution of Go tests in the CI system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ tosca-cpp:
 test: test-go test-cpp
 
 test-go: tosca-go
-	@go test ./...
+	@go test ./... -count 1
 
 test-cpp: tosca-cpp
 	@cd cpp/build ; \


### PR DESCRIPTION
Without the  `-count 1` option Go may reuse cached test results if no change in the Go code is detected. However, changes in C++ code are missed.