### PR TITLE
evmzero: Print compiler version when dumping profile

### DIFF
--- a/cpp/common/macros.h
+++ b/cpp/common/macros.h
@@ -15,3 +15,17 @@
 #define TOSCA_CHECK_OVERFLOW_ADD(a, b, result) __builtin_add_overflow(a, b, result)
 
 #define TOSCA_FORCE_INLINE __attribute__((always_inline))
+
+#define TOSCA_STRINGIFY_(str) #str
+#define TOSCA_STRINGIFY(str) TOSCA_STRINGIFY_(str)
+
+#ifdef __clang__
+#define TOSCA_COMPILER "clang " __clang_version__
+#elif __GNUC__
+#define TOSCA_COMPILER \
+  "gcc " TOSCA_STRINGIFY(__GNUC__) "." TOSCA_STRINGIFY(__GNUC_MINOR__) "." TOSCA_STRINGIFY(__GNUC_PATCHLEVEL__)
+#elif _MSC_VER
+#define TOSCA_COMPILER "msvc " TOSCA_STRINGIFY(_MSC_VER)
+#else
+#define TOSCA_COMPILER "unknown"
+#endif

--- a/cpp/vm/evmzero/profiler.h
+++ b/cpp/vm/evmzero/profiler.h
@@ -102,6 +102,7 @@ class Profile {
 
     // profiling format: <marker>, <calls>, <total-time-ticks>, <total-time-nanoseconds>\n
     std::ostream& out = out_file.is_open() ? out_file : std::cout;
+    out << "compiler: " << TOSCA_COMPILER << "\n";
     out << "marker,calls,ticks,duration[ns]\n";
     for (std::size_t i = 0; i < kNumMarkers; ++i) {
       const auto marker = static_cast<Marker>(i);


### PR DESCRIPTION
This PR adds the compiler version as the first line when dumping the profile.

This makes the output invalid csv data, however, which bothers me a bit. But I couldn't come up with a better way of printing this information. I'm very much open to suggestions of a better way of printing this.