### PR TITLE
Fix build after adding gperftools

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 project(tosca)
 
 option(TOSCA_ASAN "Enable AddressSanitizer for Tosca targets.")
@@ -19,8 +20,10 @@ add_subdirectory(${TOSCA_THIRD_PARTY_DIR}/mimalloc third_party/mimalloc EXCLUDE_
 set(BENCHMARK_ENABLE_TESTING OFF)
 add_subdirectory(${TOSCA_THIRD_PARTY_DIR}/google_benchmark third_party/google_benchmark EXCLUDE_FROM_ALL)
 
-set(BUILD_TESTING OFF)
-add_subdirectory(${TOSCA_THIRD_PARTY_DIR}/gperftools third_party/gperftools EXCLUDE_FROM_ALL)
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set(BUILD_TESTING OFF)
+  add_subdirectory(${TOSCA_THIRD_PARTY_DIR}/gperftools third_party/gperftools EXCLUDE_FROM_ALL)
+endif()
 
 function(tosca_add_compile_flags target)
   set_target_properties(${target} PROPERTIES

--- a/cpp/vm/evmzero/CMakeLists.txt
+++ b/cpp/vm/evmzero/CMakeLists.txt
@@ -48,5 +48,7 @@ foreach(evmzero_benchmark ${evmzero_benchmarks})
   target_link_libraries(${evmzero_benchmark_target} evmzero benchmark::benchmark benchmark::benchmark_main)
 
   # Always include the CPU profiler in benchmarks.
-  target_link_libraries(${evmzero_benchmark_target} -Wl,--no-as-needed profiler  -Wl,--as-needed)
+  if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    target_link_libraries(${evmzero_benchmark_target} -Wl,--no-as-needed profiler  -Wl,--as-needed)
+  endif()
 endforeach()


### PR DESCRIPTION
This PR ..
 - disable CPU profiler integration on OSX
 - suppresses the integration of tests from gperftools

The CPU profiler is an extra feature we do not need to support on OSX for now. 
Disabling it removes build dependencies and maintenance efforts.