### PR TITLE
Revert "Add re-use list for stack data instances"

### DIFF
--- a/cpp/vm/evmzero/stack.cc
+++ b/cpp/vm/evmzero/stack.cc
@@ -4,32 +4,26 @@
 
 namespace tosca::evmzero {
 
-Stack::Stack() : data_(Data::Get()), top_(data_->end()), end_(top_) {}
+Stack::Stack() : stack_(std::make_unique<Data>()), top_(stack_->end()), end_(top_) {}
 
 Stack::Stack(std::initializer_list<uint256_t> elements) : Stack() {
-  TOSCA_ASSERT(elements.size() <= data_->size());
+  TOSCA_ASSERT(elements.size() <= stack_->size());
   for (auto cur : elements) {
     Push(cur);
   }
 }
 
 Stack::Stack(const Stack& other) : Stack() {
-  *data_ = *other.data_;
-  top_ = data_->end() - other.GetSize();
-}
-
-Stack::~Stack() {
-  if (data_) {
-    data_->Release();
-  }
+  *stack_ = *other.stack_;
+  top_ = stack_->end() - other.GetSize();
 }
 
 Stack& Stack::operator=(const Stack& other) {
   if (this == &other) {
     return *this;
   }
-  *data_ = *other.data_;
-  top_ = data_->end() - other.GetSize();
+  *stack_ = *other.stack_;
+  top_ = stack_->end() - other.GetSize();
   return *this;
 }
 
@@ -46,32 +40,6 @@ std::ostream& operator<<(std::ostream& out, const Stack& stack) {
     out << stack[i];
   }
   return out << " ]B";
-}
-
-// kFreeList is the head of a lock-free synchronized linked list of Data instances that
-// are free to be reused by arbitrary threads. The list size is limited to the maximum
-// number simultaneously used stack instances and once allocated stacks are never released.
-std::atomic<Stack::Data*> Stack::Data::freeList = nullptr;
-
-Stack::Data* Stack::Data::Get() {
-  Data* res = freeList.load(std::memory_order_relaxed);
-  for (;;) {
-    if (res == nullptr) {
-      return new Data();
-    }
-    // Try to retrieve the instance by updating the head pointer. If successful,
-    // the instance can be used by this thread. If not, res is updated to the new
-    // head of the list.
-    if (freeList.compare_exchange_weak(res, res->next_)) {
-      return res;
-    }
-  }
-}
-
-void Stack::Data::Release() {
-  // On the first call next_ is updated, and on subsequent calls the head is replaced.
-  while (!freeList.compare_exchange_weak(next_, this, std::memory_order_relaxed, std::memory_order_relaxed)) {
-  }
 }
 
 }  // namespace tosca::evmzero

--- a/cpp/vm/evmzero/stack_test.cc
+++ b/cpp/vm/evmzero/stack_test.cc
@@ -1,17 +1,9 @@
 #include "vm/evmzero/stack.h"
 
 #include <gtest/gtest.h>
-#include <type_traits>
 
 namespace tosca::evmzero {
 namespace {
-
-TEST(StackTest, Traits) {
-  EXPECT_TRUE(std::is_copy_constructible_v<Stack>);
-  EXPECT_FALSE(std::is_move_constructible_v<Stack>);
-  EXPECT_TRUE(std::is_copy_assignable_v<Stack>);
-  EXPECT_FALSE(std::is_move_assignable_v<Stack>);
-}
 
 TEST(StackTest, Empty) {
   Stack stack;


### PR DESCRIPTION
This reverts commit bc16fd7ae450b47d7b28fecfcc8e67dc23761b10 to fix the nightly integration tests.