### PR TITLE
Make all failed states equal and ignore cases with PC pointing to data

### DIFF
--- a/go/ct/cti/spec_test.go
+++ b/go/ct/cti/spec_test.go
@@ -35,6 +35,11 @@ func TestComplianceTest_RandomTestCases(t *testing.T) {
 func run(spec ct.Specification, interpreter cti.CtAdapter, state ct.State, t *testing.T) {
 	t.Helper()
 
+	// Skip test where PC is pointing to Data (this are unreachable states).
+	if ct.IsData(ct.Pc()).Check(state) {
+		return
+	}
+
 	in := *state.Clone()
 
 	// run on interpreter

--- a/go/ct/state.go
+++ b/go/ct/state.go
@@ -3,10 +3,10 @@ package ct
 import (
 	"bytes"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/holiman/uint256"
+	"golang.org/x/exp/slices"
 )
 
 type StatusCode int
@@ -91,7 +91,23 @@ func (s *State) GetNextDataPosition(start int) (position int, found bool) {
 }
 
 func (s *State) Equal(other *State) bool {
-	return reflect.DeepEqual(s, other)
+	if s.Status != other.Status {
+		return false
+	}
+	// All failed states are the same.
+	if s.Status == Failed {
+		return true
+	}
+	if s.Gas != other.Gas {
+		return false
+	}
+	if s.Pc != other.Pc {
+		return false
+	}
+	if !s.Stack.Equal(&other.Stack) {
+		return false
+	}
+	return bytes.Equal(s.Code, other.Code)
 }
 
 func (s *State) Clone() *State {
@@ -147,6 +163,10 @@ func (s *Stack) Clone() Stack {
 	res := make([]uint256.Int, len(s.stack))
 	copy(res, s.stack)
 	return Stack{res}
+}
+
+func (s *Stack) Equal(other *Stack) bool {
+	return slices.Equal(s.stack, other.stack)
 }
 
 func (s *Stack) Size() int {


### PR DESCRIPTION
This PR updates the CT's State representation to treat all failed states equally and eliminates test cases where the program pointer is pointing to Data instead of Code. These are unreachable states.