### PR TITLE
evmzero: Increase valid jump target cache size to 2^16

### DIFF
--- a/cpp/common/lru_cache.h
+++ b/cpp/common/lru_cache.h
@@ -65,6 +65,8 @@ class LruCache {
     return entries_.size();
   }
 
+  constexpr size_t GetMaxSize() const { return Capacity; }
+
   void Clear() {
     std::scoped_lock lock(mutex_);
     entries_.clear();

--- a/cpp/vm/evmzero/evmzero.cc
+++ b/cpp/vm/evmzero/evmzero.cc
@@ -147,7 +147,7 @@ class VM : public evmc_vm {
   bool logging_enabled_ = false;
   bool analysis_cache_enabled_ = true;
 
-  LruCache<evmc::bytes32, op::ValidJumpTargetsBuffer, 128> valid_jump_targets_cache_;
+  LruCache<evmc::bytes32, op::ValidJumpTargetsBuffer, 1 << 16> valid_jump_targets_cache_;
 };
 
 extern "C" {


### PR DESCRIPTION
A cache size of $2^{16}$ seems to work fine on my test machine, but I hardly noticed any performance difference. I'd like to merge this change into main and see whether it has any effect on the nightly CI job.