### PR TITLE
evmzero: Tweak CheckJumpDest

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -1624,12 +1624,17 @@ inline OpResult Invoke(uint256_t* top, const uint8_t*, int64_t gas, Context& ctx
 namespace internal {
 
 inline bool Context::CheckJumpDest(uint256_t index_u256) noexcept {
-  if (index_u256 >= valid_jump_targets.size()) [[unlikely]] {
+  if (index_u256[1] != 0 || index_u256[2] != 0 || index_u256[3] != 0) [[unlikely]] {
     state = RunState::kErrorJump;
     return false;
   }
 
   const uint64_t index = static_cast<uint64_t>(index_u256);
+
+  if (index >= valid_jump_targets.size()) [[unlikely]] {
+    state = RunState::kErrorJump;
+    return false;
+  }
 
   if (!valid_jump_targets[index]) [[unlikely]] {
     state = RunState::kErrorJump;


### PR DESCRIPTION
```
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
                             │ baseline.txt │     check-jump-dest-tweak.txt     │
                             │    sec/op    │   sec/op     vs base              │
Inc/1/evmzero-16                1.220µ ± 1%   1.216µ ± 1%       ~ (p=0.273 n=7)
Inc/10/evmzero-16               1.217µ ± 1%   1.222µ ± 1%       ~ (p=0.194 n=7)
Fib/1/evmzero-16                1.154µ ± 0%   1.148µ ± 1%       ~ (p=0.173 n=7)
Fib/5/evmzero-16                3.527µ ± 1%   3.486µ ± 1%  -1.16% (p=0.001 n=7)
Fib/10/evmzero-16               30.92µ ± 1%   30.47µ ± 0%  -1.45% (p=0.002 n=7)
Fib/15/evmzero-16               329.6µ ± 3%   331.1µ ± 1%       ~ (p=1.000 n=7)
Fib/20/evmzero-16               3.646m ± 2%   3.628m ± 0%       ~ (p=0.535 n=7)
Sha3/1/evmzero-16               919.5n ± 1%   914.9n ± 1%  -0.50% (p=0.026 n=7)
Sha3/10/evmzero-16              1.417µ ± 1%   1.410µ ± 1%  -0.49% (p=0.006 n=7)
Sha3/100/evmzero-16             6.360µ ± 1%   6.359µ ± 0%       ~ (p=0.874 n=7)
Sha3/1000/evmzero-16            56.16µ ± 1%   55.76µ ± 1%  -0.71% (p=0.038 n=7)
Arith/1/evmzero-16              1.331µ ± 0%   1.324µ ± 1%       ~ (p=0.053 n=7)
Arith/10/evmzero-16             2.693µ ± 1%   2.684µ ± 1%  -0.33% (p=0.003 n=7)
Arith/100/evmzero-16            16.30µ ± 0%   16.27µ ± 0%  -0.18% (p=0.007 n=7)
Arith/280/evmzero-16            44.46µ ± 0%   44.41µ ± 0%  -0.12% (p=0.038 n=7)
Memory/1/evmzero-16             1.651µ ± 1%   1.628µ ± 0%  -1.39% (p=0.001 n=7)
Memory/10/evmzero-16            3.077µ ± 1%   3.072µ ± 1%       ~ (p=0.302 n=7)
Memory/100/evmzero-16           16.98µ ± 1%   16.85µ ± 0%  -0.77% (p=0.001 n=7)
Memory/1000/evmzero-16          155.5µ ± 0%   155.0µ ± 0%       ~ (p=0.128 n=7)
Memory/10000/evmzero-16         1.542m ± 0%   1.534m ± 0%  -0.50% (p=0.001 n=7)
Analysis/jumpdest/evmzero-16    845.8n ± 2%   839.8n ± 1%       ~ (p=0.128 n=7)
Analysis/stop/evmzero-16        851.8n ± 1%   843.5n ± 1%       ~ (p=0.165 n=7)
Analysis/push1/evmzero-16       843.5n ± 1%   842.7n ± 1%       ~ (p=0.335 n=7)
Analysis/push32/evmzero-16      847.4n ± 1%   845.2n ± 1%       ~ (p=0.335 n=7)
geomean                         7.838µ        7.802µ       -0.47%
```