### PR TITLE
Remove hashing of codes from benchmarks

### DIFF
--- a/go/examples/analysis.go
+++ b/go/examples/analysis.go
@@ -53,33 +53,33 @@ func GetJumpdestAnalysisExample() Example {
 	filler := []byte{byte(vm.JUMPDEST)}
 	code := GenerateAnalysisCode(filler)
 
-	return Example{
+	return exampleSpec{
 		Name:      "jumpdest",
 		code:      code,
 		reference: analysis,
-	}
+	}.build()
 }
 
 func GetStopAnalysisExample() Example {
 	filler := []byte{byte(vm.STOP)}
 	code := GenerateAnalysisCode(filler)
 
-	return Example{
+	return exampleSpec{
 		Name:      "stop",
 		code:      code,
 		reference: analysis,
-	}
+	}.build()
 }
 
 func GetPush1AnalysisExample() Example {
 	filler := []byte{byte(vm.PUSH1), 0}
 	code := GenerateAnalysisCode(filler)
 
-	return Example{
+	return exampleSpec{
 		Name:      "push1",
 		code:      code,
 		reference: analysis,
-	}
+	}.build()
 }
 
 func GetPush32AnalysisExample() Example {
@@ -87,11 +87,11 @@ func GetPush32AnalysisExample() Example {
 	filler = append(filler, make([]byte, 32)...)
 	code := GenerateAnalysisCode(filler)
 
-	return Example{
+	return exampleSpec{
 		Name:      "push32",
 		code:      code,
 		reference: analysis,
-	}
+	}.build()
 }
 
 func analysis(x int) int {

--- a/go/examples/arithmetic.go
+++ b/go/examples/arithmetic.go
@@ -36,12 +36,12 @@ func GetArithmeticExample() Example {
 		log.Fatalf("Unable to decode arithmetic-code: %v", err)
 	}
 
-	return Example{
+	return exampleSpec{
 		Name:      "arithmetic",
 		code:      code,
 		function:  0xCC821C09,
 		reference: arithmetic,
-	}
+	}.build()
 }
 
 func arithmetic(n int) int {

--- a/go/examples/example.go
+++ b/go/examples/example.go
@@ -10,12 +10,25 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-// Example describes a contract and an entry point with a (int)->int signature.
+// Example is an executable description of a contract and an entry point with a (int)->int signature.
 type Example struct {
+	exampleSpec
+	codeHash common.Hash // the hash of the code
+}
+
+// exampleSpec specifies a contract and an entry point with a (int)->int signature.
+type exampleSpec struct {
 	Name      string
 	code      []byte        // some contract code
 	function  uint32        // identifier of the function in the contract to be called
 	reference func(int) int // a reference function computing the same function
+}
+
+func (s exampleSpec) build() Example {
+	return Example{
+		exampleSpec: s,
+		codeHash:    crypto.Keccak256Hash(s.code),
+	}
 }
 
 type Result struct {
@@ -32,7 +45,7 @@ func (e *Example) RunOn(interpreter vm.EVMInterpreter, argument int) (Result, er
 	addr := vm.AccountRef{}
 	contract := vm.NewContract(addr, addr, big.NewInt(0), initialGas)
 	contract.Code = e.code
-	contract.CodeHash = crypto.Keccak256Hash(e.code)
+	contract.CodeHash = e.codeHash
 	contract.CodeAddr = &common.Address{}
 
 	output, err := interpreter.Run(contract, input, false)

--- a/go/examples/fib.go
+++ b/go/examples/fib.go
@@ -12,12 +12,12 @@ func GetFibExample() Example {
 		log.Fatalf("Unable to decode fib-code: %v", err)
 	}
 
-	return Example{
+	return exampleSpec{
 		Name:      "fib",
 		code:      code,
 		function:  0xF9B7C7E5, // function selector for the fib function
 		reference: fib,
-	}
+	}.build()
 }
 
 func fib(x int) int {

--- a/go/examples/inc.go
+++ b/go/examples/inc.go
@@ -12,12 +12,12 @@ func GetIncrementExample() Example {
 		log.Fatalf("Unable to decode increment-code: %v", err)
 	}
 
-	return Example{
+	return exampleSpec{
 		Name:      "inc",
 		code:      code,
 		function:  0xDD5D5211,
 		reference: inc,
-	}
+	}.build()
 }
 
 func inc(x int) int {

--- a/go/examples/memory.go
+++ b/go/examples/memory.go
@@ -32,12 +32,12 @@ func GetMemoryExample() Example {
 		log.Fatalf("Unable to decode memory-code: %v", err)
 	}
 
-	return Example{
+	return exampleSpec{
 		Name:      "memory",
 		code:      code,
 		function:  0xE88AE781,
 		reference: memory,
-	}
+	}.build()
 }
 
 func memory(n int) int {

--- a/go/examples/sha3.go
+++ b/go/examples/sha3.go
@@ -52,11 +52,11 @@ func GetSha3Example() Example {
 		byte(vm.RETURN),
 	}
 
-	return Example{
+	return exampleSpec{
 		Name:      "sha3",
 		code:      code,
 		reference: sha3Ref,
-	}
+	}.build()
 }
 
 func sha3Ref(x int) int {


### PR DESCRIPTION
This fix removes the computation of the code hash from the time covered by benchmarks.

This bug significantly inflated the cost of some benchmarks, in particular the analysis benchmarks.
```
name                         old time/op  new time/op  delta
Analysis/jumpdest/lfvm-4     98.9µs ±18%   1.5µs ± 1%  -98.51%  (p=0.000 n=10+9)
Analysis/jumpdest/evmzero-4  93.6µs ± 2%   3.0µs ± 3%  -96.76%  (p=0.000 n=10+10)
Analysis/stop/lfvm-4         90.7µs ± 8%   1.5µs ± 1%  -98.38%  (p=0.000 n=9+10)
Analysis/stop/evmzero-4      93.9µs ± 5%   3.0µs ± 2%  -96.80%  (p=0.000 n=10+9)
Analysis/push1/lfvm-4        85.6µs ± 6%   1.5µs ± 1%  -98.26%  (p=0.000 n=10+10)
Analysis/push1/evmzero-4     83.7µs ± 2%   3.0µs ± 2%  -96.41%  (p=0.000 n=10+10)
Analysis/push32/lfvm-4       81.5µs ± 1%   1.5µs ± 1%  -98.18%  (p=0.000 n=9+9)
Analysis/push32/evmzero-4     101µs ±28%     3µs ± 2%  -97.03%  (p=0.000 n=10+10)
```