### PR TITLE
Downgrade ubuntu test image to version 20.4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,12 +16,19 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
     - uses: egor-tensin/setup-clang@v1
+      with:
+        version: 14
+
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v1.13
+      with:
+        cmake-version: '3.27.x'
 
     - name: Set up Go
       uses: actions/setup-go@v3


### PR DESCRIPTION
This is in response to a C++ library issue in github's new ubuntu-latest image ([here](https://github.com/actions/runner-images/issues/8659)).