### PR TITLE
Replace lock-free reuse list with mutex based reuse list

### DIFF
--- a/cpp/vm/evmzero/stack.h
+++ b/cpp/vm/evmzero/stack.h
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <cstdint>
 #include <initializer_list>
+#include <mutex>
 #include <ostream>
 #include <vector>
 
@@ -79,7 +80,8 @@ class Stack {
     size_t size() { return kStackSize; }
 
    private:
-    static std::atomic<Data*> freeList;
+    static Data* free_list;
+    static std::mutex free_list_mutex;
 
     // An aligned blob of not auto-initialized data. Stack memory does not have
     // to be initialized, since any read is preceeded by a push or dup.


### PR DESCRIPTION
Replaces the faulty lock-free implementation with a lock-based implementation.

Performance compared to non-reuse version:
```
name                          old time/op  new time/op  delta
Inc/1/evmzero-12              2.76µs ±11%  2.80µs ± 3%    ~     (p=0.859 n=10+9)
Inc/10/evmzero-12             2.86µs ± 3%  2.73µs ± 8%  -4.45%  (p=0.003 n=10+10)
Fib/1/evmzero-12              2.66µs ± 6%  2.52µs ±10%  -5.18%  (p=0.027 n=10+10)
Fib/5/evmzero-12              9.13µs ± 6%  8.86µs ± 7%    ~     (p=0.143 n=10+10)
Fib/10/evmzero-12             83.2µs ± 7%  83.1µs ± 4%    ~     (p=0.739 n=10+10)
Fib/15/evmzero-12              900µs ±10%   879µs ± 6%    ~     (p=0.315 n=10+10)
Fib/20/evmzero-12             10.0ms ± 5%   9.7ms ± 4%  -2.55%  (p=0.034 n=10+8)
Sha3/1/evmzero-12             2.16µs ±10%  2.04µs ± 4%    ~     (p=0.052 n=10+10)
Sha3/10/evmzero-12            4.22µs ± 7%  3.99µs ± 6%  -5.47%  (p=0.010 n=9+10)
Sha3/100/evmzero-12           24.4µs ± 2%  24.4µs ± 3%    ~     (p=0.853 n=10+10)
Sha3/1000/evmzero-12           241µs ± 6%   244µs ± 6%    ~     (p=0.497 n=10+9)
Arith/1/evmzero-12            3.13µs ± 8%  3.04µs ± 5%    ~     (p=0.182 n=10+9)
Arith/10/evmzero-12           6.27µs ±10%  6.00µs ± 6%    ~     (p=0.075 n=10+10)
Arith/100/evmzero-12          37.4µs ± 8%  37.9µs ± 1%    ~     (p=0.408 n=10+8)
Arith/280/evmzero-12           103µs ± 7%   105µs ± 5%    ~     (p=0.315 n=9+10)
Memory/1/evmzero-12           4.09µs ± 7%  3.86µs ± 2%  -5.47%  (p=0.002 n=10+9)
Memory/10/evmzero-12          7.78µs ± 9%  7.82µs ± 3%    ~     (p=0.905 n=10+9)
Memory/100/evmzero-12         47.7µs ± 4%  47.4µs ± 3%    ~     (p=0.277 n=9+8)
Memory/1000/evmzero-12         452µs ± 7%   448µs ± 2%    ~     (p=0.315 n=10+8)
Memory/10000/evmzero-12       4.48ms ± 6%  4.36ms ± 6%    ~     (p=0.075 n=10+10)
Analysis/jumpdest/evmzero-12  1.89µs ± 3%  1.77µs ± 8%  -6.40%  (p=0.002 n=9+10)
Analysis/stop/evmzero-12      1.88µs ± 5%  1.72µs ± 9%  -8.60%  (p=0.000 n=10+10)
Analysis/push1/evmzero-12     1.88µs ± 7%  1.71µs ± 5%  -8.96%  (p=0.000 n=10+10)
Analysis/push32/evmzero-12    1.85µs ± 4%  1.76µs ± 7%  -4.72%  (p=0.009 n=9+10)
```