### PR TITLE
evmzero: Fix SAR with oversized shift and negative number

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -437,7 +437,7 @@ struct Impl<OpCode::SAR> {
         top[1] |= (kUint256Max << (255 - top[0]));
       }
     } else {
-      top[1] = 0;
+      top[1] = is_negative ? kUint256Max : 0;
     }
 
     return {};

--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -1404,7 +1404,7 @@ TEST(InterpreterTest, SAR) {
       .gas_before = 7,
       .gas_after = 4,
       .stack_before = {kUint256Max, 256},
-      .stack_after = {0},
+      .stack_after = {kUint256Max},
   });
 }
 


### PR DESCRIPTION
evmzero is not behaving correctly in this edge case; when a negative number is shifted with an argument >= 256, the result should be -1.