### PR TITLE
Avoid initializing stack data during stack creation

### DIFF
--- a/cpp/vm/evmzero/stack.h
+++ b/cpp/vm/evmzero/stack.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <initializer_list>
 #include <memory>
@@ -61,7 +62,20 @@ class Stack {
 
  private:
   static constexpr size_t kStackSize = 1024;
-  using Data = std::array<uint256_t, kStackSize>;
+
+  // The type retaining the actual storage for the stack.
+  class Data {
+   public:
+    Data() {}  // needed to avoid zero-initialization of data_ and use default-initialization instead (see t.ly/MkD0M).
+    uint256_t* end() { return reinterpret_cast<uint256_t*>(data_.end()); }
+    size_t size() { return kStackSize; }
+
+   private:
+    // An aligned blob of not auto-initialized data. Stack memory does not have
+    // to be initialized, since any read is preceeded by a push or dup.
+    alignas(sizeof(uint256_t)) std::array<std::byte, kStackSize * sizeof(uint256_t)> data_;
+  };
+
   std::unique_ptr<Data> stack_;
   uint256_t* top_ = nullptr;
   uint256_t* const end_ = nullptr;


### PR DESCRIPTION
This PR eliminates the initialization of the stack memory (1024*32byte = 32KB) triggered during each contract invocation. For short-running codes, this start-up overhead can be significant (up to ~1/3).

Since any value read from the stack needs to be pushed there first, skipping the initialization is safe.

```
name                         old time/op  new time/op   delta
Inc/1/evmzero-4              3.18µs ± 3%   2.45µs ± 2%  -22.83%  (p=0.001 n=7+6)
Inc/10/evmzero-4             3.12µs ± 3%   2.51µs ± 3%  -19.44%  (p=0.001 n=7+7)
Fib/1/evmzero-4              2.93µs ± 4%   2.24µs ± 2%  -23.49%  (p=0.001 n=7+7)
Fib/5/evmzero-4              10.5µs ± 9%    9.7µs ± 6%   -7.54%  (p=0.011 n=7+7)
Fib/10/evmzero-4             90.8µs ± 7%   89.1µs ± 8%     ~     (p=0.456 n=7+7)
Fib/15/evmzero-4              944µs ± 5%    965µs ± 4%     ~     (p=0.383 n=7+7)
Fib/20/evmzero-4             9.93ms ± 4%  10.15ms ± 0%   +2.26%  (p=0.048 n=7+5)
Sha3/1/evmzero-4             2.39µs ± 1%   1.71µs ± 2%  -28.59%  (p=0.001 n=7+7)
Sha3/10/evmzero-4            4.48µs ± 3%   3.76µs ± 2%  -16.01%  (p=0.001 n=7+7)
Sha3/100/evmzero-4           24.5µs ± 3%   23.8µs ± 5%     ~     (p=0.101 n=6+7)
Sha3/1000/evmzero-4           249µs ± 6%    255µs ± 5%     ~     (p=0.383 n=7+7)
Arith/1/evmzero-4            3.35µs ± 1%   2.78µs ± 2%  -17.19%  (p=0.004 n=5+6)
Arith/10/evmzero-4           7.35µs ±12%   6.31µs ± 5%  -14.26%  (p=0.002 n=7+7)
Arith/100/evmzero-4          39.5µs ± 8%   39.6µs ± 4%     ~     (p=0.731 n=6+7)
Arith/280/evmzero-4           119µs ±17%    108µs ± 4%     ~     (p=0.456 n=7+7)
Memory/1/evmzero-4           4.27µs ± 2%   3.78µs ± 5%  -11.53%  (p=0.003 n=5+7)
Memory/10/evmzero-4          8.44µs ± 5%   8.06µs ± 7%   -4.50%  (p=0.017 n=7+7)
Memory/100/evmzero-4         46.8µs ± 5%   47.7µs ± 8%     ~     (p=0.620 n=7+7)
Memory/1000/evmzero-4         447µs ± 4%    446µs ± 1%     ~     (p=0.792 n=6+5)
Memory/10000/evmzero-4       4.14ms ± 3%   4.18ms ± 2%     ~     (p=0.456 n=7+7)
Analysis/jumpdest/evmzero-4  2.12µs ± 2%   1.48µs ± 3%  -30.33%  (p=0.001 n=7+6)
Analysis/stop/evmzero-4      2.11µs ± 2%   1.47µs ± 1%  -30.11%  (p=0.001 n=7+7)
Analysis/push1/evmzero-4     2.11µs ± 2%   1.47µs ± 2%  -30.10%  (p=0.001 n=7+7)
Analysis/push32/evmzero-4    2.15µs ± 7%   1.48µs ± 2%  -31.51%  (p=0.001 n=7+7)
```