### PR TITLE
ct: Use other rng with faster seeding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 )
 
+require pgregory.net/rand v1.0.2 // indirect
+
 require (
 	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
 	github.com/VictoriaMetrics/fastcache v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -615,5 +615,7 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
+pgregory.net/rand v1.0.2 h1:ASEbkvwOmY/UPF2evJPBJ8XZg71xdKWYdByqKapI7Vw=
+pgregory.net/rand v1.0.2/go.mod h1:EyNx8APnDE3Svi8sWgUZ5lOiz60cNZUPPBTyzOUpPl4=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/go/ct/state_builder.go
+++ b/go/ct/state_builder.go
@@ -2,17 +2,16 @@ package ct
 
 import (
 	"fmt"
-	"math/rand"
-	"time"
 
 	"github.com/holiman/uint256"
+	"pgregory.net/rand"
 )
 
 func GetRandomState() State {
-	return GetRandomStateWithSeed(time.Now().UnixNano())
+	return NewStateBuilder().Build()
 }
 
-func GetRandomStateWithSeed(seed int64) State {
+func GetRandomStateWithSeed(seed uint64) State {
 	return NewStateBuilderWithSeed(seed).Build()
 }
 
@@ -44,12 +43,14 @@ const (
 )
 
 func NewStateBuilder() *StateBuilder {
-	return NewStateBuilderWithSeed(time.Now().UnixNano())
+	return &StateBuilder{
+		random: rand.New(),
+	}
 }
 
-func NewStateBuilderWithSeed(seed int64) *StateBuilder {
+func NewStateBuilderWithSeed(seed uint64) *StateBuilder {
 	return &StateBuilder{
-		random:   rand.New(rand.NewSource(seed)),
+		random:   rand.New(seed),
 		fixedOps: map[uint16]struct{}{},
 	}
 }
@@ -66,7 +67,7 @@ func (b *StateBuilder) Clone() *StateBuilder {
 		state:    *b.state.Clone(),
 		fixed:    b.fixed,
 		fixedOps: fixedOps,
-		random:   rand.New(rand.NewSource(time.Now().UnixNano())),
+		random:   rand.New(),
 	}
 }
 


### PR DESCRIPTION
This PR replaces usage of the std rng with `pgregory.net/rand`.

According to `pgregory.net/rand`'s [documentation](https://pkg.go.dev/pgregory.net/rand), `New()` is equivalent to `rand.New(rand.NewSource(time.Now().UnixNano()))` of the std rng.

The primary problem with the std rng appears to be this loop when re-seeding the rng. It spans ~630 iterations.
https://github.com/golang/go/blob/3fb1d95149fa280343581a48547c3c3f70dac5fb/src/math/rand/rng.go#L217

With this change, `State.Clone` is now dominated by `memmove` and `makeslice`.