### PR TITLE
ct: State conversion

### DIFF
--- a/go/ct/common/u256.go
+++ b/go/ct/common/u256.go
@@ -54,6 +54,10 @@ func (i U256) Uint64() uint64 {
 	return i.internal.Uint64()
 }
 
+func (i U256) Uint256() uint256.Int {
+	return i.internal
+}
+
 func (i U256) Bytes32be() [32]byte {
 	return i.internal.Bytes32()
 }

--- a/go/ct/st/code.go
+++ b/go/ct/st/code.go
@@ -83,6 +83,19 @@ func (c *Code) Eq(other *Code) bool {
 	return bytes.Equal(c.code, other.code)
 }
 
+func (a *Code) Diff(b *Code) (res []string) {
+	if a.Length() != b.Length() {
+		res = append(res, fmt.Sprintf("Different code size: %v vs %v", a.Length(), b.Length()))
+		return
+	}
+	for i := 0; i < a.Length(); i++ {
+		if aValue, bValue := a.code[i], b.code[i]; aValue != bValue {
+			res = append(res, fmt.Sprintf("Different code/data at position %d: 0x%02x vs 0x%02x", i, aValue, bValue))
+		}
+	}
+	return
+}
+
 func (c *Code) CopyTo(dst []byte) int {
 	return copy(dst, c.code)
 }

--- a/go/ct/st/state.go
+++ b/go/ct/st/state.go
@@ -159,7 +159,7 @@ func (s *State) Diff(o *State) []string {
 	}
 
 	if !s.Code.Eq(o.Code) {
-		res = append(res, fmt.Sprintf("Different code: size %d vs %d", len(s.Code.code), len(o.Code.code)))
+		res = append(res, s.Code.Diff(o.Code)...)
 	}
 
 	if !s.Stack.Eq(o.Stack) {

--- a/go/ct/st/state_test.go
+++ b/go/ct/st/state_test.go
@@ -321,7 +321,7 @@ func TestState_DiffMismatch(t *testing.T) {
 	s1.Gas = 7
 	s1.Stack.Push(NewU256(42))
 
-	s2 := NewState(NewCode([]byte{byte(PUSH2), 7, 4, byte(ADD), byte(STOP)}))
+	s2 := NewState(NewCode([]byte{byte(PUSH2), 7, 5, byte(ADD)}))
 	s2.Status = Running
 	s2.Revision = London
 	s2.Pc = 3

--- a/go/vm/lfvm/ct.go
+++ b/go/vm/lfvm/ct.go
@@ -1,0 +1,219 @@
+package lfvm
+
+import (
+	"fmt"
+	"math/big"
+
+	ct "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/holiman/uint256"
+)
+
+////////////////////////////////////////////////////////////
+// lfvm -> ct : helper functions
+
+func convertLfvmStatusToCtStatus(status Status) (st.StatusCode, error) {
+	switch status {
+	case RUNNING:
+		return st.Running, nil
+	case STOPPED:
+		return st.Stopped, nil
+	case REVERTED:
+		return st.Reverted, nil
+	case RETURNED:
+		return st.Returned, nil
+	case SUICIDED:
+		// Suicide is not yet modeled by the CT, and for now it just maps to the STOPPED status.
+		return st.Stopped, nil
+	case INVALID_INSTRUCTION:
+		return st.Failed, nil
+	case OUT_OF_GAS:
+		return st.Failed, nil
+	case SEGMENTATION_FAULT:
+		return st.Failed, nil
+	case ERROR:
+		return st.Failed, nil
+	default:
+		return st.Failed, fmt.Errorf("unable to convert lfvm status %v to ct status", status)
+	}
+}
+
+func convertLfvmRevisionToCtRevision(ctx *context) (st.Revision, error) {
+	if ctx.isBerlin && !ctx.isLondon {
+		return st.Berlin, nil
+	} else if !ctx.isBerlin && ctx.isLondon {
+		return st.London, nil
+	} else if !ctx.isBerlin && !ctx.isLondon {
+		return st.Istanbul, nil
+	} else {
+		return st.NumRevisions, fmt.Errorf("invalid revision, both berlin and london set")
+	}
+}
+
+func convertLfvmPcToCtPc(ctx *context, originalCode *st.Code) (uint16, error) {
+	code := make([]byte, originalCode.Length())
+	originalCode.CopyTo(code)
+	pcMap, err := GenPcMapWithoutSuperInstructions(code)
+	if err != nil {
+		return 0, err
+	}
+	pc, ok := pcMap.lfvmToEvm[uint16(ctx.pc)]
+	if !ok {
+		return 0, fmt.Errorf("unable to convert lfvm pc %d to evm pc", ctx.pc)
+	}
+	return pc, nil
+}
+
+func convertLfvmStackToCtStack(ctx *context) *st.Stack {
+	stack := st.NewStack()
+	for i := ctx.stack.len() - 1; i >= 0; i-- {
+		val := ctx.stack.Data()[i]
+		stack.Push(ct.NewU256(val[3], val[2], val[1], val[0]))
+	}
+	return stack
+}
+
+////////////////////////////////////////////////////////////
+// lfvm -> ct
+
+func ConvertLfvmContextToCtState(ctx *context, originalCode *st.Code) (*st.State, error) {
+	status, err := convertLfvmStatusToCtStatus(ctx.status)
+	if err != nil {
+		return nil, err
+	}
+
+	pc, err := convertLfvmPcToCtPc(ctx, originalCode)
+	if err != nil {
+		return nil, err
+	}
+
+	revision, err := convertLfvmRevisionToCtRevision(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	state := st.State{
+		Status:   status,
+		Revision: revision,
+		Pc:       pc,
+		Gas:      ctx.contract.Gas,
+		Code:     originalCode,
+		Stack:    convertLfvmStackToCtStack(ctx),
+	}
+
+	return &state, nil
+}
+
+////////////////////////////////////////////////////////////
+// ct -> lfvm : helper functions
+
+func convertCtPcToLfvmPc(state *st.State) (int32, error) {
+	code := make([]byte, state.Code.Length())
+	state.Code.CopyTo(code)
+	pcMap, err := GenPcMapWithoutSuperInstructions(code)
+	if err != nil {
+		return 0, err
+	}
+	pc, ok := pcMap.evmToLfvm[state.Pc]
+	if !ok {
+		return 0, fmt.Errorf("unable to convert evm pc %d to lfvm pc", state.Pc)
+	}
+	return int32(pc), nil
+}
+
+func convertCtCodeToLfvmCode(state *st.State) (Code, error) {
+	code := make([]byte, state.Code.Length())
+	state.Code.CopyTo(code)
+	return convert(code, false)
+}
+
+func convertCtStatusToLfvmStatus(state *st.State) (Status, error) {
+	switch state.Status {
+	case st.Running:
+		return RUNNING, nil
+	case st.Stopped:
+		return STOPPED, nil
+	case st.Returned:
+		return RETURNED, nil
+	case st.Reverted:
+		return REVERTED, nil
+	case st.Failed:
+		return ERROR, nil
+	default:
+		return ERROR, fmt.Errorf("unable to convert ct status %v to lfvm status", state.Status)
+	}
+}
+
+func convertCtStackToLfvmStack(state *st.State) *Stack {
+	stack := NewStack()
+	for i := 0; i < state.Stack.Size(); i++ {
+		val := state.Stack.Get(i).Uint256()
+		stack.push(&val)
+	}
+	return stack
+}
+
+func convertCtRevisionToLfvmRevision(revision st.Revision, ctx *context) error {
+	switch revision {
+	case st.Istanbul:
+		// True by default in context.
+	case st.Berlin:
+		ctx.isBerlin = true
+	case st.London:
+		ctx.isLondon = true
+	default:
+		return fmt.Errorf("failed to convert revision: %v", revision)
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////
+// ct -> lfvm
+
+func ConvertCtStateToLfvmContext(state *st.State) (*context, error) {
+	// Create a dummy contract.
+	addr := vm.AccountRef{}
+	contract := vm.NewContract(addr, addr, big.NewInt(0), state.Gas)
+
+	pc, err := convertCtPcToLfvmPc(state)
+	if err != nil {
+		return nil, err
+	}
+
+	status, err := convertCtStatusToLfvmStatus(state)
+	if err != nil {
+		return nil, err
+	}
+
+	code, err := convertCtCodeToLfvmCode(state)
+	if err != nil {
+		return nil, err
+	}
+
+	data := []byte{}
+
+	// Create execution context.
+	ctx := context{
+		evm:      &vm.EVM{StateDB: nil},
+		pc:       pc,
+		stack:    convertCtStackToLfvmStack(state),
+		memory:   NewMemory(),
+		stateDB:  nil,
+		status:   status,
+		contract: contract,
+		code:     code,
+		data:     data,
+		callsize: *uint256.NewInt(uint64(len(data))),
+		readOnly: false,
+		isBerlin: state.Revision == st.Berlin,
+		isLondon: state.Revision == st.London,
+	}
+
+	err = convertCtRevisionToLfvmRevision(state.Revision, &ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ctx, nil
+}

--- a/go/vm/lfvm/ct_test.go
+++ b/go/vm/lfvm/ct_test.go
@@ -1,0 +1,486 @@
+package lfvm
+
+import (
+	"testing"
+
+	ct "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+)
+
+////////////////////////////////////////////////////////////
+// ct -> lfvm
+
+func getEmptyState() *st.State {
+	return st.NewState(st.NewCode([]byte{}))
+}
+
+func TestConvertToLfvm_StatusCode(t *testing.T) {
+	state := getEmptyState()
+	state.Status = st.Stopped
+
+	ctx, err := ConvertCtStateToLfvmContext(state)
+
+	if err != nil {
+		t.Fatalf("failed to convert ct state to lfvm context: %v", err)
+	}
+
+	if want, got := STOPPED, ctx.status; want != got {
+		t.Errorf("unexpected status, wanted %v, got %v", want, got)
+	}
+}
+
+func TestConvertToLfvm_InvalidStatusCode(t *testing.T) {
+	state := getEmptyState()
+	state.Status = st.NumStatusCodes
+
+	ctx, err := ConvertCtStateToLfvmContext(state)
+
+	if err == nil {
+		t.Errorf("expected invalid status, but got: %v", ctx.status)
+	}
+}
+
+func TestConvertToLfvm_Revision(t *testing.T) {
+	tests := map[string][]struct {
+		ctRevision            st.Revision
+		convertSuccess        bool
+		lfvmRevisionPredicate func(ctx *context) bool
+	}{
+		"istanbul": {{st.Istanbul, true, func(ctx *context) bool { return !ctx.isBerlin && !ctx.isLondon }}},
+		"berlin":   {{st.Berlin, true, func(ctx *context) bool { return ctx.isBerlin && !ctx.isLondon }}},
+		"london":   {{st.London, true, func(ctx *context) bool { return !ctx.isBerlin && ctx.isLondon }}},
+		"invalid":  {{st.NumRevisions, false, nil}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			for _, cur := range test {
+				state := getEmptyState()
+				state.Revision = cur.ctRevision
+
+				ctx, err := ConvertCtStateToLfvmContext(state)
+
+				if want, got := cur.convertSuccess, (err == nil); want != got {
+					t.Errorf("unexpected conversion error: wanted %v, got %v", want, got)
+				}
+
+				if err == nil {
+					if !cur.lfvmRevisionPredicate(ctx) {
+						t.Errorf("revision check for %v failed", cur.ctRevision)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestConvertToLfvm_Pc(t *testing.T) {
+	tests := map[string][]struct {
+		evmCode []byte
+		evmPc   uint16
+		lfvmPc  uint16
+	}{
+		"empty": {{}},
+		"pos-0": {{[]byte{byte(ct.STOP)}, 0, 0}},
+		"pos-1": {{[]byte{byte(ct.STOP), byte(ct.STOP), byte(ct.STOP)}, 1, 1}},
+		"shifted": {{[]byte{
+			byte(ct.PUSH1), 0x01,
+			byte(ct.PUSH1), 0x02,
+			byte(ct.ADD)}, 2, 1}},
+		"jumpdest": {{[]byte{
+			byte(ct.PUSH3), 0x00, 0x00, 0x06,
+			byte(ct.JUMP),
+			byte(ct.INVALID),
+			byte(ct.JUMPDEST)},
+			6, 6}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			for _, cur := range test {
+				code := st.NewCode(cur.evmCode)
+				state := st.NewState(code)
+				state.Pc = cur.evmPc
+
+				ctx, err := ConvertCtStateToLfvmContext(state)
+
+				if err != nil {
+					t.Fatalf("failed to convert ct state to lfvm context: %v", err)
+				}
+
+				if want, got := cur.lfvmPc, uint16(ctx.pc); want != got {
+					t.Errorf("unexpected program counter, wanted %d, got %d", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestConvertToLfvm_Gas(t *testing.T) {
+	state := getEmptyState()
+	state.Gas = 777
+
+	ctx, err := ConvertCtStateToLfvmContext(state)
+
+	if err != nil {
+		t.Fatalf("failed to convert ct state to lfvm context: %v", err)
+	}
+
+	if want, got := uint64(777), ctx.contract.Gas; want != got {
+		t.Errorf("unexpected gas value, wanted %v, got %v", want, got)
+	}
+}
+
+func TestConvertToLfvm_Code(t *testing.T) {
+	tests := map[string][]struct {
+		evmCode  []byte
+		lfvmCode Code
+	}{
+		"empty": {{}},
+		"stop":  {{[]byte{byte(ct.STOP)}, Code{Instruction{STOP, 0x0000}}}},
+		"add": {{[]byte{
+			byte(ct.PUSH1), 0x01,
+			byte(ct.PUSH1), 0x02,
+			byte(ct.ADD)},
+			Code{Instruction{PUSH1, 0x0100},
+				Instruction{PUSH1, 0x0200},
+				Instruction{ADD, 0x0000}}}},
+		"jump": {{[]byte{
+			byte(ct.PUSH1), 0x04,
+			byte(ct.JUMP),
+			byte(ct.INVALID),
+			byte(ct.JUMPDEST)},
+			Code{Instruction{PUSH1, 0x0400},
+				Instruction{JUMP, 0x0000},
+				Instruction{INVALID, 0x0000},
+				Instruction{JUMP_TO, 0x0004},
+				Instruction{JUMPDEST, 0x0000}}}},
+		"jumpdest": {{[]byte{
+			byte(ct.PUSH3), 0x00, 0x00, 0x06,
+			byte(ct.JUMP),
+			byte(ct.INVALID),
+			byte(ct.JUMPDEST)},
+			Code{Instruction{PUSH3, 0x0000},
+				Instruction{DATA, 0x0600},
+				Instruction{JUMP, 0x0000},
+				Instruction{INVALID, 0x0000},
+				Instruction{JUMP_TO, 0x0006},
+				Instruction{NOOP, 0x0000},
+				Instruction{JUMPDEST, 0x0000}}}},
+		"push2": {{[]byte{byte(ct.PUSH2), 0xBA, 0xAD}, Code{Instruction{PUSH2, 0xBAAD}}}},
+		"push3": {{[]byte{byte(ct.PUSH3), 0xBA, 0xAD, 0xC0}, Code{Instruction{PUSH3, 0xBAAD}, Instruction{DATA, 0xC000}}}},
+		"push31": {{[]byte{
+			byte(ct.PUSH31),
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+			0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F},
+			Code{Instruction{PUSH31, 0x0102},
+				Instruction{DATA, 0x0304},
+				Instruction{DATA, 0x0506},
+				Instruction{DATA, 0x0708},
+				Instruction{DATA, 0x090A},
+				Instruction{DATA, 0x0B0C},
+				Instruction{DATA, 0x0D0E},
+				Instruction{DATA, 0x0F10},
+				Instruction{DATA, 0x1112},
+				Instruction{DATA, 0x1314},
+				Instruction{DATA, 0x1516},
+				Instruction{DATA, 0x1718},
+				Instruction{DATA, 0x191A},
+				Instruction{DATA, 0x1B1C},
+				Instruction{DATA, 0x1D1E},
+				Instruction{DATA, 0x1F00}}}},
+		"push32": {{[]byte{
+			byte(ct.PUSH32),
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+			0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0xFF},
+			Code{Instruction{PUSH32, 0x0102},
+				Instruction{DATA, 0x0304},
+				Instruction{DATA, 0x0506},
+				Instruction{DATA, 0x0708},
+				Instruction{DATA, 0x090A},
+				Instruction{DATA, 0x0B0C},
+				Instruction{DATA, 0x0D0E},
+				Instruction{DATA, 0x0F10},
+				Instruction{DATA, 0x1112},
+				Instruction{DATA, 0x1314},
+				Instruction{DATA, 0x1516},
+				Instruction{DATA, 0x1718},
+				Instruction{DATA, 0x191A},
+				Instruction{DATA, 0x1B1C},
+				Instruction{DATA, 0x1D1E},
+				Instruction{DATA, 0x1FFF}}}},
+		"invalid": {{[]byte{byte(ct.INVALID)}, Code{Instruction{INVALID, 0x0000}}}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			for _, cur := range test {
+				code := st.NewCode(cur.evmCode)
+				state := st.NewState(code)
+				ctx, err := ConvertCtStateToLfvmContext(state)
+
+				if err != nil {
+					t.Fatalf("failed to convert ct state to lfvm context: %v", err)
+				}
+
+				want := cur.lfvmCode
+				got := ctx.code
+
+				if wantSize, gotSize := len(want), len(got); wantSize != gotSize {
+					t.Fatalf("unexpected code size, wanted %d, got %d", wantSize, gotSize)
+				}
+
+				for i := 0; i < len(got); i++ {
+					if wantInst, gotInst := want[i], got[i]; wantInst != gotInst {
+						t.Errorf("unexpected instruction, wanted %v, got %v", wantInst, gotInst)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestConvertToLfvm_Stack(t *testing.T) {
+	newLfvmStack := func(values ...ct.U256) *Stack {
+		stack := NewStack()
+		for i := len(values) - 1; i >= 0; i-- {
+			value := values[i].Uint256()
+			stack.push(&value)
+		}
+		return stack
+	}
+
+	tests := map[string][]struct {
+		ctStack   *st.Stack
+		lfvmStack *Stack
+	}{
+		"empty": {{
+			st.NewStack(),
+			newLfvmStack()}},
+		"one-element": {{
+			st.NewStack(ct.NewU256(7)),
+			newLfvmStack(ct.NewU256(7))}},
+		"two-elements": {{
+			st.NewStack(ct.NewU256(1), ct.NewU256(2)),
+			newLfvmStack(ct.NewU256(1), ct.NewU256(2))}},
+		"three-elements": {{
+			st.NewStack(ct.NewU256(1), ct.NewU256(2), ct.NewU256(3)),
+			newLfvmStack(ct.NewU256(1), ct.NewU256(2), ct.NewU256(3))}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			for _, cur := range test {
+				state := getEmptyState()
+				state.Stack = cur.ctStack
+
+				ctx, err := ConvertCtStateToLfvmContext(state)
+
+				if err != nil {
+					t.Fatalf("failed to convert ct state to lfvm context: %v", err)
+				}
+
+				if want, got := cur.lfvmStack.len(), ctx.stack.len(); want != got {
+					t.Fatalf("unexpected stack size, wanted %v, got %v", want, got)
+				}
+
+				for i := 0; i < ctx.stack.len(); i++ {
+					want := cur.lfvmStack.Data()[i]
+					got := ctx.stack.Data()[i]
+					if want != got {
+						t.Errorf("unexpected stack value, wanted %v, got %v", want, got)
+					}
+				}
+			}
+		})
+	}
+}
+
+////////////////////////////////////////////////////////////
+// lfvm -> ct
+
+func getContextWithEvmCode(code *st.Code) (*context, error) {
+	byteCode := make([]byte, code.Length())
+	code.CopyTo(byteCode)
+	lfvmCode, err := convert(byteCode, false)
+	if err != nil {
+		return nil, err
+	}
+	data := make([]byte, 0)
+	ctx := getContext(lfvmCode, data, 0, nil, 0, false, false)
+	return &ctx, nil
+}
+
+func TestConvertToCt_StatusCode(t *testing.T) {
+	ctx := getEmptyContext()
+	ctx.status = STOPPED
+
+	state, err := ConvertLfvmContextToCtState(&ctx, st.NewCode([]byte{}))
+
+	if err != nil {
+		t.Fatalf("failed to convert lfvm context to ct state: %v", err)
+	}
+
+	if want, got := st.Stopped, state.Status; want != got {
+		t.Errorf("unexpected status, wanted %v, got %v", want, got)
+	}
+}
+
+func TestConvertToCt_InvalidStatusCode(t *testing.T) {
+	ctx := getEmptyContext()
+	ctx.status = 0xFF
+
+	state, err := ConvertLfvmContextToCtState(&ctx, st.NewCode([]byte{}))
+
+	if err == nil {
+		t.Errorf("expected invalid status, but got: %v", state.Status)
+	}
+}
+
+func TestConvertToCt_Revision(t *testing.T) {
+	tests := map[string][]struct {
+		lfvmRevisionSetter func(ctx *context)
+		convertSuccess     bool
+		ctRevision         st.Revision
+	}{
+		"istanbul": {{func(ctx *context) { ctx.isBerlin = false; ctx.isLondon = false }, true, st.Istanbul}},
+		"berlin":   {{func(ctx *context) { ctx.isBerlin = true; ctx.isLondon = false }, true, st.Berlin}},
+		"london":   {{func(ctx *context) { ctx.isBerlin = false; ctx.isLondon = true }, true, st.London}},
+		"invalid":  {{func(ctx *context) { ctx.isBerlin = true; ctx.isLondon = true }, false, st.NumRevisions}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			for _, cur := range test {
+				ctx := getEmptyContext()
+				cur.lfvmRevisionSetter(&ctx)
+
+				state, err := ConvertLfvmContextToCtState(&ctx, st.NewCode([]byte{}))
+
+				if want, got := cur.convertSuccess, (err == nil); want != got {
+					t.Errorf("unexpected conversion error: wanted %v, got %v", want, got)
+				}
+
+				if err == nil {
+					if want, got := cur.ctRevision, state.Revision; want != got {
+						t.Errorf("failed to convert revision: wanted %v, got %v", want, got)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestConvertToCt_Pc(t *testing.T) {
+	tests := map[string][]struct {
+		evmCode []byte
+		lfvmPc  uint16
+		evmPc   uint16
+	}{
+		"empty": {{}},
+		"pos-0": {{[]byte{byte(ct.STOP)}, 0, 0}},
+		"pos-1": {{[]byte{byte(ct.STOP), byte(ct.STOP), byte(ct.STOP)}, 1, 1}},
+		"shifted": {{[]byte{
+			byte(ct.PUSH1), 0x01,
+			byte(ct.PUSH1), 0x02,
+			byte(ct.ADD)}, 1, 2}},
+		"jumpdest": {{[]byte{
+			byte(ct.PUSH3), 0x00, 0x00, 0x06,
+			byte(ct.JUMP),
+			byte(ct.INVALID),
+			byte(ct.JUMPDEST)},
+			6, 6}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			for _, cur := range test {
+				origCode := st.NewCode(cur.evmCode)
+				ctx, err := getContextWithEvmCode(origCode)
+				if err != nil {
+					t.Fatalf("failed to create lfvm context with code: %v", err)
+				}
+
+				ctx.pc = int32(cur.lfvmPc)
+
+				state, err := ConvertLfvmContextToCtState(ctx, origCode)
+
+				if err != nil {
+					t.Fatalf("failed to convert lfvm context to ct state: %v", err)
+				}
+
+				if want, got := cur.evmPc, state.Pc; want != got {
+					t.Errorf("unexpected program counter, wanted %d, got %d", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestConvertToCt_Gas(t *testing.T) {
+	ctx := getEmptyContext()
+	ctx.contract.Gas = 777
+
+	state, err := ConvertLfvmContextToCtState(&ctx, st.NewCode([]byte{}))
+
+	if err != nil {
+		t.Fatalf("failed to convert lfvm context to ct state: %v", err)
+	}
+
+	if want, got := uint64(777), state.Gas; want != got {
+		t.Errorf("unexpected gas value, wanted %v, got %v", want, got)
+	}
+}
+
+func TestConvertToCt_Stack(t *testing.T) {
+	newLfvmStack := func(values ...ct.U256) *Stack {
+		stack := NewStack()
+		for i := len(values) - 1; i >= 0; i-- {
+			value := values[i].Uint256()
+			stack.push(&value)
+		}
+		return stack
+	}
+
+	tests := map[string][]struct {
+		lfvmStack *Stack
+		ctStack   *st.Stack
+	}{
+		"empty": {{
+			newLfvmStack(),
+			st.NewStack()}},
+		"one-element": {{
+			newLfvmStack(ct.NewU256(7)),
+			st.NewStack(ct.NewU256(7))}},
+		"two-elements": {{
+			newLfvmStack(ct.NewU256(1), ct.NewU256(2)),
+			st.NewStack(ct.NewU256(1), ct.NewU256(2))}},
+		"three-elements": {{
+			newLfvmStack(ct.NewU256(1), ct.NewU256(2), ct.NewU256(3)),
+			st.NewStack(ct.NewU256(1), ct.NewU256(2), ct.NewU256(3))}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			for _, cur := range test {
+				ctx := getEmptyContext()
+				ctx.stack = cur.lfvmStack
+
+				state, err := ConvertLfvmContextToCtState(&ctx, st.NewCode([]byte{}))
+
+				if err != nil {
+					t.Fatalf("failed to convert lfvm context to ct state: %v", err)
+				}
+
+				want := cur.ctStack
+				got := state.Stack
+
+				diffs := got.Diff(want)
+
+				for _, diff := range diffs {
+					t.Errorf("%s", diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR is based on #228, so that one must be merged first.

This PR adds conversion functions to convert between the ct `State` representation and the equivalent LFVM `context` and vice versa.