### PR TITLE
evmzero: Add -march=native -mtune=native compiled flags

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -19,7 +19,7 @@ function(tosca_add_compile_flags target)
     CXX_EXTENSIONS OFF)
   target_compile_options(${target} PRIVATE
     $<$<CXX_COMPILER_ID:MSVC>:/MP /W4 /external:W0>
-    $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall -Wextra -Wpedantic -Wtype-limits -Wconversion -Wsign-conversion -Wdouble-promotion -g>
+    $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-march=native -mtune=native -Wall -Wextra -Wpedantic -Wtype-limits -Wconversion -Wsign-conversion -Wdouble-promotion -g>
     $<$<CXX_COMPILER_ID:GNU>:-Wno-missing-field-initializers -fdiagnostics-color>
     $<$<CXX_COMPILER_ID:Clang,AppleClang>:-fcolor-diagnostics>)
   target_compile_definitions(${target} PRIVATE $<$<BOOL:${TOSCA_ASSERT}>:TOSCA_ASSERT_ENABLED>)


### PR DESCRIPTION
It appears that benchmarks are negatively impacted with these flags while block execution becomes marginally faster.

```
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
                             │ baseline.txt │              march.txt              │
                             │    sec/op    │    sec/op     vs base               │
Inc/1/evmzero-16               3.457µ ±  1%   3.489µ ±  1%   +0.93% (p=0.035 n=7)
Inc/10/evmzero-16              3.449µ ±  1%   3.495µ ±  2%   +1.33% (p=0.001 n=7)
Fib/1/evmzero-16               3.703µ ±  3%   3.670µ ±  1%        ~ (p=0.097 n=7)
Fib/5/evmzero-16               7.621µ ±  1%   7.829µ ±  6%   +2.73% (p=0.001 n=7)
Fib/10/evmzero-16              51.35µ ±  2%   53.51µ ±  2%   +4.22% (p=0.001 n=7)
Fib/15/evmzero-16              534.0µ ±  6%   560.3µ ±  1%   +4.93% (p=0.017 n=7)
Fib/20/evmzero-16              5.843m ± 30%   6.141m ±  1%   +5.10% (p=0.026 n=7)
Sha3/1/evmzero-16              2.145µ ±  2%   2.200µ ±  2%   +2.56% (p=0.001 n=7)
Sha3/10/evmzero-16             3.429µ ±  1%   3.423µ ±  1%        ~ (p=0.402 n=7)
Sha3/100/evmzero-16            15.49µ ±  1%   15.59µ ±  2%        ~ (p=0.073 n=7)
Sha3/1000/evmzero-16           142.7µ ±  1%   143.5µ ±  1%        ~ (p=0.165 n=7)
Arith/1/evmzero-16             3.607µ ±  2%   3.640µ ±  2%   +0.91% (p=0.038 n=7)
Arith/10/evmzero-16            5.398µ ±  2%   5.494µ ±  3%   +1.78% (p=0.007 n=7)
Arith/100/evmzero-16           22.54µ ±  1%   23.87µ ± 15%   +5.91% (p=0.001 n=7)
Arith/280/evmzero-16           57.30µ ±  0%   62.17µ ± 12%   +8.50% (p=0.001 n=7)
Memory/1/evmzero-16            4.672µ ±  4%   4.742µ ±  3%   +1.50% (p=0.029 n=7)
Memory/10/evmzero-16           6.830µ ±  3%   7.043µ ±  1%   +3.12% (p=0.011 n=7)
Memory/100/evmzero-16          26.47µ ±  1%   28.78µ ±  0%   +8.74% (p=0.001 n=7)
Memory/1000/evmzero-16         223.9µ ±  1%   248.9µ ±  1%  +11.20% (p=0.001 n=7)
Memory/10000/evmzero-16        2.214m ±  0%   2.454m ±  4%  +10.86% (p=0.001 n=7)
Analysis/jumpdest/evmzero-16   53.30µ ±  0%   53.28µ ±  0%        ~ (p=0.318 n=7)
Analysis/stop/evmzero-16       53.28µ ±  0%   53.33µ ±  0%        ~ (p=0.209 n=7)
Analysis/push1/evmzero-16      53.25µ ±  0%   53.32µ ±  0%   +0.14% (p=0.002 n=7)
Analysis/push32/evmzero-16     53.28µ ±  0%   53.26µ ±  0%        ~ (p=0.559 n=7)
geomean                        28.38µ         29.24µ         +3.05%
```

---

Workers: 16
Block range: 40000000 40200000

Baseline:
```
substate-cli replay done in 2m24.037s
2023/07/27 20:42:03 NOTICE   replay/replayAction: net VM time: 30m12.979104345s
```

`-march=native -mtune=native`:
```
substate-cli replay done in 2m19.331s
2023/07/27 20:45:14 NOTICE   replay/replayAction: net VM time: 29m2.626587795s
```

---

Workers: 1
Block range: 40000000 40020000

Baseline:
```
substate-cli replay done in 1m30.225s
2023/07/27 20:51:47 NOTICE   replay/replayAction: net VM time: 1m4.780435577s
```

`-march=native -mtune=native`:
```
substate-cli replay done in 1m29.417s
2023/07/27 20:49:14 NOTICE   replay/replayAction: net VM time: 1m4.012767606s
```