### PR TITLE
evmzero: Add fallback mock host for tests

### DIFF
--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -70,6 +70,8 @@ struct InterpreterTestDescription {
 };
 
 void RunInterpreterTest(const InterpreterTestDescription& desc) {
+  MockHost fallback_mock_host;
+
   auto valid_jump_targets = op::CalculateValidJumpTargets(desc.code);
 
   auto padded_code = internal::PadCode(desc.code);
@@ -83,7 +85,7 @@ void RunInterpreterTest(const InterpreterTestDescription& desc) {
       .memory = desc.memory_before,
       .stack = desc.stack_before,
       .message = &desc.message,
-      .host = desc.host,
+      .host = desc.host ? desc.host : &fallback_mock_host,
       .revision = desc.revision,
   };
 


### PR DESCRIPTION
This prevents a nullptr deref for test cases that are not expected to interact with the host but do so anyway.

To be more specific: we don't have any such test cases right now, but sometimes during development, an instruction might interact with the host since we just changed a bit of related code. The test case now segfaults due to the nullptr deref. With the fallback host, this segfault is prevent. The mock instance will output warning messages about the unexpected interaction.