### PR TITLE
evmzero: Fix memory copy operations with size == 0

### DIFF
--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -2262,18 +2262,12 @@ TEST(InterpreterTest, EXTCODECOPY) {
 TEST(InterpreterTest, EXTCODECOPY_ZeroSize) {
   const std::vector<uint8_t> code = {op::PUSH4, 0x0A, 0x0B, 0x0C, 0xD};
 
-  MockHost host;
-  EXPECT_CALL(host, copy_code(evmc::address(0x42), 1, _, 0))  //
-      .Times(1)
-      .WillOnce(Return(0));
-
   RunInterpreterTest({
       .code = {op::EXTCODECOPY},
       .state_after = RunState::kDone,
       .gas_before = 3000,
       .gas_after = 3000 - 700,
       .stack_before = {0, 1, 2, 0x42},
-      .host = &host,
   });
 }
 
@@ -2414,8 +2408,9 @@ TEST(InterpreterTest, EXTCODECOPY_OversizedMemory) {
 
   RunInterpreterTest({
       .code = {op::EXTCODECOPY},
-      .state_after = RunState::kErrorGas,
+      .state_after = RunState::kDone,
       .gas_before = 10000000,
+      .gas_after = 9999300,
       .stack_before = {0, 0, uint256_t{1} << 100, 0x42},
   });
 }
@@ -2550,8 +2545,9 @@ TEST(InterpreterTest, RETURNDATACOPY_OversizedMemory) {
 
   RunInterpreterTest({
       .code = {op::RETURNDATACOPY},
-      .state_after = RunState::kErrorGas,
+      .state_after = RunState::kDone,
       .gas_before = 10000000,
+      .gas_after = 9999997,
       .stack_before = {0, 0, uint256_t{1} << 100},
       .last_call_data{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
   });


### PR DESCRIPTION
Apparently copy operations with with bogus offsets are valid when the size is zero.