### PR TITLE
Add re-use list for stack data instances

### DIFF
--- a/cpp/vm/evmzero/stack.cc
+++ b/cpp/vm/evmzero/stack.cc
@@ -4,26 +4,32 @@
 
 namespace tosca::evmzero {
 
-Stack::Stack() : stack_(std::make_unique<Data>()), top_(stack_->end()), end_(top_) {}
+Stack::Stack() : data_(Data::Get()), top_(data_->end()), end_(top_) {}
 
 Stack::Stack(std::initializer_list<uint256_t> elements) : Stack() {
-  TOSCA_ASSERT(elements.size() <= stack_->size());
+  TOSCA_ASSERT(elements.size() <= data_->size());
   for (auto cur : elements) {
     Push(cur);
   }
 }
 
 Stack::Stack(const Stack& other) : Stack() {
-  *stack_ = *other.stack_;
-  top_ = stack_->end() - other.GetSize();
+  *data_ = *other.data_;
+  top_ = data_->end() - other.GetSize();
+}
+
+Stack::~Stack() {
+  if (data_) {
+    data_->Release();
+  }
 }
 
 Stack& Stack::operator=(const Stack& other) {
   if (this == &other) {
     return *this;
   }
-  *stack_ = *other.stack_;
-  top_ = stack_->end() - other.GetSize();
+  *data_ = *other.data_;
+  top_ = data_->end() - other.GetSize();
   return *this;
 }
 
@@ -40,6 +46,32 @@ std::ostream& operator<<(std::ostream& out, const Stack& stack) {
     out << stack[i];
   }
   return out << " ]B";
+}
+
+// kFreeList is the head of a lock-free synchronized linked list of Data instances that
+// are free to be reused by arbitrary threads. The list size is limited to the maximum
+// number simultaneously used stack instances and once allocated stacks are never released.
+std::atomic<Stack::Data*> Stack::Data::freeList = nullptr;
+
+Stack::Data* Stack::Data::Get() {
+  Data* res = freeList.load(std::memory_order_relaxed);
+  for (;;) {
+    if (res == nullptr) {
+      return new Data();
+    }
+    // Try to retrieve the instance by updating the head pointer. If successful,
+    // the instance can be used by this thread. If not, res is updated to the new
+    // head of the list.
+    if (freeList.compare_exchange_weak(res, res->next_)) {
+      return res;
+    }
+  }
+}
+
+void Stack::Data::Release() {
+  // On the first call next_ is updated, and on subsequent calls the head is replaced.
+  while (!freeList.compare_exchange_weak(next_, this, std::memory_order_relaxed, std::memory_order_relaxed)) {
+  }
 }
 
 }  // namespace tosca::evmzero

--- a/cpp/vm/evmzero/stack.h
+++ b/cpp/vm/evmzero/stack.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <initializer_list>
-#include <memory>
 #include <ostream>
 #include <vector>
 
@@ -19,6 +19,7 @@ class Stack {
   Stack(const Stack&);
   Stack(Stack&&) = delete;
   Stack(std::initializer_list<uint256_t>);
+  ~Stack();
 
   uint64_t GetSize() const { return uint64_t(end_ - top_); }
   uint64_t GetMaxSize() const { return kStackSize; }
@@ -67,16 +68,28 @@ class Stack {
   class Data {
    public:
     Data() {}  // needed to avoid zero-initialization of data_ and use default-initialization instead (see t.ly/MkD0M).
+
+    // Retrieves an instance from a global re-use list.
+    static Data* Get();
+
+    // Releases this instance to be re-used by another stack.
+    void Release();
+
     uint256_t* end() { return reinterpret_cast<uint256_t*>(data_.end()); }
     size_t size() { return kStackSize; }
 
    private:
+    static std::atomic<Data*> freeList;
+
     // An aligned blob of not auto-initialized data. Stack memory does not have
     // to be initialized, since any read is preceeded by a push or dup.
     alignas(sizeof(uint256_t)) std::array<std::byte, kStackSize * sizeof(uint256_t)> data_;
+
+    // A next-pointer to be used when enqueuing instances in the free list.
+    Data* next_ = nullptr;
   };
 
-  std::unique_ptr<Data> stack_;
+  Data* const data_ = nullptr;
   uint256_t* top_ = nullptr;
   uint256_t* const end_ = nullptr;
 };

--- a/cpp/vm/evmzero/stack_test.cc
+++ b/cpp/vm/evmzero/stack_test.cc
@@ -1,9 +1,17 @@
 #include "vm/evmzero/stack.h"
 
 #include <gtest/gtest.h>
+#include <type_traits>
 
 namespace tosca::evmzero {
 namespace {
+
+TEST(StackTest, Traits) {
+  EXPECT_TRUE(std::is_copy_constructible_v<Stack>);
+  EXPECT_FALSE(std::is_move_constructible_v<Stack>);
+  EXPECT_TRUE(std::is_copy_assignable_v<Stack>);
+  EXPECT_FALSE(std::is_move_assignable_v<Stack>);
+}
 
 TEST(StackTest, Empty) {
   Stack stack;


### PR DESCRIPTION
Adds a re-use list for stack instances instead of re-allocating it.

The impact seems reasonably high for low-runtime benchmarks. However, I am not sure whether we should use thread locals or other forms of reuse lists.

```
name                         old time/op  new time/op  delta
Inc/1/evmzero-4              2.51µs ± 6%  2.36µs ± 5%   -5.98%  (p=0.000 n=25+25)
Inc/10/evmzero-4             2.51µs ± 7%  2.38µs ± 6%   -5.46%  (p=0.000 n=25+25)
Fib/1/evmzero-4              2.35µs ± 6%  2.18µs ± 5%   -7.47%  (p=0.000 n=24+25)
Fib/5/evmzero-4              9.88µs ± 7%  9.73µs ± 9%     ~     (p=0.369 n=25+24)
Fib/10/evmzero-4             93.4µs ±15%  96.9µs ±10%   +3.77%  (p=0.019 n=25+25)
Fib/15/evmzero-4             1.01ms ± 8%  1.00ms ± 6%     ~     (p=0.486 n=25+23)
Fib/20/evmzero-4             10.7ms ±12%  10.3ms ± 5%   -4.23%  (p=0.006 n=25+25)
Sha3/1/evmzero-4             1.78µs ± 6%  1.62µs ± 7%   -9.27%  (p=0.000 n=25+25)
Sha3/10/evmzero-4            3.99µs ± 8%  3.77µs ± 7%   -5.66%  (p=0.000 n=25+25)
Sha3/100/evmzero-4           24.6µs ± 6%  24.7µs ± 9%     ~     (p=0.725 n=25+25)
Sha3/1000/evmzero-4           255µs ± 9%   254µs ± 6%     ~     (p=0.788 n=25+25)
Arith/1/evmzero-4            2.80µs ± 6%  2.64µs ± 5%   -5.90%  (p=0.000 n=24+25)
Arith/10/evmzero-4           6.48µs ± 7%  6.16µs ± 9%   -4.84%  (p=0.000 n=24+25)
Arith/100/evmzero-4          41.2µs ±10%  40.1µs ± 6%   -2.65%  (p=0.032 n=25+24)
Arith/280/evmzero-4           112µs ±11%   109µs ± 8%     ~     (p=0.077 n=25+25)
Memory/1/evmzero-4           3.88µs ± 8%  3.61µs ± 7%   -6.87%  (p=0.000 n=24+25)
Memory/10/evmzero-4          8.20µs ± 8%  7.92µs ± 8%   -3.43%  (p=0.018 n=25+25)
Memory/100/evmzero-4         48.2µs ± 9%  48.1µs ± 9%     ~     (p=0.893 n=25+25)
Memory/1000/evmzero-4         474µs ± 9%   468µs ± 9%     ~     (p=0.714 n=24+25)
Memory/10000/evmzero-4       4.29ms ± 8%  4.32ms ± 5%     ~     (p=0.216 n=25+25)
Analysis/jumpdest/evmzero-4  1.52µs ± 4%  1.36µs ± 7%  -10.37%  (p=0.000 n=25+25)
Analysis/stop/evmzero-4      1.51µs ± 6%  1.36µs ± 6%  -10.05%  (p=0.000 n=23+25)
Analysis/push1/evmzero-4     1.53µs ±10%  1.34µs ± 5%  -12.67%  (p=0.000 n=25+25)
Analysis/push32/evmzero-4    1.51µs ± 5%  1.34µs ± 5%  -10.99%  (p=0.000 n=24+24)
```