### PR TITLE
evmzero: Fix performance degredation with Sha3Cache feedback

### DIFF
--- a/cpp/common/macros.h
+++ b/cpp/common/macros.h
@@ -13,3 +13,5 @@
 #endif
 
 #define TOSCA_CHECK_OVERFLOW_ADD(a, b, result) __builtin_add_overflow(a, b, result)
+
+#define TOSCA_FORCE_INLINE __attribute__((always_inline)) 

--- a/cpp/vm/evmzero/sha3_cache.h
+++ b/cpp/vm/evmzero/sha3_cache.h
@@ -6,6 +6,7 @@
 
 #include "common/hash_utils.h"
 #include "common/lru_cache.h"
+#include "common/macros.h"
 #include "vm/evmzero/uint256.h"
 
 namespace tosca::evmzero {
@@ -15,7 +16,7 @@ namespace tosca::evmzero {
 // capcity. A least-recently-used strategy is employed.
 class Sha3Cache {
  public:
-  uint256_t Hash(std::span<const uint8_t> key_view) noexcept {
+  TOSCA_FORCE_INLINE uint256_t Hash(std::span<const uint8_t> key_view) noexcept {
     auto calculate_hash = [&key_view]() {  //
       return ToUint256(ethash::keccak256(key_view.data(), key_view.size()));
     };


### PR DESCRIPTION
While integrating feedback for the SHA3 cache PR #125, benchmark performance degraded substantially. Experimenting with the changes showed that this degradation is likely caused by not inlining the `Sha3Cache`'s primary member function.

sha3_cache_1.txt: d3dd59c1425e56154d6c553a5ba3b13ca52ebb5d
sha3_cache_4.txt: dbb7a2831b5e11db9f3974d239cd96f7f59a0dc3

```
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
                             │ sha3_cache_1.txt │          sha3_cache_4.txt           │
                             │      sec/op      │    sec/op     vs base               │
Inc/1/evmzero-16                   3.620µ ±  1%   3.562µ ±  3%        ~ (p=0.209 n=7)
Inc/10/evmzero-16                  3.625µ ±  4%   3.590µ ±  1%   -0.97% (p=0.007 n=7)
Fib/1/evmzero-16                   3.793µ ±  2%   3.768µ ±  1%   -0.66% (p=0.049 n=7)
Fib/5/evmzero-16                   8.731µ ±  2%   8.167µ ±  6%   -6.46% (p=0.001 n=7)
Fib/10/evmzero-16                  64.28µ ± 15%   56.82µ ±  1%  -11.62% (p=0.001 n=7)
Fib/15/evmzero-16                  679.8µ ±  1%   594.5µ ±  4%  -12.55% (p=0.001 n=7)
Fib/20/evmzero-16                  7.426m ±  0%   6.503m ± 27%  -12.43% (p=0.026 n=7)
Sha3/1/evmzero-16                  2.193µ ±  1%   2.201µ ±  6%        ~ (p=0.157 n=7)
Sha3/10/evmzero-16                 3.544µ ±  1%   3.561µ ±  1%        ~ (p=0.272 n=7)
Sha3/100/evmzero-16                16.69µ ±  4%   16.46µ ±  2%   -1.41% (p=0.011 n=7)
Sha3/1000/evmzero-16               155.6µ ±  3%   151.6µ ± 11%   -2.54% (p=0.026 n=7)
Arith/1/evmzero-16                 3.822µ ±  3%   3.749µ ±  1%   -1.91% (p=0.001 n=7)
Arith/10/evmzero-16                6.194µ ±  3%   5.777µ ±  3%   -6.73% (p=0.001 n=7)
Arith/100/evmzero-16               28.44µ ±  0%   25.21µ ±  2%  -11.36% (p=0.001 n=7)
Arith/280/evmzero-16               73.35µ ±  0%   64.50µ ±  1%  -12.07% (p=0.001 n=7)
Memory/1/evmzero-16                5.101µ ±  2%   4.929µ ±  4%   -3.37% (p=0.011 n=7)
Memory/10/evmzero-16               7.881µ ±  3%   7.423µ ±  4%   -5.81% (p=0.001 n=7)
Memory/100/evmzero-16              34.32µ ±  0%   30.90µ ±  0%   -9.96% (p=0.001 n=7)
Memory/1000/evmzero-16             303.4µ ± 14%   268.1µ ± 15%  -11.64% (p=0.011 n=7)
Memory/10000/evmzero-16            3.004m ±  0%   2.647m ±  0%  -11.89% (p=0.001 n=7)
Analysis/jumpdest/evmzero-16       53.28µ ±  0%   53.29µ ±  0%        ~ (p=0.535 n=7)
Analysis/stop/evmzero-16           53.30µ ±  0%   53.32µ ±  0%        ~ (p=0.400 n=7)
Analysis/push1/evmzero-16          53.31µ ±  0%   53.27µ ±  0%        ~ (p=0.196 n=7)
Analysis/push32/evmzero-16         53.32µ ±  0%   53.27µ ±  0%        ~ (p=0.244 n=7)
geomean                            32.09µ         30.39µ         -5.31%
```

```
Debian clang version 14.0.6
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```

- Release build
- TOSCA_ASAN off
- TOSCA_ASSERT on
- Similar differences as shown here were not found when using GCC (12.2.0)