### PR TITLE
evmzero: Fix warning caused by explicit move semantics

### DIFF
--- a/cpp/vm/evmzero/stack.h
+++ b/cpp/vm/evmzero/stack.h
@@ -16,7 +16,7 @@ class Stack {
  public:
   Stack();
   Stack(const Stack&);
-  Stack(Stack&&) = default;
+  Stack(Stack&&) = delete;
   Stack(std::initializer_list<uint256_t>);
 
   uint64_t GetSize() const { return uint64_t(end_ - top_); }
@@ -47,7 +47,7 @@ class Stack {
   }
 
   Stack& operator=(const Stack&);
-  Stack& operator=(Stack&&) = default;
+  Stack& operator=(Stack&&) = delete;
 
   // Accesses elements starting from the top; index 0 is the top element.
   uint256_t& operator[](size_t index) {


### PR DESCRIPTION
Clang issues a warning here since move-constructor and move-assignment cannot be generated by the compiler (due to the use of `std::unique_ptr`).

```
/mnt/p/fantom/tosca/cpp/vm/evmzero/stack.h:50:10: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
  Stack& operator=(Stack&&) = default;
```