### PR TITLE
Updates U256 API to use consistent big-endian order

### DIFF
--- a/go/ct/u256.go
+++ b/go/ct/u256.go
@@ -13,14 +13,15 @@ type U256 struct {
 }
 
 // NewU256 creates a new U256 instance from up to 4 uint64 arguments. The
-// arguments are given in the order from least significant to most significant.
-// No argument results in a value of zero.
+// arguments are given in the order from most significant to least significant
+// by padding leading zeros as needed. No argument results in a value of zero.
 func NewU256(args ...uint64) (result U256) {
 	if len(args) > 4 {
 		panic("To many arguments")
 	}
+	offset := 4 - len(args)
 	for i := 0; i < len(args) && i < len(result.internal); i++ {
-		result.internal[i] = args[i]
+		result.internal[3-i-offset] = args[i]
 	}
 	return
 }
@@ -160,5 +161,5 @@ func (a U256) Shr(b U256) (z U256) {
 }
 
 func (i U256) String() string {
-	return fmt.Sprintf("%016x %016x %016x %016x", i.internal[0], i.internal[1], i.internal[2], i.internal[3])
+	return fmt.Sprintf("%016x %016x %016x %016x", i.internal[3], i.internal[2], i.internal[1], i.internal[0])
 }

--- a/go/ct/u256_test.go
+++ b/go/ct/u256_test.go
@@ -2,7 +2,6 @@ package ct
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 )
 
@@ -20,7 +19,7 @@ func TestU256IsZero(t *testing.T) {
 func TestU256Bytes32be(t *testing.T) {
 	x := NewU256(1, 2, 3, 4)
 	xBytes := x.Bytes32be()
-	if !bytes.Equal(xBytes[:], []byte{0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1}) {
+	if !bytes.Equal(xBytes[:], []byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4}) {
 		t.Fail()
 	}
 }
@@ -28,7 +27,7 @@ func TestU256Bytes32be(t *testing.T) {
 func TestU256Bytes20be(t *testing.T) {
 	x := NewU256(1, 2, 3, 4)
 	xBytes := x.Bytes20be()
-	if !bytes.Equal(xBytes[:], []byte{0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1}) {
+	if !bytes.Equal(xBytes[:], []byte{0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4}) {
 		t.Fail()
 	}
 }
@@ -196,20 +195,34 @@ func TestU256Not(t *testing.T) {
 
 func TestU256Shl(t *testing.T) {
 	x := NewU256(42)
-	if x.Shl(NewU256(64)).Ne(NewU256(0, 42)) {
+	if x.Shl(NewU256(64)).Ne(NewU256(42, 0)) {
 		t.Fail()
 	}
 }
 func TestU256Shr(t *testing.T) {
-	x := NewU256(0, 42)
+	x := NewU256(42, 0)
 	if x.Shr(NewU256(64)).Ne(NewU256(42)) {
 		t.Fail()
 	}
 }
 
 func TestU256String(t *testing.T) {
-	x := NewU256(42, 13, 47, 1)
-	if fmt.Sprint(x) != "000000000000002a 000000000000000d 000000000000002f 0000000000000001" {
-		t.Fail()
+	tests := []struct {
+		value U256
+		print string
+	}{
+		{U256{}, "0000000000000000 0000000000000000 0000000000000000 0000000000000000"},
+		{NewU256(0), "0000000000000000 0000000000000000 0000000000000000 0000000000000000"},
+		{NewU256(1), "0000000000000000 0000000000000000 0000000000000000 0000000000000001"},
+		{NewU256(2), "0000000000000000 0000000000000000 0000000000000000 0000000000000002"},
+		{NewU256(1, 2), "0000000000000000 0000000000000000 0000000000000001 0000000000000002"},
+		{NewU256(1, 2, 3), "0000000000000000 0000000000000001 0000000000000002 0000000000000003"},
+		{NewU256(42, 13, 47, 1), "000000000000002a 000000000000000d 000000000000002f 0000000000000001"},
+	}
+
+	for _, test := range tests {
+		if want, got := test.print, test.value.String(); want != got {
+			t.Errorf("Unexpected print, wanted %s, got %s", want, got)
+		}
 	}
 }


### PR DESCRIPTION
This PR aligns the U256 API to consistently use big-endian word order to fit the natural language order of numbers.

In particular, `NewU256(1,2)` now produces 1 * 2^64 + 2 while it used to produce 2 * 2^64 + 1. This also makes the effect of left and right shifts more intuitive.

The printing of numbers was also adjusted such that the print of sorted numbers corresponds to their lexicographical order.