### PR TITLE
evmzero: Add information about build settings to profiler output

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.19)
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW) # option respects set variables
 project(tosca)
 

--- a/cpp/common/macros.h
+++ b/cpp/common/macros.h
@@ -18,14 +18,3 @@
 
 #define TOSCA_STRINGIFY_(str) #str
 #define TOSCA_STRINGIFY(str) TOSCA_STRINGIFY_(str)
-
-#ifdef __clang__
-#define TOSCA_COMPILER "clang " __clang_version__
-#elif __GNUC__
-#define TOSCA_COMPILER \
-  "gcc " TOSCA_STRINGIFY(__GNUC__) "." TOSCA_STRINGIFY(__GNUC_MINOR__) "." TOSCA_STRINGIFY(__GNUC_PATCHLEVEL__)
-#elif _MSC_VER
-#define TOSCA_COMPILER "msvc " TOSCA_STRINGIFY(_MSC_VER)
-#else
-#define TOSCA_COMPILER "unknown"
-#endif

--- a/cpp/vm/evmzero/CMakeLists.txt
+++ b/cpp/vm/evmzero/CMakeLists.txt
@@ -11,7 +11,19 @@ add_library(evmzero SHARED
   opcodes.cc
   stack.cc)
 tosca_add_compile_flags(evmzero)
-target_include_directories(evmzero SYSTEM PUBLIC ${TOSCA_THIRD_PARTY_DIR}/intx/include)
+
+get_target_property(EVMZERO_COMPILE_DEFINITIONS evmzero COMPILE_DEFINITIONS)
+get_target_property(EVMZERO_COMPILE_OPTIONS evmzero COMPILE_OPTIONS)
+# The target properties contain generator expressions which cannot be resolved through
+# configure_file. The workaround is to use file(GENERATE ... TARGET ...) to expand
+# the generator expressions.
+file(GENERATE OUTPUT target_properties.inc CONTENT
+"constexpr auto kCompileDefinitions = \"${EVMZERO_COMPILE_DEFINITIONS}\";
+constexpr auto kCompileOptions = \"${EVMZERO_COMPILE_OPTIONS}\";"
+  TARGET evmzero)
+configure_file(build_info.h.in build_info.h)
+
+target_include_directories(evmzero SYSTEM PUBLIC ${TOSCA_THIRD_PARTY_DIR}/intx/include ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(evmzero PUBLIC tosca_common ethash::keccak evmc::evmc)
 
 if(EVMZERO_MIMALLOC)

--- a/cpp/vm/evmzero/build_info.h.in
+++ b/cpp/vm/evmzero/build_info.h.in
@@ -1,0 +1,11 @@
+
+namespace tosca::evmzero::internal {
+constexpr auto kCompilerId = "@CMAKE_CXX_COMPILER_ID@";
+constexpr auto kCompilerVersion = "@CMAKE_CXX_COMPILER_VERSION@";
+constexpr auto kBuildType = "@CMAKE_BUILD_TYPE@";
+#include "target_properties.inc"
+constexpr auto kAssertions = "@TOSCA_ASSERT@";
+constexpr auto kAsan = "@TOSCA_ASAN@";
+constexpr auto kMimalloc = "@EVMZERO_MIMALLOC@";
+constexpr auto kTracy = "@EVMZERO_TRACY@";
+}  // namespace tosca::evmzero::internal

--- a/cpp/vm/evmzero/profiler.h
+++ b/cpp/vm/evmzero/profiler.h
@@ -14,6 +14,7 @@
 #include <x86intrin.h>
 #endif
 
+#include "build_info.h"
 #include "common/macros.h"
 #include "profiler_markers.h"
 
@@ -102,7 +103,14 @@ class Profile {
 
     // profiling format: <marker>, <calls>, <total-time-ticks>, <total-time-nanoseconds>\n
     std::ostream& out = out_file.is_open() ? out_file : std::cout;
-    out << "compiler: " << TOSCA_COMPILER << "\n";
+    out << "Compiler: " << internal::kCompilerId << " " << internal::kCompilerVersion << "\n";
+    out << "Build type: " << internal::kBuildType << "\n";
+    out << "Compile definitions: " << internal::kCompileDefinitions << "\n";
+    out << "Compile options: " << internal::kCompileOptions << "\n";
+    out << "Assertions: " << internal::kAssertions << "\n";
+    out << "ASAN: " << internal::kAsan << "\n";
+    out << "Mimalloc: " << internal::kMimalloc << "\n";
+    out << "Tracy: " << internal::kTracy << "\n";
     out << "marker,calls,ticks,duration[ns]\n";
     for (std::size_t i = 0; i < kNumMarkers; ++i) {
       const auto marker = static_cast<Marker>(i);


### PR DESCRIPTION
This PR adds additional information to the output of the profiler.

The information is:

  - Compiler and version
  - Build type debug/release
  - Compiler flags
  - Assertions on/off
  - ASAN on/off
  - Mimalloc on/off
  - Tracy on/off

The cmake mechanism to get the compiler flags is a bit convoluted and requires at least cmake version 3.19. If we must support older cmake versions as well I can drop the compiler flags and only include the other information.