### PR TITLE
ct: Add basic Rule definition

### DIFF
--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -1,0 +1,300 @@
+package rlz
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Fantom-foundation/Tosca/go/ct/gen"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+)
+
+// Condition represents a state property.
+type Condition interface {
+	// Check evaluates the Condition.
+	Check(*st.State) bool
+
+	// Restrict sets constraints on the given StateGenerator such that this
+	// Condition holds.
+	Restrict(*gen.StateGenerator)
+
+	// EnumerateTestCases sets constraints on a copy of the given generator and
+	// invokes the given consumer function with it.
+	EnumerateTestCases(generator *gen.StateGenerator, consumer func(*gen.StateGenerator))
+
+	fmt.Stringer
+}
+
+////////////////////////////////////////////////////////////
+// Conjunction
+
+type conjunction struct {
+	conditions []Condition
+}
+
+func And(conditions ...Condition) Condition {
+	if len(conditions) == 1 {
+		return conditions[0]
+	}
+	// Merge nested conjunctions into a single conjunction.
+	res := []Condition{}
+	for _, cur := range conditions {
+		if c, ok := cur.(*conjunction); ok {
+			res = append(res, c.conditions...)
+		} else {
+			res = append(res, cur)
+		}
+	}
+	return &conjunction{conditions: res}
+}
+
+func (c *conjunction) Check(s *st.State) bool {
+	for _, cur := range c.conditions {
+		if !cur.Check(s) {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *conjunction) Restrict(generator *gen.StateGenerator) {
+	for _, cur := range c.conditions {
+		cur.Restrict(generator)
+	}
+}
+
+func (c *conjunction) EnumerateTestCases(generator *gen.StateGenerator, consumer func(*gen.StateGenerator)) {
+	if len(c.conditions) == 0 {
+		consumer(generator)
+		return
+	}
+	rest := And(c.conditions[1:]...)
+	c.conditions[0].EnumerateTestCases(generator, func(generator *gen.StateGenerator) {
+		rest.EnumerateTestCases(generator, consumer)
+	})
+}
+
+func (c *conjunction) String() string {
+	if len(c.conditions) == 0 {
+		return "true"
+	}
+	first := true
+	var builder strings.Builder
+	for _, cur := range c.conditions {
+		if !first {
+			builder.WriteString(" ∧ ")
+		} else {
+			first = false
+		}
+		builder.WriteString(cur.String())
+	}
+	return builder.String()
+}
+
+////////////////////////////////////////////////////////////
+// Equal
+
+type eq[T any] struct {
+	lhs Expression[T]
+	rhs T
+}
+
+func Eq[T any](lhs Expression[T], rhs T) Condition {
+	return &eq[T]{lhs, rhs}
+}
+
+func (e *eq[T]) Check(s *st.State) bool {
+	domain := e.lhs.Domain()
+	return domain.Equal(e.lhs.Eval(s), e.rhs)
+}
+
+func (e *eq[T]) Restrict(generator *gen.StateGenerator) {
+	e.lhs.Restrict(e.rhs, generator)
+}
+
+func (e *eq[T]) EnumerateTestCases(generator *gen.StateGenerator, consumer func(*gen.StateGenerator)) {
+	domain := e.lhs.Domain()
+	for _, value := range domain.Samples(e.rhs) {
+		clone := generator.Clone()
+		e.lhs.Restrict(value, clone)
+		consumer(clone)
+	}
+}
+
+func (e *eq[T]) String() string {
+	return fmt.Sprintf("%s = %v", e.lhs, e.rhs)
+}
+
+////////////////////////////////////////////////////////////
+// Not Equal
+
+type ne[T any] struct {
+	lhs Expression[T]
+	rhs T
+}
+
+func Ne[T any](lhs Expression[T], rhs T) Condition {
+	return &ne[T]{lhs, rhs}
+}
+
+func (e *ne[T]) Check(s *st.State) bool {
+	domain := e.lhs.Domain()
+	return !domain.Equal(e.lhs.Eval(s), e.rhs)
+}
+
+func (e *ne[T]) Restrict(generator *gen.StateGenerator) {
+	domain := e.lhs.Domain()
+	e.lhs.Restrict(domain.SomethingNotEqual(e.rhs), generator)
+}
+
+func (e *ne[T]) EnumerateTestCases(generator *gen.StateGenerator, consumer func(*gen.StateGenerator)) {
+	domain := e.lhs.Domain()
+	for _, value := range domain.Samples(e.rhs) {
+		clone := generator.Clone()
+		e.lhs.Restrict(value, clone)
+		consumer(clone)
+	}
+}
+
+func (e *ne[T]) String() string {
+	return fmt.Sprintf("%s ≠ %v", e.lhs, e.rhs)
+}
+
+////////////////////////////////////////////////////////////
+// Less Than
+
+type lt[T any] struct {
+	lhs Expression[T]
+	rhs T
+}
+
+func Lt[T any](lhs Expression[T], rhs T) Condition {
+	return &lt[T]{lhs, rhs}
+}
+
+func (c *lt[T]) Check(s *st.State) bool {
+	domain := c.lhs.Domain()
+	return domain.Less(c.lhs.Eval(s), c.rhs)
+}
+
+func (c *lt[T]) Restrict(generator *gen.StateGenerator) {
+	domain := c.lhs.Domain()
+	c.lhs.Restrict(domain.Predecessor(c.rhs), generator)
+}
+
+func (c *lt[T]) EnumerateTestCases(generator *gen.StateGenerator, consumer func(*gen.StateGenerator)) {
+	domain := c.lhs.Domain()
+	for _, value := range domain.Samples(c.rhs) {
+		clone := generator.Clone()
+		c.lhs.Restrict(value, clone)
+		consumer(clone)
+	}
+}
+
+func (c *lt[T]) String() string {
+	return fmt.Sprintf("%s < %v", c.lhs, c.rhs)
+}
+
+////////////////////////////////////////////////////////////
+// Less Equal
+
+type le[T any] struct {
+	lhs Expression[T]
+	rhs T
+}
+
+func Le[T any](lhs Expression[T], rhs T) Condition {
+	return &le[T]{lhs, rhs}
+}
+
+func (c *le[T]) Check(s *st.State) bool {
+	domain := c.lhs.Domain()
+	e := c.lhs.Eval(s)
+	return domain.Less(e, c.rhs) || domain.Equal(e, c.rhs)
+}
+
+func (c *le[T]) Restrict(generator *gen.StateGenerator) {
+	c.lhs.Restrict(c.rhs, generator)
+}
+
+func (c *le[T]) EnumerateTestCases(generator *gen.StateGenerator, consumer func(*gen.StateGenerator)) {
+	domain := c.lhs.Domain()
+	for _, value := range domain.Samples(c.rhs) {
+		clone := generator.Clone()
+		c.lhs.Restrict(value, clone)
+		consumer(clone)
+	}
+}
+
+func (c *le[T]) String() string {
+	return fmt.Sprintf("%s ≤ %v", c.lhs, c.rhs)
+}
+
+////////////////////////////////////////////////////////////
+// Greater Than
+
+type gt[T any] struct {
+	lhs Expression[T]
+	rhs T
+}
+
+func Gt[T any](lhs Expression[T], rhs T) Condition {
+	return &gt[T]{lhs, rhs}
+}
+
+func (c *gt[T]) Check(s *st.State) bool {
+	domain := c.lhs.Domain()
+	e := c.lhs.Eval(s)
+	return !(domain.Less(e, c.rhs) || domain.Equal(e, c.rhs))
+}
+
+func (c *gt[T]) Restrict(generator *gen.StateGenerator) {
+	domain := c.lhs.Domain()
+	c.lhs.Restrict(domain.Successor(c.rhs), generator)
+}
+
+func (c *gt[T]) EnumerateTestCases(generator *gen.StateGenerator, consumer func(*gen.StateGenerator)) {
+	domain := c.lhs.Domain()
+	for _, value := range domain.Samples(c.rhs) {
+		clone := generator.Clone()
+		c.lhs.Restrict(value, clone)
+		consumer(clone)
+	}
+}
+
+func (c *gt[T]) String() string {
+	return fmt.Sprintf("%s > %v", c.lhs, c.rhs)
+}
+
+////////////////////////////////////////////////////////////
+// Greater Equal
+
+type ge[T any] struct {
+	lhs Expression[T]
+	rhs T
+}
+
+func Ge[T any](lhs Expression[T], rhs T) Condition {
+	return &ge[T]{lhs, rhs}
+}
+
+func (c *ge[T]) Check(s *st.State) bool {
+	domain := c.lhs.Domain()
+	return !domain.Less(c.lhs.Eval(s), c.rhs)
+}
+
+func (c *ge[T]) Restrict(generator *gen.StateGenerator) {
+	c.lhs.Restrict(c.rhs, generator)
+}
+
+func (c *ge[T]) EnumerateTestCases(generator *gen.StateGenerator, consumer func(*gen.StateGenerator)) {
+	domain := c.lhs.Domain()
+	for _, value := range domain.Samples(c.rhs) {
+		clone := generator.Clone()
+		c.lhs.Restrict(value, clone)
+		consumer(clone)
+	}
+}
+
+func (c *ge[T]) String() string {
+	return fmt.Sprintf("%s ≥ %v", c.lhs, c.rhs)
+}

--- a/go/ct/rlz/conditions_test.go
+++ b/go/ct/rlz/conditions_test.go
@@ -1,0 +1,76 @@
+package rlz
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/ct"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+)
+
+func TestCondition_Check(t *testing.T) {
+	newStateWithStatusAndPc := func(status st.StatusCode, pc uint16) *st.State {
+		state := st.NewState(st.NewCode([]byte{}))
+		state.Status = status
+		state.Pc = pc
+		return state
+	}
+
+	newStateWithPc := func(pc uint16) *st.State {
+		state := st.NewState(st.NewCode([]byte{}))
+		state.Pc = pc
+		return state
+	}
+
+	tests := []struct {
+		condition Condition
+		valid     *st.State
+		invalid   *st.State
+	}{
+		{Eq(Pc(), ct.NewU256(42)), newStateWithPc(42), newStateWithPc(41)},
+		{Ne(Pc(), ct.NewU256(42)), newStateWithPc(41), newStateWithPc(42)},
+		{Lt(Pc(), ct.NewU256(42)), newStateWithPc(41), newStateWithPc(42)},
+		{Lt(Pc(), ct.NewU256(42)), newStateWithPc(41), newStateWithPc(43)},
+		{Le(Pc(), ct.NewU256(42)), newStateWithPc(41), newStateWithPc(43)},
+		{Le(Pc(), ct.NewU256(42)), newStateWithPc(42), newStateWithPc(43)},
+		{Le(Pc(), ct.NewU256(42)), newStateWithPc(42), newStateWithPc(44)},
+		{Gt(Pc(), ct.NewU256(42)), newStateWithPc(43), newStateWithPc(42)},
+		{Gt(Pc(), ct.NewU256(42)), newStateWithPc(43), newStateWithPc(41)},
+		{Ge(Pc(), ct.NewU256(42)), newStateWithPc(42), newStateWithPc(41)},
+		{Ge(Pc(), ct.NewU256(42)), newStateWithPc(43), newStateWithPc(41)},
+		{Ge(Pc(), ct.NewU256(42)), newStateWithPc(43), newStateWithPc(40)},
+		{And(Eq(Status(), st.Reverted), Eq(Pc(), ct.NewU256(42))), newStateWithStatusAndPc(st.Reverted, 42), newStateWithStatusAndPc(st.Returned, 42)},
+		{And(Eq(Status(), st.Reverted), Eq(Pc(), ct.NewU256(42))), newStateWithStatusAndPc(st.Reverted, 42), newStateWithStatusAndPc(st.Reverted, 41)},
+	}
+
+	for _, test := range tests {
+		if !test.condition.Check(test.valid) {
+			t.Errorf("Condition %v should be valid for\n%v", test.condition, test.valid)
+		}
+		if test.condition.Check(test.invalid) {
+			t.Errorf("Condition %v should not be valid for\n%v", test.condition, test.invalid)
+		}
+	}
+}
+
+func TestCondition_String(t *testing.T) {
+	tests := []struct {
+		condition Condition
+		result    string
+	}{
+		{And(), "true"},
+		{And(And(), And()), "true"},
+		{Eq(Pc(), ct.NewU256(42)), "PC = 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
+		{Ne(Pc(), ct.NewU256(42)), "PC ≠ 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
+		{Lt(Pc(), ct.NewU256(42)), "PC < 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
+		{Le(Pc(), ct.NewU256(42)), "PC ≤ 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
+		{Gt(Pc(), ct.NewU256(42)), "PC > 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
+		{Ge(Pc(), ct.NewU256(42)), "PC ≥ 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
+		{And(Eq(Status(), st.Running), Eq(Status(), st.Failed)), "status = running ∧ status = failed"},
+	}
+
+	for _, test := range tests {
+		if got, want := test.condition.String(), test.result; got != want {
+			t.Errorf("unexpected print, wanted %s, got %s", want, got)
+		}
+	}
+}

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -1,0 +1,204 @@
+package rlz
+
+import (
+	"math"
+
+	"github.com/Fantom-foundation/Tosca/go/ct"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+)
+
+// Domain represents the domain of values for a given type.
+type Domain[T any] interface {
+	Equal(T, T) bool
+	Less(T, T) bool
+	Predecessor(T) T
+	Successor(T) T
+	SomethingNotEqual(T) T
+	Samples(T) []T
+	SamplesForAll([]T) []T
+}
+
+////////////////////////////////////////////////////////////
+// Bool
+
+type boolDomain struct{}
+
+func (boolDomain) Equal(a bool, b bool) bool { return a == b }
+func (boolDomain) Less(a bool, b bool) bool  { panic("not useful") }
+func (boolDomain) Predecessor(a bool) bool   { panic("not useful") }
+func (boolDomain) Successor(a bool) bool     { panic("not useful") }
+
+func (boolDomain) SomethingNotEqual(a bool) bool {
+	return !a
+}
+
+func (boolDomain) Samples(bool) []bool {
+	return []bool{false, true}
+}
+
+func (boolDomain) SamplesForAll(_ []bool) []bool {
+	return []bool{false, true}
+}
+
+////////////////////////////////////////////////////////////
+// uint16
+
+type uint16Domain struct{}
+
+func (uint16Domain) Equal(a uint16, b uint16) bool     { return a == b }
+func (uint16Domain) Less(a uint16, b uint16) bool      { return a < b }
+func (uint16Domain) Predecessor(a uint16) uint16       { return a - 1 }
+func (uint16Domain) Successor(a uint16) uint16         { return a + 1 }
+func (uint16Domain) SomethingNotEqual(a uint16) uint16 { return a + 1 }
+
+func (d uint16Domain) Samples(a uint16) []uint16 {
+	return d.SamplesForAll([]uint16{a})
+}
+
+func (uint16Domain) SamplesForAll(as []uint16) []uint16 {
+	res := []uint16{0, ^uint16(0)}
+
+	// Test every element off by one.
+	for _, a := range as {
+		res = append(res, a-1)
+		res = append(res, a)
+		res = append(res, a+1)
+	}
+
+	// Add all powers of 2.
+	for i := 0; i < 16; i++ {
+		res = append(res, uint16(1<<i))
+	}
+
+	// TODO: consider removing duplicates.
+
+	return res
+}
+
+////////////////////////////////////////////////////////////
+// uint64
+
+type uint64Domain struct{}
+
+func (uint64Domain) Equal(a uint64, b uint64) bool     { return a == b }
+func (uint64Domain) Less(a uint64, b uint64) bool      { return a < b }
+func (uint64Domain) Predecessor(a uint64) uint64       { return a - 1 }
+func (uint64Domain) Successor(a uint64) uint64         { return a + 1 }
+func (uint64Domain) SomethingNotEqual(a uint64) uint64 { return a + 1 }
+
+func (d uint64Domain) Samples(a uint64) []uint64 {
+	return d.SamplesForAll([]uint64{a})
+}
+
+func (uint64Domain) SamplesForAll(as []uint64) []uint64 {
+	res := []uint64{0, ^uint64(0)}
+
+	// Test every element off by one.
+	for _, a := range as {
+		res = append(res, a-1)
+		res = append(res, a)
+		res = append(res, a+1)
+	}
+
+	// Add all powers of 2.
+	for i := 0; i < 64; i++ {
+		res = append(res, uint64(1<<i))
+	}
+
+	// TODO: consider removing duplicates.
+
+	return res
+}
+
+////////////////////////////////////////////////////////////
+// U256
+
+type u256Domain struct{}
+
+func (u256Domain) Equal(a ct.U256, b ct.U256) bool { return a.Eq(b) }
+func (u256Domain) Less(a ct.U256, b ct.U256) bool  { return a.Lt(b) }
+func (u256Domain) Predecessor(a ct.U256) ct.U256   { return a.Sub(ct.NewU256(1)) }
+func (u256Domain) Successor(a ct.U256) ct.U256     { return a.Add(ct.NewU256(1)) }
+
+func (u256Domain) SomethingNotEqual(a ct.U256) ct.U256 {
+	return a.Add(ct.NewU256(1))
+}
+
+func (d u256Domain) Samples(a ct.U256) []ct.U256 {
+	return d.SamplesForAll([]ct.U256{a})
+}
+
+func (d u256Domain) SamplesForAll(as []ct.U256) []ct.U256 {
+	res := []ct.U256{}
+
+	// Test every element off by one.
+	for _, a := range as {
+		res = append(res, d.Predecessor(a))
+		res = append(res, a)
+		res = append(res, d.Successor(a))
+	}
+
+	// Add more interesting values.
+	res = append(res, NumericParameter{}.SampleValues()...)
+
+	// TODO: consider removing duplicates.
+
+	return res
+}
+
+////////////////////////////////////////////////////////////
+// st.Status
+
+type statusCodeDomain struct{}
+
+func (statusCodeDomain) Equal(a st.StatusCode, b st.StatusCode) bool { return a == b }
+func (statusCodeDomain) Less(a st.StatusCode, b st.StatusCode) bool  { panic("not useful") }
+func (statusCodeDomain) Predecessor(a st.StatusCode) st.StatusCode   { panic("not useful") }
+func (statusCodeDomain) Successor(a st.StatusCode) st.StatusCode     { panic("not useful") }
+
+func (statusCodeDomain) SomethingNotEqual(a st.StatusCode) st.StatusCode {
+	if a == st.Running {
+		return st.Stopped
+	}
+	return st.Running
+}
+
+func (statusCodeDomain) Samples(a st.StatusCode) []st.StatusCode {
+	return []st.StatusCode{st.Running, st.Stopped, st.Returned, st.Reverted, st.Failed}
+}
+
+func (statusCodeDomain) SamplesForAll(a []st.StatusCode) []st.StatusCode {
+	return []st.StatusCode{st.Running, st.Stopped, st.Returned, st.Reverted, st.Failed}
+}
+
+////////////////////////////////////////////////////////////
+// Program Counter
+
+type pcDomain struct{}
+
+func (pcDomain) Equal(a ct.U256, b ct.U256) bool     { return a.Eq(b) }
+func (pcDomain) Less(a ct.U256, b ct.U256) bool      { return a.Lt(b) }
+func (pcDomain) Predecessor(a ct.U256) ct.U256       { return a.Sub(ct.NewU256(1)) }
+func (pcDomain) Successor(a ct.U256) ct.U256         { return a.Add(ct.NewU256(1)) }
+func (pcDomain) SomethingNotEqual(a ct.U256) ct.U256 { return a.Add(ct.NewU256(1)) }
+
+func (d pcDomain) Samples(a ct.U256) []ct.U256 {
+	return d.SamplesForAll([]ct.U256{a})
+}
+
+func (pcDomain) SamplesForAll(as []ct.U256) []ct.U256 {
+	pcs := []uint16{}
+	for _, a := range as {
+		if a.IsUint64() && a.Uint64() <= uint64(math.MaxUint16) {
+			pcs = append(pcs, uint16(a.Uint64()))
+		}
+	}
+
+	pcs = uint16Domain{}.SamplesForAll(pcs)
+
+	res := make([]ct.U256, 0, len(pcs))
+	for _, cur := range pcs {
+		res = append(res, ct.NewU256(uint64(cur)))
+	}
+	return res
+}

--- a/go/ct/rlz/expressions.go
+++ b/go/ct/rlz/expressions.go
@@ -1,0 +1,73 @@
+package rlz
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/Fantom-foundation/Tosca/go/ct"
+	"github.com/Fantom-foundation/Tosca/go/ct/gen"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+)
+
+type Expression[T any] interface {
+	Domain() Domain[T]
+
+	// Eval evaluates this expression on the given state.
+	Eval(*st.State) T
+
+	// Restrict applies constraints to the given generator such that this
+	// expression evaluates to the given value when invoked on the generated
+	// states.
+	Restrict(value T, generator *gen.StateGenerator)
+
+	fmt.Stringer
+}
+
+////////////////////////////////////////////////////////////
+// st.Status
+
+type status struct{}
+
+func Status() Expression[st.StatusCode] {
+	return status{}
+}
+
+func (status) Domain() Domain[st.StatusCode] { return statusCodeDomain{} }
+
+func (status) Eval(s *st.State) st.StatusCode {
+	return s.Status
+}
+
+func (status) Restrict(status st.StatusCode, generator *gen.StateGenerator) {
+	generator.SetStatus(status)
+}
+
+func (status) String() string {
+	return "status"
+}
+
+////////////////////////////////////////////////////////////
+// Program Counter
+
+type pc struct{}
+
+func Pc() Expression[ct.U256] {
+	return pc{}
+}
+
+func (pc) Domain() Domain[ct.U256] { return pcDomain{} }
+
+func (pc) Eval(s *st.State) ct.U256 {
+	return ct.NewU256(uint64(s.Pc))
+}
+
+func (pc) Restrict(pc ct.U256, generator *gen.StateGenerator) {
+	if !pc.IsUint64() || pc.Uint64() > uint64(math.MaxUint16) {
+		panic("invalid value for PC")
+	}
+	generator.SetPc(uint16(pc.Uint64()))
+}
+
+func (pc) String() string {
+	return "PC"
+}

--- a/go/ct/rlz/expressions_test.go
+++ b/go/ct/rlz/expressions_test.go
@@ -1,0 +1,53 @@
+package rlz
+
+import (
+	"testing"
+
+	"pgregory.net/rand"
+
+	"github.com/Fantom-foundation/Tosca/go/ct"
+	"github.com/Fantom-foundation/Tosca/go/ct/gen"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+)
+
+func TestExpression_StatusEval(t *testing.T) {
+	state := st.NewState(st.NewCode([]byte{}))
+	state.Status = st.Reverted
+	if Status().Eval(state) != st.Reverted {
+		t.Fail()
+	}
+}
+
+func TestExpression_StatusRestrict(t *testing.T) {
+	generator := gen.NewStateGenerator()
+	Status().Restrict(st.Reverted, generator)
+
+	state, err := generator.Generate(rand.New(0))
+	if err != nil {
+		t.Errorf("State generation failed %v", err)
+	}
+	if state.Status != st.Reverted {
+		t.Errorf("Generator was not restricted by expression")
+	}
+}
+
+func TestExpression_PcEval(t *testing.T) {
+	state := st.NewState(st.NewCode([]byte{}))
+	state.Pc = 42
+	if Pc().Eval(state) != ct.NewU256(42) {
+		t.Fail()
+	}
+}
+
+func TestExpression_PcRestrict(t *testing.T) {
+	generator := gen.NewStateGenerator()
+	Pc().Restrict(ct.NewU256(42), generator)
+
+	state, err := generator.Generate(rand.New(0))
+	if err != nil {
+		t.Errorf("State generation failed %v", err)
+	}
+	if state.Pc != 42 {
+		t.Errorf("Generator was not restricted by expression")
+	}
+}

--- a/go/ct/rlz/parameters.go
+++ b/go/ct/rlz/parameters.go
@@ -1,0 +1,31 @@
+package rlz
+
+import (
+	"github.com/Fantom-foundation/Tosca/go/ct"
+)
+
+type Parameter interface {
+	Samples(example ct.U256) []ct.U256
+}
+
+type NumericParameter struct{}
+
+func (n NumericParameter) Samples(ct.U256) []ct.U256 {
+	return n.SampleValues()
+}
+
+func (NumericParameter) SampleValues() []ct.U256 {
+	return []ct.U256{
+		ct.NewU256(0),
+		ct.NewU256(1),
+		ct.NewU256(1 << 8),
+		ct.NewU256(1 << 16),
+		ct.NewU256(1 << 32),
+		ct.NewU256(1 << 48),
+		ct.NewU256(1).Shl(ct.NewU256(64)),
+		ct.NewU256(1).Shl(ct.NewU256(128)),
+		ct.NewU256(1).Shl(ct.NewU256(192)),
+		ct.NewU256(1).Shl(ct.NewU256(255)),
+		ct.NewU256(0).Not(),
+	}
+}

--- a/go/ct/rlz/rules.go
+++ b/go/ct/rlz/rules.go
@@ -1,0 +1,43 @@
+package rlz
+
+import (
+	"errors"
+
+	"pgregory.net/rand"
+
+	"github.com/Fantom-foundation/Tosca/go/ct/gen"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+)
+
+type Rule struct {
+	Name      string
+	Condition Condition
+}
+
+// GenerateSatisfyingState produces an st.State satisfying this Rule.
+func (rule *Rule) GenerateSatisfyingState(rnd *rand.Rand) (*st.State, error) {
+	generator := gen.NewStateGenerator()
+	rule.Condition.Restrict(generator)
+	return generator.Generate(rnd)
+}
+
+// EnumerateTestCases generates interesting st.States according to this Rule.
+// Each valid st.State is passed to the given consume function.
+func (rule *Rule) EnumerateTestCases(rnd *rand.Rand, consume func(s *st.State)) error {
+	var generatorErrors []error
+
+	generator := gen.NewStateGenerator()
+	rule.Condition.EnumerateTestCases(generator, func(g *gen.StateGenerator) {
+		state, err := g.Generate(rnd)
+		if errors.Is(err, gen.ErrUnsatisfiable) {
+			return // ignored
+		}
+		if err != nil {
+			generatorErrors = append(generatorErrors, err)
+			return
+		}
+		consume(state)
+	})
+
+	return errors.Join(generatorErrors...)
+}

--- a/go/ct/rlz/rules_test.go
+++ b/go/ct/rlz/rules_test.go
@@ -1,0 +1,66 @@
+package rlz
+
+import (
+	"testing"
+
+	"pgregory.net/rand"
+
+	"github.com/Fantom-foundation/Tosca/go/ct"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+)
+
+func TestRule_GenerateSatisfyingState(t *testing.T) {
+	tests := []Condition{
+		And(), // = anything
+		Eq(Status(), st.Failed),
+		Eq(Pc(), ct.NewU256(42)),
+		And(Eq(Status(), st.Failed), Eq(Pc(), ct.NewU256(42))),
+	}
+
+	rnd := rand.New(0)
+
+	for _, test := range tests {
+		rule := Rule{Condition: test}
+		state, err := rule.GenerateSatisfyingState(rnd)
+		if err != nil {
+			t.Errorf("Failed to generate state: %v", err)
+		}
+		if !test.Check(state) {
+			t.Errorf("Generated state does not satisfy condition %v: %v", test, &state)
+		}
+	}
+}
+
+func TestRule_EnumerateTestCases(t *testing.T) {
+	tests := []Condition{
+		And(), // = anything
+		Eq(Status(), st.Failed),
+		Eq(Pc(), ct.NewU256(42)),
+		And(Eq(Status(), st.Failed), Eq(Pc(), ct.NewU256(42))),
+	}
+
+	rnd := rand.New(0)
+
+	for _, test := range tests {
+		matches := 0
+		misses := 0
+
+		rule := Rule{Condition: test}
+		err := rule.EnumerateTestCases(rnd, func(sample *st.State) {
+			if test.Check(sample) {
+				matches++
+			} else {
+				misses++
+			}
+		})
+		if err != nil {
+			t.Errorf("EnumerateTestCases failed %v", err)
+		}
+		if matches == 0 {
+			t.Errorf("none of the %d generated samples for %v is a match", matches+misses, test)
+		}
+		if matches+misses > 1 && misses == 0 {
+			t.Errorf("none of the %d generated samples for %v is a miss", matches+misses, test)
+		}
+	}
+}

--- a/go/ct/u256.go
+++ b/go/ct/u256.go
@@ -39,6 +39,10 @@ func (i U256) IsUint64() bool {
 	return i.internal.IsUint64()
 }
 
+func (i U256) Uint64() uint64 {
+	return i.internal.Uint64()
+}
+
 func (i U256) Bytes32be() [32]byte {
 	return i.internal.Bytes32()
 }


### PR DESCRIPTION
This PR adopts parts of the CT prototype's `Rule` definition.
It currently covers:

- Rule Definition
  - *no parameters*
- Condition Interface
- Condition Implementation
  - Conjunction
  - Equal
  - Not Equal
  - Less Than
  - Less Equal
  - Greater Than
  - Greater Equal
- Domain Interface
- Domain Implementation
  - `bool`
  - `uint16`
  - `uint64`
  - `U256`
  - `st.Status`
  - Program counter
- Parameter Interface
- Parameter Sampling
  - `U256`
- Expression Interface
- Expression Implementation
  - `st.Status`
  - Program counter