### PR TITLE
Align profiling data export mechanism for various Tosca VMs

### DIFF
--- a/go/common/evmc_bridge.go
+++ b/go/common/evmc_bridge.go
@@ -51,6 +51,11 @@ func (e *EvmcVM) Destroy() {
 	e.vm = nil
 }
 
+// GetEvmcVM provides direct access to the VM connected through the EVMC library.
+func (e *EvmcVM) GetEvmcVM() *evmc.VM {
+	return e.vm
+}
+
 // NewEvmcInterpreter instantiates an interpreter with the given evm and config.
 func NewEvmcInterpreter(vm *EvmcVM, evm *vm.EVM, cfg vm.Config) *EvmcInterpreter {
 	return &EvmcInterpreter{
@@ -184,11 +189,6 @@ func (e *EvmcInterpreter) Run(contract *vm.Contract, input []byte, readOnly bool
 	}
 
 	return result.Output, err
-}
-
-// GetEvmcVM provides direct access to the VM connected through the EVMC library.
-func (e *EvmcInterpreter) GetEvmcVM() *evmc.VM {
-	return e.evmc.vm
 }
 
 // The HostContext allows a non-Go EVM implementation to access the StateDB and

--- a/go/vm/evmone/evmone.go
+++ b/go/vm/evmone/evmone.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/Fantom-foundation/Tosca/go/common"
+	"github.com/Fantom-foundation/Tosca/go/vm/registry"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
@@ -51,10 +52,10 @@ func NewAdvancedInterpreter(evm *vm.EVM, cfg vm.Config) vm.EVMInterpreter {
 }
 
 func init() {
-	vm.RegisterInterpreterFactory("evmone-basic", NewBasicInterpreter)
-	vm.RegisterInterpreterFactory("evmone-advanced", NewAdvancedInterpreter)
+	registry.RegisterInterpreterFactory("evmone-basic", NewBasicInterpreter)
+	registry.RegisterInterpreterFactory("evmone-advanced", NewAdvancedInterpreter)
 
 	// We use the basic version as the default since it showed better performance in
 	// benchmarks (to verify on your system, run benchmarks in go/vm/vm_test.go).
-	vm.RegisterInterpreterFactory("evmone", NewBasicInterpreter)
+	registry.RegisterInterpreterFactory("evmone", NewBasicInterpreter)
 }

--- a/go/vm/evmzero/evmzero_test.go
+++ b/go/vm/evmzero/evmzero_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Fantom-foundation/Tosca/go/examples"
+	"github.com/Fantom-foundation/Tosca/go/vm/registry"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
 
@@ -31,12 +32,16 @@ func TestFib10(t *testing.T) {
 
 func TestEvmzero_DumpProfile(t *testing.T) {
 	example := examples.GetFibExample()
+	vmInstance, ok := registry.GetVirtualMachine("evmzero-profiling").(registry.ProfilingVM)
+	if !ok || vmInstance == nil {
+		t.Fatalf("profiling evmzero configuration does not support profiling")
+	}
 	interpreter := vm.NewInterpreter("evmzero-profiling", &vm.EVM{}, vm.Config{})
 	for i := 0; i < 10; i++ {
 		example.RunOn(interpreter, 10)
-		DumpProfile(interpreter)
+		vmInstance.DumpProfile()
 		if i == 5 {
-			ResetProfiler(interpreter)
+			vmInstance.ResetProfile()
 		}
 	}
 }

--- a/go/vm/lfvm/interpreter.go
+++ b/go/vm/lfvm/interpreter.go
@@ -373,10 +373,16 @@ func (s *stats_collector) NextOp(op OpCode) {
 var global_stats_mu = sync.Mutex{}
 var global_statistics = newStatistics()
 
-func PrintCollectedInstructionStatistics() {
+func printCollectedInstructionStatistics() {
 	global_stats_mu.Lock()
 	defer global_stats_mu.Unlock()
 	global_statistics.Print()
+}
+
+func resetCollectedInstructionStatistics() {
+	global_stats_mu.Lock()
+	defer global_stats_mu.Unlock()
+	global_statistics = newStatistics()
 }
 
 func runWithStatistics(c *context) {

--- a/go/vm/registry/registry.go
+++ b/go/vm/registry/registry.go
@@ -1,0 +1,73 @@
+package registry
+
+import (
+	"fmt"
+	"strings"
+
+	geth "github.com/ethereum/go-ethereum/core/vm"
+)
+
+// This package provides a registry for VM instances. Ideally this registry would
+// be placed into the go-opera repository (replacing the current VM-implementation
+// registry), however, to limit the impact of Tosca on go-opera it is defined here.
+//
+// The registry is intended to be used only by Tosca-internal code. The public
+// interface forwarding calls to this package is found in the vm package of the
+// parent directory. Please only refer to this when importing Tosca into your
+// project.
+
+// vm_registry is a global registry for VM instances of different implementations
+// and configurations.
+var vm_registry = map[string]VirtualMachine{}
+
+// RegisterVirtualMachine can be used to register a new VirtualMachine instance to
+// be exported for general use in the binary. The name is not case-sensitive, and
+// a panic is triggered if a VM was bound to the same name before, or the VM is nil.
+// This function is mainly intented to be used by package initialization code.
+func RegisterVirtualMachine(name string, vm VirtualMachine) {
+	key := strings.ToLower(name)
+	if vm == nil {
+		panic(fmt.Sprintf("invalid initialization: cannot register nil-VM using `%s`", key))
+	}
+	if _, found := vm_registry[key]; found {
+		panic(fmt.Sprintf("invalid initialization: multiple VMs registered for `%s`", key))
+	}
+	vm_registry[key] = vm
+	geth.RegisterInterpreterFactory(name, func(evm *geth.EVM, cfg geth.Config) geth.EVMInterpreter {
+		return vm.NewInterpreter(evm, cfg)
+	})
+}
+
+// RegisterInterpreterFactory is a convenience function for the registration call
+// above for cases where a VM implementation offers nothing more than means to create
+// interpreter instances.
+func RegisterInterpreterFactory(name string, factory geth.InterpreterFactory) {
+	RegisterVirtualMachine(name, &simpleVm{factory})
+}
+
+// GetVirtualMachine performs a lookup for the given name (case-insensitive) in the
+// VM registry. The result is nil if no VM was registered under the given name.
+func GetVirtualMachine(name string) VirtualMachine {
+	return vm_registry[strings.ToLower(name)]
+}
+
+type simpleVm struct {
+	factory geth.InterpreterFactory
+}
+
+func (e *simpleVm) NewInterpreter(evm *geth.EVM, cfg geth.Config) geth.EVMInterpreter {
+	return e.factory(evm, cfg)
+}
+
+// VirtualMachine is a copy of the vm.VirtualMachine interface to break
+// cyclic dependencies.
+type VirtualMachine interface {
+	NewInterpreter(evm *geth.EVM, cfg geth.Config) geth.EVMInterpreter
+}
+
+// ProfilingVM is a copy of the vm.ProfilingVM interface to break
+// cyclic dependencies.
+type ProfilingVM interface {
+	ResetProfile()
+	DumpProfile()
+}

--- a/go/vm/test/vm_test.go
+++ b/go/vm/test/vm_test.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"strings"
 	"testing"
 
 	"github.com/Fantom-foundation/Tosca/go/examples"
-	"github.com/Fantom-foundation/Tosca/go/vm/evmzero"
+	tosca "github.com/Fantom-foundation/Tosca/go/vm"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -166,8 +165,9 @@ func benchmark(b *testing.B, example examples.Example, arg int) {
 
 	for _, variant := range Variants {
 		evm := GetCleanEVM(London, variant, nil)
-		if strings.HasSuffix(variant, "-profiling") {
-			evmzero.ResetProfiler(evm.GetInterpreter())
+		vm := tosca.GetVirtualMachine(variant)
+		if pvm, ok := vm.(tosca.ProfilingVM); ok {
+			pvm.ResetProfile()
 		}
 		b.Run(variant, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
@@ -181,8 +181,8 @@ func benchmark(b *testing.B, example examples.Example, arg int) {
 				}
 			}
 		})
-		if strings.HasSuffix(variant, "-profiling") {
-			evmzero.DumpProfile(evm.GetInterpreter())
+		if pvm, ok := vm.(tosca.ProfilingVM); ok {
+			pvm.DumpProfile()
 		}
 	}
 }

--- a/go/vm/vm.go
+++ b/go/vm/vm.go
@@ -6,7 +6,41 @@ package vm
 // external use.
 
 import (
+	// EVM implementations offered externaly.
 	_ "github.com/Fantom-foundation/Tosca/go/vm/evmone"
 	_ "github.com/Fantom-foundation/Tosca/go/vm/evmzero"
 	_ "github.com/Fantom-foundation/Tosca/go/vm/lfvm"
+
+	// Implementation of registry support
+	"github.com/Fantom-foundation/Tosca/go/vm/registry"
+	geth "github.com/ethereum/go-ethereum/core/vm"
 )
+
+// VirtualMachine (VM) represents an instance of an EVM-byte-code execution engine
+// loaded in memory. Each instance can host multiple interpreter instances, each
+// capable of running a single EVM contract invocation. Multiple interpreters may
+// exist at the same time, processing contracts in parallel. However, at any time
+// each interpreter instance may only process a single contract.
+type VirtualMachine interface {
+	// NewInterpreter creates a new interpreter instance based on this VM instance.
+	NewInterpreter(evm *geth.EVM, cfg geth.Config) geth.EVMInterpreter
+}
+
+// ProfilingVM is an optional extension to the VirtualMachine interface above which
+// may be implemented by VM implementations collecting statistical data regarding
+// their execution.
+type ProfilingVM interface {
+	// ResetProfile resets the operation statistic collected by the underlying VM implementation.
+	// Use this, for instance, at the beginning of a benchmark. It should not be called while
+	// running operations on the VM implementations in parallel.
+	ResetProfile()
+
+	// DumpProfile prints a snapshot of the profiling data collected since the last reset to stdout.
+	// In the future this interface will be changed to return the result instead of printing it.
+	DumpProfile()
+}
+
+// GetVirtualMachine provides access to all VM implementations loaded in the current binary.
+func GetVirtualMachine(name string) VirtualMachine {
+	return registry.GetVirtualMachine(name)
+}


### PR DESCRIPTION
With this change, VM instances supporting the collection of profiling data can be distinguished from VM instances not doing so by type, allowing applications like Aida to test for the availability of profiling information in a uniform, non-name-convention-based way.