### PR TITLE
Add caching of padded code

### DIFF
--- a/cpp/vm/evmzero/interpreter.h
+++ b/cpp/vm/evmzero/interpreter.h
@@ -36,7 +36,7 @@ const char* ToString(RunState);
 std::ostream& operator<<(std::ostream&, RunState);
 
 struct InterpreterArgs {
-  std::span<const uint8_t> code;
+  std::span<const uint8_t> padded_code;
   std::span<const uint8_t> valid_jump_targets;
   const evmc_message* message = nullptr;
   const evmc_host_interface* host_interface = nullptr;
@@ -67,7 +67,7 @@ struct Context {
   int64_t gas = kMaxGas;
   int64_t gas_refunds = 0;
 
-  std::vector<uint8_t> code;
+  std::span<const uint8_t> padded_code;
   std::vector<uint8_t> return_data;
   std::span<const uint8_t> valid_jump_targets;
 
@@ -102,6 +102,11 @@ struct Context {
 
   MemoryExpansionCostResult MemoryExpansionCost(uint256_t offset, uint256_t size) noexcept;
 };
+
+// Pads the given code with extra STOP/zero bytes to make sure that no operations are exceeding
+// the end-of-code boundaries when being executed. By padding the code before executing it,
+// bound checks during the execution can be avoided.
+std::vector<uint8_t> PadCode(std::span<const uint8_t> code);
 
 template <bool LoggingEnabled>
 extern void RunInterpreter(Context&);

--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -72,11 +72,12 @@ struct InterpreterTestDescription {
 void RunInterpreterTest(const InterpreterTestDescription& desc) {
   auto valid_jump_targets = op::CalculateValidJumpTargets(desc.code);
 
+  auto padded_code = internal::PadCode(desc.code);
   internal::Context ctx{
       .is_static_call = desc.is_static_call,
       .gas = desc.gas_before,
       .gas_refunds = desc.gas_refund_before,
-      .code = desc.code,
+      .padded_code = padded_code,
       .return_data = desc.last_call_data,
       .valid_jump_targets = valid_jump_targets,
       .memory = desc.memory_before,


### PR DESCRIPTION
Caching the padded code eliminates the last O(N) operation from running codes (N ... length of contract).

Especially for short contract execution, this is beneficial (up to -1/3):
```
name                         old time/op  new time/op  delta
Inc/1/evmzero-4              3.17µs ± 2%  3.18µs ± 3%     ~     (p=0.805 n=7+7)
Inc/10/evmzero-4             3.20µs ± 3%  3.12µs ± 3%   -2.46%  (p=0.026 n=7+7)
Fib/1/evmzero-4              2.95µs ± 1%  2.93µs ± 4%     ~     (p=0.274 n=7+7)
Fib/5/evmzero-4              10.2µs ± 9%  10.5µs ± 9%     ~     (p=0.383 n=7+7)
Fib/10/evmzero-4             89.2µs ± 6%  90.8µs ± 7%     ~     (p=0.318 n=7+7)
Fib/15/evmzero-4              961µs ± 5%   944µs ± 5%     ~     (p=0.209 n=7+7)
Fib/20/evmzero-4             10.6ms ± 9%   9.9ms ± 4%   -6.05%  (p=0.011 n=7+7)
Sha3/1/evmzero-4             2.58µs ± 5%  2.39µs ± 1%   -7.26%  (p=0.001 n=7+7)
Sha3/10/evmzero-4            4.78µs ± 8%  4.48µs ± 3%   -6.13%  (p=0.002 n=7+7)
Sha3/100/evmzero-4           25.9µs ± 3%  24.5µs ± 3%   -5.45%  (p=0.002 n=6+6)
Sha3/1000/evmzero-4           256µs ± 5%   249µs ± 6%     ~     (p=0.383 n=7+7)
Arith/1/evmzero-4            3.54µs ± 6%  3.35µs ± 1%   -5.23%  (p=0.003 n=7+5)
Arith/10/evmzero-4           7.07µs ± 4%  7.35µs ±12%     ~     (p=0.295 n=6+7)
Arith/100/evmzero-4          40.7µs ± 3%  39.5µs ± 8%     ~     (p=0.073 n=7+6)
Arith/280/evmzero-4           111µs ± 7%   119µs ±17%     ~     (p=0.805 n=7+7)
Memory/1/evmzero-4           4.63µs ± 3%  4.27µs ± 2%   -7.72%  (p=0.003 n=7+5)
Memory/10/evmzero-4          9.22µs ± 7%  8.44µs ± 5%   -8.54%  (p=0.007 n=7+7)
Memory/100/evmzero-4         50.6µs ± 8%  46.8µs ± 5%   -7.48%  (p=0.004 n=7+7)
Memory/1000/evmzero-4         466µs ± 6%   447µs ± 4%     ~     (p=0.073 n=7+6)
Memory/10000/evmzero-4       4.23ms ± 2%  4.14ms ± 3%   -2.05%  (p=0.035 n=6+7)
Analysis/jumpdest/evmzero-4  3.10µs ± 2%  2.12µs ± 2%  -31.44%  (p=0.001 n=6+7)
Analysis/stop/evmzero-4      3.08µs ± 5%  2.11µs ± 2%  -31.66%  (p=0.001 n=7+7)
Analysis/push1/evmzero-4     3.02µs ± 2%  2.11µs ± 2%  -30.27%  (p=0.001 n=7+7)
Analysis/push32/evmzero-4    3.14µs ± 4%  2.15µs ± 7%  -31.34%  (p=0.001 n=7+7)
```
