### PR TITLE
evmzero: Fix out-of-code on PUSH32 without any arguments

### DIFF
--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -4136,6 +4136,14 @@ TEST(InterpreterTest, PUSH_OutOfBytes) {
       .gas_after = 7,
       .stack_after = {0xFFFF0000},
   });
+
+  RunInterpreterTest({
+      .code = {op::PUSH32},
+      .state_after = RunState::kDone,
+      .gas_before = 10,
+      .gas_after = 7,
+      .stack_after = {0},
+  });
 }
 
 TEST(InterpreterTest, DISABLED_PUSH_StackOverflow) {}


### PR DESCRIPTION
32 additional STOP bytes are one too few to cover the worst case. While the integration test suit already covers this case, the unit tests currently do not.

This PR increases the number of STOP bytes to 33 and adds a unit test for the worst case. Asan is able to catch the out-of-bounds access on my system.