### PR TITLE
Add immutable code and associated generator

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.21
         cache: false
 
     - name: Check Go sources formatting

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Fantom-foundation/Tosca
 
-go 1.19
+go 1.21
 
 require (
 	github.com/ethereum/evmc/v10 v10.0.0
@@ -35,6 +35,7 @@ require (
 	github.com/urfave/cli/v2 v2.3.0 // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.7 // indirect
+	pgregory.net/rand v1.0.2 // indirect
 )
 
 replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20230110052435-1ac0bdd8f402

--- a/go.sum
+++ b/go.sum
@@ -612,5 +612,7 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
+pgregory.net/rand v1.0.2 h1:ASEbkvwOmY/UPF2evJPBJ8XZg71xdKWYdByqKapI7Vw=
+pgregory.net/rand v1.0.2/go.mod h1:EyNx8APnDE3Svi8sWgUZ5lOiz60cNZUPPBTyzOUpPl4=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/go/ct/common/error.go
+++ b/go/ct/common/error.go
@@ -1,0 +1,8 @@
+package common
+
+// ConstErr is an error type that can be used to define error constants.
+type ConstErr string
+
+func (e ConstErr) Error() string {
+	return string(e)
+}

--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -1,0 +1,192 @@
+package gen
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+	"pgregory.net/rand"
+)
+
+// CodeGenerator is a utility class for generating Codes. It provides three
+// capabilities:
+//   - The specification of constraints and the generation of a code satisfying
+//     those constraints or the identification of unsatisfiable constraints.
+//     This constraint solver is sound and complete.
+//   - Support for cloning a generator state and restoring it.
+//
+// The goal of the CodeGenerator is to produce high entropy results by setting
+// all unconstrained degrees of freedom for the final code to random values.
+type CodeGenerator struct {
+	// Constraints
+	sizes []int
+	ops   []opConstraint
+}
+
+type opConstraint struct {
+	pos int
+	op  st.OpCode
+}
+
+// NewCodeGenerator creates a generator without any initial constraints.
+func NewCodeGenerator() *CodeGenerator {
+	return &CodeGenerator{}
+}
+
+// SetSize adds a constraint on the size of the resulting code. Multiple size
+// constraints may be added, though conflicting constraints will result in an
+// error signalling unsatisfiability during the generation process.
+func (g *CodeGenerator) SetSize(size int) error {
+	for _, cur := range g.sizes {
+		if cur == size {
+			return nil
+		}
+	}
+	g.sizes = append(g.sizes, size)
+	return nil
+}
+
+// SetOperation fixes an operation to be placed at a given offset.
+func (g *CodeGenerator) SetOperation(pos int, op st.OpCode) error {
+	g.ops = append(g.ops, opConstraint{pos: pos, op: op})
+	return nil
+}
+
+// Generate produces a Code instance satisfying the constraints set on this
+// generator or returns an error indicating unsatisfiability.
+func (g *CodeGenerator) Generate(rnd *rand.Rand) (*st.Code, error) {
+	// Pick a size.
+	if len(g.sizes) > 1 {
+		return nil, fmt.Errorf("%w, multiple conflicting sizes defined: %v", ErrUnsatisfiable, g.sizes)
+	}
+
+	size := 0
+	if len(g.sizes) == 1 {
+		size = g.sizes[0]
+		if size < 0 {
+			return nil, fmt.Errorf("%w, can not produce code with negative size %d", ErrUnsatisfiable, size)
+		}
+	} else {
+		// Pick a random size that is large enough for all operation constraints.
+		minSize := 0
+		for _, constraint := range g.ops {
+			if constraint.pos > minSize {
+				minSize = constraint.pos + 1
+			}
+		}
+		size = int(rnd.Int31n(int32(24576+1-minSize))) + minSize
+	}
+
+	// Create the code and fill in content based on the operation constraints.
+	code := make([]byte, size)
+
+	// If there are no operation constraints producing random code is sufficient.
+	if len(g.ops) == 0 {
+		rnd.Read(code)
+		return st.NewCode(code), nil
+	}
+
+	// If there are constraints we need to make sure that all operations are
+	// indeed operations (not data) and that the operation code is correct.
+	sort.Slice(g.ops, func(i, j int) bool { return g.ops[i].pos < g.ops[j].pos })
+	if last := g.ops[len(g.ops)-1].pos; last >= size {
+		return nil, fmt.Errorf(
+			"%w, operation constraint on position %d cannot be satisfied with a code length of %d",
+			ErrUnsatisfiable, last, size,
+		)
+	}
+
+	// Build random code incrementally.
+	ops := g.ops
+	for i := 0; i < size; i++ {
+		// Pick the next operation.
+		op := st.INVALID
+		nextFixedPosition := ops[0].pos
+		if nextFixedPosition < i {
+			return nil, fmt.Errorf(
+				"%w, unable to satisfy op[%d]=%v constraint",
+				ErrUnsatisfiable, ops[0].pos, ops[0].op,
+			)
+		}
+
+		if i == nextFixedPosition {
+			op = ops[0].op
+			ops = ops[1:]
+		} else {
+			// Pick a random operation, but make sure to not overshoot to next position.
+			limit := st.PUSH32
+			if maxDataSize := nextFixedPosition - i - 1; maxDataSize < 32 {
+				limit = st.OpCode(int(st.PUSH1) + maxDataSize - 1)
+			}
+
+			op = st.OpCode(rnd.Int())
+			if limit < op && op <= st.PUSH32 {
+				op = limit
+			}
+		}
+
+		code[i] = byte(op)
+
+		// If this was the last, fill the rest randomly.
+		if len(ops) == 0 {
+			rnd.Read(code[i+1:])
+			break
+		}
+
+		// Fill data if needed and continue with the rest.
+		if st.PUSH1 <= op && op <= st.PUSH32 {
+			width := int(op - st.PUSH1 + 1)
+			rnd.Read(code[i+1 : i+1+width])
+			i += width
+		}
+	}
+
+	return st.NewCode(code), nil
+}
+
+// Clone creates an independent copy of a generator in its current state. Future
+// modifications are isolated from each other.
+func (g *CodeGenerator) Clone() *CodeGenerator {
+	return &CodeGenerator{
+		sizes: slices.Clone(g.sizes),
+		ops:   slices.Clone(g.ops),
+	}
+}
+
+// Restore copies the state of the provided generator into this generator.
+func (g *CodeGenerator) Restore(other *CodeGenerator) {
+	if g == other {
+		return
+	}
+	g.sizes = slices.Clone(other.sizes)
+	g.ops = slices.Clone(other.ops)
+}
+
+func (g *CodeGenerator) String() string {
+	builder := strings.Builder{}
+	builder.WriteString("{")
+
+	first := true
+	sort.Slice(g.sizes, func(i, j int) bool { return g.sizes[i] < g.sizes[j] })
+	for _, size := range g.sizes {
+		if !first {
+			builder.WriteRune(',')
+		}
+		first = false
+		builder.WriteString(fmt.Sprintf("size=%d", size))
+	}
+
+	sort.Slice(g.ops, func(i, j int) bool { return g.ops[i].pos < g.ops[j].pos })
+	for _, op := range g.ops {
+		if !first {
+			builder.WriteRune(',')
+		}
+		first = false
+		builder.WriteString(fmt.Sprintf("op[%d]=%v", op.pos, op.op))
+	}
+
+	builder.WriteString("}")
+	return builder.String()
+}

--- a/go/ct/gen/code_test.go
+++ b/go/ct/gen/code_test.go
@@ -1,0 +1,214 @@
+package gen
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+	"pgregory.net/rand"
+)
+
+func TestCodeGenerator_UnconstrainedBuilderCanProduceCode(t *testing.T) {
+	rnd := rand.New()
+	generator := NewCodeGenerator()
+	if _, err := generator.Generate(rnd); err != nil {
+		t.Fatalf("unexpected error during build: %v", err)
+	}
+}
+
+func TestCodeGenerator_SetCodeSizeIsEnforced(t *testing.T) {
+	sizes := []int{0, 1, 2, 1 << 20, 1 << 23}
+
+	rnd := rand.New()
+	for _, size := range sizes {
+		generator := NewCodeGenerator()
+		if err := generator.SetSize(size); err != nil {
+			t.Fatalf("unexpected error setting size: %v", err)
+		}
+		code, err := generator.Generate(rnd)
+		if err != nil {
+			t.Fatalf("unexpected error during build: %v", err)
+		}
+		if want, got := size, code.Length(); want != got {
+			t.Errorf("unexpected code length, wanted %d, got %d", want, got)
+		}
+	}
+}
+
+func TestCodeGenerator_ConflictingSizesAreDetected(t *testing.T) {
+	generator := NewCodeGenerator()
+	if err := generator.SetSize(12); err != nil {
+		t.Fatalf("error setting code size: %v", err)
+	}
+	if err := generator.SetSize(14); err != nil {
+		t.Fatalf("error setting code size: %v", err)
+	}
+	rnd := rand.New()
+	if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
+		t.Errorf("unsatisfiable constraint not detected, got %v", err)
+	}
+}
+
+func TestCodeGenerator_NegativeCodeSizesAreDetected(t *testing.T) {
+	generator := NewCodeGenerator()
+	if err := generator.SetSize(-12); err != nil {
+		t.Fatalf("error setting code size: %v", err)
+	}
+	rnd := rand.New()
+	if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
+		t.Errorf("unsatisfiable constraint not detected, got %v", err)
+	}
+}
+
+func TestCodeGenerator_NonConflictingSizesAreAccepted(t *testing.T) {
+	generator := NewCodeGenerator()
+	if err := generator.SetSize(12); err != nil {
+		t.Fatalf("error setting code size: %v", err)
+	}
+	if err := generator.SetSize(12); err != nil {
+		t.Fatalf("error setting code size: %v", err)
+	}
+	rnd := rand.New()
+	if _, err := generator.Generate(rnd); err != nil {
+		t.Errorf("generation failed: %v", err)
+	}
+}
+
+func TestCodeGenerator_OperationConstraintsAreEnforced(t *testing.T) {
+	tests := map[string][]struct {
+		pos int
+		op  st.OpCode
+	}{
+		"empty":            {},
+		"single":           {{4, st.STOP}},
+		"multiple-no-data": {{4, st.STOP}, {6, st.ADD}, {2, st.INVALID}},
+		"pair":             {{4, st.PUSH1}, {7, st.PUSH32}},
+		"tight":            {{0, st.PUSH1}, {2, st.PUSH1}, {4, st.PUSH1}},
+		"wide":             {{2, st.PUSH1}, {20000, st.PUSH1}},
+	}
+
+	rnd := rand.New()
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			generator := NewCodeGenerator()
+
+			for _, cur := range test {
+				if err := generator.SetOperation(cur.pos, cur.op); err != nil {
+					t.Fatalf("failed to add operation constraint: %v", err)
+				}
+			}
+
+			code, err := generator.Generate(rnd)
+			if err != nil {
+				t.Fatalf("unexpected error during build: %v", err)
+			}
+
+			for _, cur := range test {
+				if !code.IsCode(cur.pos) {
+					t.Fatalf("position %d is not code", cur.pos)
+				}
+				if op, err := code.GetOperation(cur.pos); err != nil || op != cur.op {
+					t.Errorf("failed to satisfy operator constraint for position %v, wanted %v, got %v, err %v", cur.pos, cur.op, op, err)
+				}
+			}
+		})
+	}
+}
+
+func TestCodeGenerator_ImpossibleConstraintsAreDetected(t *testing.T) {
+	type op struct {
+		pos int
+		op  st.OpCode
+	}
+	tests := map[string]struct {
+		size int
+		ops  []op
+	}{
+		"too_small_code":                            {size: 2, ops: []op{{4, st.STOP}}},
+		"just_too_small":                            {size: 4, ops: []op{{4, st.STOP}}},
+		"conflicting_ops":                           {size: 4, ops: []op{{2, st.STOP}, {2, st.INVALID}}},
+		"operation_in_short_data_begin":             {size: 4, ops: []op{{0, st.PUSH2}, {1, st.STOP}}},
+		"operation_in_short_data_end":               {size: 4, ops: []op{{0, st.PUSH2}, {2, st.STOP}}},
+		"operation_in_long_data_begin":              {size: 40, ops: []op{{0, st.PUSH32}, {1, st.STOP}}},
+		"operation_in_long_data_mid":                {size: 40, ops: []op{{0, st.PUSH32}, {16, st.PUSH1}}},
+		"operation_in_long_data_end":                {size: 40, ops: []op{{0, st.PUSH32}, {32, st.PUSH32}}},
+		"add_operation_making_other_operation_data": {size: 40, ops: []op{{16, st.PUSH32}, {0, st.PUSH32}}},
+	}
+
+	rnd := rand.New()
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			generator := NewCodeGenerator()
+
+			if err := generator.SetSize(test.size); err != nil {
+				t.Fatalf("unexpected error setting code size: %v", err)
+			}
+
+			for _, cur := range test.ops {
+				if err := generator.SetOperation(cur.pos, cur.op); err != nil {
+					t.Fatalf("unexpected error setting operation constraint: %v", err)
+				}
+			}
+
+			if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
+				t.Fatalf("expected error indicating unsatisfiability, but got %v", err)
+			}
+		})
+	}
+}
+
+func TestCodeGenerator_CloneCopiesBuilderState(t *testing.T) {
+	original := NewCodeGenerator()
+	original.SetSize(12)
+	original.SetOperation(4, st.PUSH2)
+	original.SetOperation(7, st.STOP)
+
+	clone := original.Clone()
+
+	if want, got := original.String(), clone.String(); want != got {
+		t.Errorf("invalid clone, wanted %s, got %s", want, got)
+	}
+}
+
+func TestCodeGenerator_ClonesAreIndependent(t *testing.T) {
+	base := NewCodeGenerator()
+	base.SetOperation(4, st.STOP)
+
+	clone1 := base.Clone()
+	clone1.SetSize(12)
+	clone1.SetOperation(7, st.INVALID)
+
+	clone2 := base.Clone()
+	clone2.SetSize(14)
+	clone2.SetOperation(7, st.PUSH2)
+
+	want := "{size=12,op[4]=STOP,op[7]=INVALID}"
+	if got := clone1.String(); got != want {
+		t.Errorf("invalid clone, wanted %s, got %s", want, got)
+	}
+
+	want = "{size=14,op[4]=STOP,op[7]=PUSH2}"
+	if got := clone2.String(); got != want {
+		t.Errorf("invalid clone, wanted %s, got %s", want, got)
+	}
+}
+
+func TestCodeGenerator_ClonesCanBeUsedToResetBuilder(t *testing.T) {
+	generator := NewCodeGenerator()
+	generator.SetOperation(4, st.STOP)
+
+	backup := generator.Clone()
+
+	generator.SetSize(12)
+	generator.SetOperation(7, st.INVALID)
+	want := "{size=12,op[4]=STOP,op[7]=INVALID}"
+	if got := generator.String(); got != want {
+		t.Errorf("unexpected generator state, wanted %s, got %s", want, got)
+	}
+
+	generator.Restore(backup)
+	want = "{op[4]=STOP}"
+	if got := generator.String(); got != want {
+		t.Errorf("invalid clone, wanted %s, got %s", want, got)
+	}
+}

--- a/go/ct/gen/error.go
+++ b/go/ct/gen/error.go
@@ -1,0 +1,7 @@
+package gen
+
+import "github.com/Fantom-foundation/Tosca/go/ct/common"
+
+// ErrUnsatisfiable is an error returned by generators if constraints
+// are not satisfiable.
+const ErrUnsatisfiable = common.ConstErr("unsatisfiable constraints")

--- a/go/ct/st/code.go
+++ b/go/ct/st/code.go
@@ -1,0 +1,88 @@
+package st
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+
+	"github.com/Fantom-foundation/Tosca/go/ct/common"
+)
+
+// Code is an immutable representation of EVM byte code which may be freely
+// copied and shared through shallow copies.
+type Code struct {
+	code   []byte
+	isCode []bool
+}
+
+// ErrInvalidPosition is an error produced by observer functions on the Code if
+// specified positions are invalid.
+const ErrInvalidPosition = common.ConstErr("invalid position")
+
+// NewCode creates an immutable code representation based on the given raw
+// code representation. The resulting code contains a copy of the provided code
+// to guarantee immutability.
+func NewCode(code []byte) *Code {
+	isCode := make([]bool, 0, len(code)+32)
+	for i := 0; i < len(code); i++ {
+		isCode = append(isCode, true)
+		op := OpCode(code[i])
+		if PUSH1 <= op && op <= PUSH32 {
+			width := int(op - PUSH1 + 1)
+			isCode = append(isCode, make([]bool, width)...)
+			i += width
+		}
+	}
+
+	return &Code{
+		code:   slices.Clone(code),
+		isCode: isCode,
+	}
+}
+
+func (c *Code) Length() int {
+	return len(c.code)
+}
+
+func (c *Code) IsCode(pos int) bool {
+	if pos < 0 || pos >= len(c.isCode) {
+		return true
+	}
+	return c.isCode[pos]
+}
+
+func (c *Code) IsData(pos int) bool {
+	return !c.IsCode(pos)
+}
+
+func (c *Code) GetOperation(pos int) (OpCode, error) {
+	if pos < 0 || pos >= len(c.isCode) {
+		return STOP, nil
+	}
+	if !c.isCode[pos] {
+		return INVALID, ErrInvalidPosition
+	}
+	return OpCode(c.code[pos]), nil
+}
+
+func (c *Code) GetData(pos int) (byte, error) {
+	if !c.IsData(pos) {
+		return 0, ErrInvalidPosition
+	}
+	if pos >= len(c.code) {
+		return 0, nil
+	}
+	return c.code[pos], nil
+}
+
+func (c *Code) Eq(other *Code) bool {
+	return bytes.Equal(c.code, other.code)
+}
+
+func (c *Code) CopyTo(dst []byte) int {
+	return copy(dst, c.code)
+}
+
+func (c *Code) String() string {
+	return fmt.Sprintf("%x", c.code)
+}

--- a/go/ct/st/code_test.go
+++ b/go/ct/st/code_test.go
@@ -1,0 +1,91 @@
+package st
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestCode_IsCode(t *testing.T) {
+	code := NewCode([]byte{byte(ADD), byte(PUSH1), 0, byte(PUSH2), 1})
+	for i, want := range []bool{true, true, false, true, false, false, true, true} {
+		if got := code.IsCode(i); want != got {
+			t.Errorf("unexpected result for position %d, want %t, got %t", i, want, got)
+		}
+	}
+}
+
+func TestCode_IsData(t *testing.T) {
+	code := NewCode([]byte{byte(ADD), byte(PUSH1), 0, byte(PUSH2)})
+	for i, want := range []bool{false, false, true, false, true, true, false, false} {
+		if got := code.IsData(i); want != got {
+			t.Errorf("unexpected result for position %d, want %t, got %t", i, want, got)
+		}
+	}
+}
+
+func TestCode_GetOperation(t *testing.T) {
+	code := NewCode([]byte{byte(ADD), byte(PUSH1), 0, byte(PUSH2)})
+	for i, want := range map[int]OpCode{-1: STOP, 0: ADD, 1: PUSH1, 3: PUSH2, 6: STOP} {
+		if got, err := code.GetOperation(i); err != nil || want != got {
+			t.Errorf("unexpected result for position %d, want %v, got %v, err %v", i, want, got, err)
+		}
+	}
+	for _, i := range []int{2, 4, 5} {
+		if _, err := code.GetOperation(i); !errors.Is(err, ErrInvalidPosition) {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+}
+
+func TestCode_GetData(t *testing.T) {
+	code := NewCode([]byte{byte(ADD), byte(PUSH1), 5, byte(PUSH2)})
+	for i, want := range map[int]byte{2: 5, 4: 0, 5: 0} {
+		if got, err := code.GetData(i); err != nil || want != got {
+			t.Errorf("unexpected result for position %d, want %v, got %v, err %v", i, want, got, err)
+		}
+	}
+	for _, i := range []int{0, 1, 3} {
+		if _, err := code.GetData(i); !errors.Is(err, ErrInvalidPosition) {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+}
+
+func TestCode_CopyTo(t *testing.T) {
+	src := []byte{byte(ADD), byte(PUSH1), 5, byte(PUSH2)}
+	code := NewCode(src)
+
+	if got, want := code.Length(), len(src); got != want {
+		t.Errorf("unexpected code length, wanted %d, got %d", want, got)
+	}
+
+	for i := 0; i < len(src); i++ {
+		dst := make([]byte, i)
+		if got := code.CopyTo(dst); got != i || !bytes.Equal(src[0:i], dst) {
+			t.Errorf("failed to copy data, expected %x, got %x, return %d", src[0:i], dst, i)
+		}
+	}
+}
+
+func TestCode_Equal(t *testing.T) {
+	a := NewCode([]byte{1, 2, 3})
+	b := NewCode([]byte{3, 2, 1})
+	c := a
+
+	if a.Eq(b) {
+		t.Errorf("should not be equal: %v vs. %v", a, b)
+	}
+
+	if !a.Eq(c) {
+		t.Errorf("should be equal: %v vs. %v", a, c)
+	}
+}
+
+func TestCode_Printer(t *testing.T) {
+	code := NewCode([]byte{byte(ADD), byte(PUSH1), 5, byte(PUSH2)})
+	want := "01600561"
+	if got := code.String(); want != got {
+		t.Errorf("invalid print, wanted %s, got %s", want, got)
+	}
+}

--- a/go/ct/st/opcode.go
+++ b/go/ct/st/opcode.go
@@ -1,0 +1,37 @@
+package st
+
+type OpCode byte
+
+const (
+	STOP    OpCode = 0x00
+	ADD     OpCode = 0x01
+	PUSH1   OpCode = 0x60
+	PUSH2   OpCode = 0x61
+	PUSH3   OpCode = 0x62
+	PUSH31  OpCode = 0x7E
+	PUSH32  OpCode = 0x7F
+	INVALID OpCode = 0xFE
+)
+
+func (op OpCode) String() string {
+	switch op {
+	case STOP:
+		return "STOP"
+	case ADD:
+		return "ADD"
+	case PUSH1:
+		return "PUSH1"
+	case PUSH2:
+		return "PUSH2"
+	case PUSH3:
+		return "PUSH3"
+	case PUSH31:
+		return "PUSH31"
+	case PUSH32:
+		return "PUSH32"
+	case INVALID:
+		return "INVALID"
+	default:
+		return "?"
+	}
+}

--- a/go/ct/st/opcode_test.go
+++ b/go/ct/st/opcode_test.go
@@ -1,0 +1,16 @@
+package st
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestOpCode_CanBePrinted(t *testing.T) {
+	validName := regexp.MustCompile(`^\?|([A-Z0-9]+)$`)
+	for i := 0; i < 256; i++ {
+		print := OpCode(i).String()
+		if !validName.Match([]byte(print)) {
+			t.Errorf("Invalid print for op %v (%d)", print, i)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a `Code` type for representing codes in the CT framework as well as a generator supporting the random generation of codes.

`Code` instances are immutable, which enables effective sharing. 

`CodeGenerator` collects constraints on the resulting code which are attempted to be satisfied during the `Generate` process. Properties not defined through constraints are filled with random values. Furthermore, to facilitate the effective utilization of the generator in recursive enumeration processes, the generator state can be cloned and restored, as well as sealed early. The latter enables cheaper clone and recovery operations.