### PR TITLE
Reduce memory usage to enable parallel testing

### DIFF
--- a/go/ct/cti/spec_test.go
+++ b/go/ct/cti/spec_test.go
@@ -13,10 +13,12 @@ func TestComplianceTest_DerivedTestCases(t *testing.T) {
 	spec := cts.Specification
 	adapter := cti.CtAdapter{}
 	for _, rule := range spec.GetRules() {
+		rule := rule
 		t.Run(rule.Name, func(t *testing.T) {
-			for _, state := range ct.GetTestSamples(rule) {
+			t.Parallel()
+			rule.EnumerateTestCases(func(state ct.State) {
 				run(spec, adapter, state, t)
-			}
+			})
 		})
 	}
 }

--- a/go/ct/cts/specification_test.go
+++ b/go/ct/cts/specification_test.go
@@ -9,8 +9,10 @@ import (
 func TestSpecification_RulesCoverTestCases(t *testing.T) {
 	rules := Specification.GetRules()
 	for _, rule := range rules {
+		rule := rule
 		t.Run(rule.Name, func(t *testing.T) {
-			for _, cur := range ct.GetTestSamples(rule) {
+			t.Parallel()
+			rule.EnumerateTestCases(func(cur ct.State) {
 				rules := Specification.GetRulesFor(cur)
 				if len(rules) == 0 {
 					t.Fatalf("no specification for state %v", &cur)
@@ -18,7 +20,7 @@ func TestSpecification_RulesCoverTestCases(t *testing.T) {
 				if len(rules) > 1 {
 					t.Fatalf("multiple rules for state %v: %v", &cur, rules)
 				}
-			}
+			})
 		})
 	}
 }

--- a/go/ct/rule.go
+++ b/go/ct/rule.go
@@ -56,24 +56,22 @@ type Expression[T any] interface {
 }
 
 // GetSatisfyingState produces a state satisfying the given condition.
-func GetSatisfyingState(rule Rule) State {
+func (rule *Rule) GetSatisfyingState() State {
 	builder := NewStateBuilder()
 	rule.Condition.restrict(builder)
 	return builder.Build()
 }
 
-// GetTestSamples produces a list of states representing relevant test
+// EnumerateTestCases enumerates a list of states representing relevant test
 // cases for the given condition. At least one of those cases is satisfying
 // the condition.
-func GetTestSamples(rule Rule) []State {
-	res := []State{}
+func (rule *Rule) EnumerateTestCases(consume func(s State)) {
 	builder := NewStateBuilder()
 	rule.Condition.enumerateTestCases(builder, func(s *StateBuilder) {
 		enumerateParameters(0, rule.Parameter, s, func(s *StateBuilder) {
-			res = append(res, s.Build())
+			consume(s.Build())
 		})
 	})
-	return res
 }
 
 func enumerateParameters(pos int, params []Parameter, builder *StateBuilder, consume func(s *StateBuilder)) {

--- a/go/ct/rule_test.go
+++ b/go/ct/rule_test.go
@@ -52,7 +52,8 @@ func TestCondition_CreateSatisfyingState(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		res := GetSatisfyingState(Rule{Condition: test})
+		rule := Rule{Condition: test}
+		res := rule.GetSatisfyingState()
 		if !test.Check(res) {
 			t.Errorf("Generated state does not satisfy condition %v: %v", test, &res)
 		}
@@ -77,21 +78,22 @@ func TestCondition_CanGenerateTestSamples(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		samples := GetTestSamples(Rule{Condition: test})
 		matches := 0
 		misses := 0
-		for _, sample := range samples {
+
+		rule := Rule{Condition: test}
+		rule.EnumerateTestCases(func(sample State) {
 			if test.Check(sample) {
 				matches++
 			} else {
 				misses++
 			}
-		}
+		})
 		if matches == 0 {
-			t.Errorf("none of the %d generated samples for %v is a match", len(samples), test)
+			t.Errorf("none of the %d generated samples for %v is a match", matches+misses, test)
 		}
-		if len(samples) > 1 && misses == 0 {
-			t.Errorf("none of the %d generated samples for %v is a miss", len(samples), test)
+		if matches+misses > 1 && misses == 0 {
+			t.Errorf("none of the %d generated samples for %v is a miss", matches+misses, test)
 		}
 	}
 }
@@ -108,22 +110,20 @@ func TestCondition_CanGenerateTestSamplesForParameters(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		samples := GetTestSamples(test)
-
 		matches := 0
 		misses := 0
-		for _, sample := range samples {
+		test.EnumerateTestCases(func(sample State) {
 			if test.Condition.Check(sample) {
 				matches++
 			} else {
 				misses++
 			}
-		}
+		})
 		if matches == 0 {
-			t.Errorf("none of the %d generated samples is a match", len(samples))
+			t.Errorf("none of the %d generated samples is a match", matches+misses)
 		}
-		if len(samples) > 1 && misses == 0 {
-			t.Errorf("none of the %d generated samples is a miss", len(samples))
+		if matches+misses > 1 && misses == 0 {
+			t.Errorf("none of the %d generated samples is a miss", matches+misses)
 		}
 	}
 }


### PR DESCRIPTION
Before this PR lists of test cases got materialized before being executed. This required a large (and growing) amount of memory, easily exceeding 32 GB, and preventing the parallel execution of tests.

With this PR the creation of lists of tests is replaced by the one-by-one enumeration of tests. This way, at any time, only one test state needs to be in memory, significantly reducing memory usage. This allows multiple tests to be run in parallel, speeding up the evaluation.