### PR TITLE
cti: Add ct adapter

### DIFF
--- a/go/ct/cti/ct_adapter.go
+++ b/go/ct/cti/ct_adapter.go
@@ -1,0 +1,68 @@
+package cti
+
+import (
+	"errors"
+	"math"
+
+	"github.com/Fantom-foundation/Tosca/go/ct"
+	"github.com/holiman/uint256"
+)
+
+type CtAdapter struct {
+	state State
+}
+
+func (evm *CtAdapter) StepN(init ct.State, numSteps int) (ct.State, error) {
+	evm.state = decodeCtState(init)
+	evm.state.StepN(numSteps)
+	return encodeCtState(evm.state)
+}
+
+func decodeCtState(input ct.State) (output State) {
+	// ct.Failed maps to cti.Invalid
+	output.Status = Status(input.Status)
+
+	output.Pc = int(input.Pc)
+	output.GasLeft = int64(input.Gas)
+
+	output.Code = make([]OpCode, len(input.Code))
+	for i := range input.Code {
+		output.Code[i] = OpCode(input.Code[i])
+	}
+
+	output.Stack = make([]uint256.Int, input.Stack.Size())
+	for i := range output.Stack {
+		output.Stack[i] = input.Stack.Get(input.Stack.Size() - 1 - i)
+	}
+
+	return
+}
+
+func encodeCtState(input State) (output ct.State, err error) {
+	if input.Status < Invalid {
+		output.Status = ct.StatusCode(input.Status)
+	} else {
+		output.Status = ct.Failed
+	}
+
+	if input.Pc > math.MaxUint16 {
+		return output, errors.New("program counter out of range")
+	}
+	output.Pc = uint16(input.Pc)
+
+	if input.GasLeft < 0 {
+		return output, errors.New("gas left out of range")
+	}
+	output.Gas = uint64(input.GasLeft)
+
+	output.Code = make([]byte, len(input.Code))
+	for i := range input.Code {
+		output.Code[i] = byte(input.Code[i])
+	}
+
+	for _, v := range input.Stack {
+		output.Stack.Push(v)
+	}
+
+	return
+}

--- a/go/ct/cti/ct_adapter_test.go
+++ b/go/ct/cti/ct_adapter_test.go
@@ -1,0 +1,30 @@
+package cti
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/ct"
+	"github.com/holiman/uint256"
+)
+
+func TestCtiAdapter(t *testing.T) {
+	s := ct.State{
+		Status: ct.Running,
+		Gas:    100,
+		Code:   []byte{ct.ADD},
+		Stack:  ct.NewStack([]uint256.Int{*uint256.NewInt(21), *uint256.NewInt(42)}),
+	}
+
+	var evm CtAdapter
+
+	s, err := evm.StepN(s, 2)
+	if err != nil {
+		t.Error(err)
+	}
+
+	top := s.Stack.Get(0)
+
+	if s.Status != ct.Stopped || !top.Eq(uint256.NewInt(21+42)) {
+		t.Fail()
+	}
+}

--- a/go/ct/evm.go
+++ b/go/ct/evm.go
@@ -1,0 +1,5 @@
+package ct
+
+type Evm interface {
+	StepN(State, numSteps int) (State, error)
+}

--- a/go/ct/state.go
+++ b/go/ct/state.go
@@ -90,6 +90,10 @@ type Stack struct {
 	stack []uint256.Int
 }
 
+func NewStack(values []uint256.Int) Stack {
+	return Stack{values}
+}
+
 func (s *Stack) Clone() Stack {
 	res := make([]uint256.Int, len(s.stack))
 	copy(res, s.stack)


### PR DESCRIPTION
This PR adds an adapter to `cti` that decodes a `ct` state, runs the interpreter for a given number of steps, and encodes the resulting state for `ct`.