### PR TITLE
evmzero: Fix mimalloc integration by providing missing delete functions

### DIFF
--- a/cpp/vm/evmzero/allocator.cc
+++ b/cpp/vm/evmzero/allocator.cc
@@ -56,7 +56,21 @@ void operator delete(void* ptr, std::align_val_t al) noexcept { mi_free_aligned(
 
 void operator delete[](void* ptr, std::align_val_t al) noexcept { mi_free_aligned(ptr, static_cast<size_t>(al)); }
 
+void operator delete(void* ptr, size_t) noexcept { mi_free(ptr); }
+
+void operator delete[](void* ptr, size_t) noexcept { mi_free(ptr); }
+
+void operator delete(void* ptr, size_t, std::align_val_t al) noexcept { mi_free_aligned(ptr, static_cast<size_t>(al)); }
+
+void operator delete[](void* ptr, size_t, std::align_val_t al) noexcept {
+  mi_free_aligned(ptr, static_cast<size_t>(al));
+}
+
 // replaceable placement deallocation functions
+
+void operator delete(void* ptr, const std::nothrow_t&) noexcept { mi_free(ptr); }
+
+void operator delete[](void* ptr, const std::nothrow_t&) noexcept { mi_free(ptr); }
 
 void operator delete(void* ptr, std::align_val_t al, const std::nothrow_t&) noexcept {
   mi_free_aligned(ptr, static_cast<size_t>(al));


### PR DESCRIPTION
When using gcc the recently introduced mimalloc integration causes a compilation warning:

```
/.../tosca/cpp/vm/evmzero/allocator.cc:51:6: warning: the program should also define ‘void operator delete(void*, std::size_t)’ [-Wsized-deallocation]
   51 | void operator delete(void* ptr) noexcept { mi_free(ptr); }
```

and also crashes at runtime with:

```
munmap_chunk(): invalid pointer
SIGABRT: abort
```

This happens because the wrong `delete` function is being called.

This PR extends the mimalloc integration by implementing all `delete` functions so that there cannot be an implementation mismatch between which `new`/`delete` pair is being used.

This PR solves issue #138.

Note: I also tried to implement unit tests to cover this error case, but the compiler is very smart when generating code within the same translation unit. The compiler will choose not to use a user-defined `new` implementation when the corresponding `delete` would call the standard `delete` implementation and thus cause a mismatch. I did not manage to trick the compiler into generating a mismatched `new`/`delete` pair and so could not implement unit tests for this.