### PR TITLE
Fix call depth check in evmc-bridge, evmzero

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -1194,7 +1194,7 @@ template <op::OpCodes Op>
 static void create_impl(Context& ctx) noexcept {
   static_assert(Op == op::CREATE || Op == op::CREATE2);
 
-  if (ctx.message->depth >= 1024) [[unlikely]] {
+  if (ctx.message->depth > 1024) [[unlikely]] {
     ctx.state = RunState::kErrorCreate;
     return;
   }
@@ -1265,7 +1265,7 @@ template <op::OpCodes Op>
 static void call_impl(Context& ctx) noexcept {
   static_assert(Op == op::CALL || Op == op::CALLCODE || Op == op::DELEGATECALL || Op == op::STATICCALL);
 
-  if (ctx.message->depth >= 1024) [[unlikely]] {
+  if (ctx.message->depth > 1024) [[unlikely]] {
     ctx.state = RunState::kErrorCall;
     return;
   }

--- a/go/common/evmc_bridge.go
+++ b/go/common/evmc_bridge.go
@@ -72,11 +72,11 @@ func (e *EvmcInterpreter) Run(contract *vm.Contract, input []byte, readOnly bool
 
 	// Track the recursive call depth of this Call within a transaction.
 	// A maximum limit of params.CallCreateDepth must be enforced.
-	e.evm.Depth++
-	defer func() { e.evm.Depth-- }()
 	if e.evm.Depth > int(params.CallCreateDepth) {
 		return nil, vm.ErrDepth
 	}
+	e.evm.Depth++
+	defer func() { e.evm.Depth-- }()
 
 	host_ctx := HostContext{
 		evm:         e.evm,


### PR DESCRIPTION
On Friday, Jan told me that there is an issue with the call depth check. Specifically the call-depth check appears to be off-by-one in evmzero and evmone, when compared to geth and lfvm.

This commit adjust the checks in the evmc-bridge and evmzero to be in line with geth and lfvm.