### PR TITLE
evmzero: Read/write memory directly

### DIFF
--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -2311,7 +2311,7 @@ TEST(InterpreterTest, EXTCODECOPY_WriteZeros) {
   MockHost host;
   EXPECT_CALL(host, copy_code(evmc::address(0x42), 1, _, 3))  //
       .Times(1)
-      .WillOnce(DoAll(SetArrayArgument<2>(code.data() + 1, code.data() + 2), Return(3)));
+      .WillOnce(DoAll(SetArrayArgument<2>(code.data() + 1, code.data() + 1 + 1), Return(1)));
 
   RunInterpreterTest({
       .code = {op::EXTCODECOPY},

--- a/cpp/vm/evmzero/memory.h
+++ b/cpp/vm/evmzero/memory.h
@@ -23,6 +23,13 @@ class Memory {
 
   uint64_t GetSize() const { return memory_.size(); }
 
+  // Get a span for the given memory offset and size that can be used for
+  // reading or writing. Grows memory automatically, unless size == 0.
+  std::span<uint8_t> GetSpan(uint64_t offset, uint64_t size) {
+    Grow(offset, size);
+    return {memory_.data() + offset, size};
+  }
+
   // Read from the given buffer into memory at memory_offset. Grows memory
   // automatically, unless buffer.size() == 0.
   void ReadFrom(std::span<const uint8_t> buffer, uint64_t memory_offset) {


### PR DESCRIPTION
```
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
                             │ baseline.txt │           direct_mem.txt           │
                             │    sec/op    │    sec/op     vs base              │
Inc/1/evmzero-16               3.566µ ±  1%   3.510µ ±  2%  -1.57% (p=0.038 n=7)
Inc/10/evmzero-16              3.549µ ±  2%   3.507µ ±  1%  -1.18% (p=0.001 n=7)
Fib/1/evmzero-16               3.781µ ±  2%   3.710µ ±  1%  -1.88% (p=0.001 n=7)
Fib/5/evmzero-16               8.191µ ± 11%   8.052µ ±  6%  -1.70% (p=0.026 n=7)
Fib/10/evmzero-16              57.33µ ±  9%   56.01µ ±  2%  -2.30% (p=0.002 n=7)
Fib/15/evmzero-16              597.0µ ±  1%   584.5µ ±  4%  -2.10% (p=0.026 n=7)
Fib/20/evmzero-16              6.536m ±  0%   6.424m ± 27%  -1.71% (p=0.026 n=7)
Sha3/1/evmzero-16              2.357µ ±  1%   2.345µ ±  2%  -0.51% (p=0.009 n=7)
Sha3/10/evmzero-16             5.032µ ±  1%   5.014µ ±  2%       ~ (p=0.334 n=7)
Sha3/100/evmzero-16            30.87µ ±  0%   30.43µ ±  0%  -1.43% (p=0.001 n=7)
Sha3/1000/evmzero-16           287.8µ ±  1%   286.1µ ±  2%  -0.60% (p=0.026 n=7)
Arith/1/evmzero-16             3.747µ ±  1%   3.702µ ±  2%       ~ (p=0.093 n=7)
Arith/10/evmzero-16            5.888µ ±  3%   5.756µ ±  3%  -2.24% (p=0.017 n=7)
Arith/100/evmzero-16           26.15µ ± 14%   25.16µ ±  4%  -3.76% (p=0.017 n=7)
Arith/280/evmzero-16           67.04µ ± 15%   64.46µ ± 15%  -3.85% (p=0.017 n=7)
Memory/1/evmzero-16            4.893µ ±  1%   4.889µ ±  3%       ~ (p=0.837 n=7)
Memory/10/evmzero-16           7.506µ ±  5%   7.344µ ±  1%  -2.16% (p=0.001 n=7)
Memory/100/evmzero-16          31.65µ ± 23%   30.44µ ± 15%  -3.82% (p=0.017 n=7)
Memory/1000/evmzero-16         275.1µ ±  1%   264.7µ ±  0%  -3.78% (p=0.001 n=7)
Memory/10000/evmzero-16        2.732m ±  9%   2.629m ±  0%  -3.77% (p=0.001 n=7)
Analysis/jumpdest/evmzero-16   53.30µ ±  0%   53.25µ ±  0%       ~ (p=0.165 n=7)
Analysis/stop/evmzero-16       53.31µ ±  0%   53.30µ ±  3%       ~ (p=1.000 n=7)
Analysis/push1/evmzero-16      53.28µ ±  0%   53.33µ ±  0%       ~ (p=0.620 n=7)
Analysis/push32/evmzero-16     53.33µ ±  0%   53.27µ ±  0%  -0.13% (p=0.026 n=7)
geomean                        32.86µ         32.31µ        -1.68%
```