### PR TITLE
ct: Add Stack implementation

### DIFF
--- a/go/ct/gen/code_test.go
+++ b/go/ct/gen/code_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCodeGenerator_UnconstrainedGeneratorCanProduceCode(t *testing.T) {
-	rnd := rand.New()
+	rnd := rand.New(0)
 	generator := NewCodeGenerator()
 	if _, err := generator.Generate(rnd); err != nil {
 		t.Fatalf("unexpected error during build: %v", err)
@@ -19,7 +19,7 @@ func TestCodeGenerator_UnconstrainedGeneratorCanProduceCode(t *testing.T) {
 func TestCodeGenerator_SetCodeSizeIsEnforced(t *testing.T) {
 	sizes := []int{0, 1, 2, 1 << 20, 1 << 23}
 
-	rnd := rand.New()
+	rnd := rand.New(0)
 	for _, size := range sizes {
 		generator := NewCodeGenerator()
 		generator.SetSize(size)
@@ -37,7 +37,7 @@ func TestCodeGenerator_ConflictingSizesAreDetected(t *testing.T) {
 	generator := NewCodeGenerator()
 	generator.SetSize(12)
 	generator.SetSize(14)
-	rnd := rand.New()
+	rnd := rand.New(0)
 	if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
 		t.Errorf("unsatisfiable constraint not detected, got %v", err)
 	}
@@ -46,7 +46,7 @@ func TestCodeGenerator_ConflictingSizesAreDetected(t *testing.T) {
 func TestCodeGenerator_NegativeCodeSizesAreDetected(t *testing.T) {
 	generator := NewCodeGenerator()
 	generator.SetSize(-12)
-	rnd := rand.New()
+	rnd := rand.New(0)
 	if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
 		t.Errorf("unsatisfiable constraint not detected, got %v", err)
 	}
@@ -56,7 +56,7 @@ func TestCodeGenerator_NonConflictingSizesAreAccepted(t *testing.T) {
 	generator := NewCodeGenerator()
 	generator.SetSize(12)
 	generator.SetSize(12)
-	rnd := rand.New()
+	rnd := rand.New(0)
 	if _, err := generator.Generate(rnd); err != nil {
 		t.Errorf("generation failed: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestCodeGenerator_OperationConstraintsAreEnforced(t *testing.T) {
 		"wide":             {{2, st.PUSH1}, {20000, st.PUSH1}},
 	}
 
-	rnd := rand.New()
+	rnd := rand.New(0)
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			generator := NewCodeGenerator()
@@ -121,7 +121,7 @@ func TestCodeGenerator_ImpossibleConstraintsAreDetected(t *testing.T) {
 		"add_operation_making_other_operation_data": {size: 40, ops: []op{{16, st.PUSH32}, {0, st.PUSH32}}},
 	}
 
-	rnd := rand.New()
+	rnd := rand.New(0)
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			generator := NewCodeGenerator()
@@ -139,7 +139,7 @@ func TestCodeGenerator_ImpossibleConstraintsAreDetected(t *testing.T) {
 	}
 }
 
-func TestCodeGenerator_CloneCopiesBuilderState(t *testing.T) {
+func TestCodeGenerator_CloneCopiesGeneratorState(t *testing.T) {
 	original := NewCodeGenerator()
 	original.SetSize(12)
 	original.SetOperation(4, st.PUSH2)
@@ -175,7 +175,7 @@ func TestCodeGenerator_ClonesAreIndependent(t *testing.T) {
 	}
 }
 
-func TestCodeGenerator_ClonesCanBeUsedToResetBuilder(t *testing.T) {
+func TestCodeGenerator_ClonesCanBeUsedToResetGenerator(t *testing.T) {
 	generator := NewCodeGenerator()
 	generator.SetOperation(4, st.STOP)
 

--- a/go/ct/gen/stack.go
+++ b/go/ct/gen/stack.go
@@ -1,0 +1,133 @@
+package gen
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"pgregory.net/rand"
+
+	"github.com/Fantom-foundation/Tosca/go/ct"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+)
+
+type StackGenerator struct {
+	sizes  []int
+	values []valueConstraint
+}
+
+type valueConstraint struct {
+	pos   int
+	value ct.U256
+}
+
+func (c *valueConstraint) Less(o *valueConstraint) bool {
+	if c.pos != o.pos {
+		return c.pos < o.pos
+	}
+	return c.value.Lt(o.value)
+}
+
+func NewStackGenerator() *StackGenerator {
+	return &StackGenerator{}
+}
+
+func (g *StackGenerator) SetSize(size int) {
+	if !slices.Contains(g.sizes, size) {
+		g.sizes = append(g.sizes, size)
+	}
+}
+
+func (g *StackGenerator) SetValue(pos int, value ct.U256) {
+	v := valueConstraint{pos, value}
+	if !slices.Contains(g.values, v) {
+		g.values = append(g.values, v)
+	}
+}
+
+func (g *StackGenerator) Generate(rnd *rand.Rand) (*st.Stack, error) {
+	// Pick a size
+	size := 0
+	if len(g.sizes) > 1 {
+		return nil, fmt.Errorf("%w, multiple conflicting sizes defined: %v", ErrUnsatisfiable, g.sizes)
+	} else if len(g.sizes) == 1 {
+		size = g.sizes[0]
+		if size < 0 {
+			return nil, fmt.Errorf("%w, can not produce stack with negative size %d", ErrUnsatisfiable, size)
+		}
+		if maxInValues := g.maxPositionInValues(); size <= maxInValues {
+			return nil, fmt.Errorf("%w, set stack size %d too small for max position in value constraints %d", ErrUnsatisfiable, size, maxInValues)
+		}
+	} else {
+		size = int(rnd.Int31n(5)) + g.maxPositionInValues() + 1
+	}
+	if size > 1024 {
+		return nil, fmt.Errorf("%w, can not produce stack larger than 1024 elements %d", ErrUnsatisfiable, size)
+	}
+
+	stack := st.NewStackWithSize(size)
+	stackMask := make([]bool, size)
+
+	// Apply value constraints
+	for _, value := range g.values {
+		if value.pos < 0 {
+			return nil, fmt.Errorf("%w, cannot satisfy constraint value[%d]=%v", ErrUnsatisfiable, value.pos, value.value)
+		}
+		if stackMask[value.pos] {
+			return nil, fmt.Errorf("%w, conflicting value constraints at position %d", ErrUnsatisfiable, value.pos)
+		}
+		stack.Set(value.pos, value.value)
+		stackMask[value.pos] = true
+	}
+
+	// Fill in remaining slots
+	for i, isSet := range stackMask {
+		if !isSet {
+			stack.Set(i, ct.RandU256(rnd))
+		}
+	}
+
+	return stack, nil
+}
+
+func (g *StackGenerator) maxPositionInValues() int {
+	max := -1
+	for _, value := range g.values {
+		if value.pos > max {
+			max = value.pos
+		}
+	}
+	return max
+}
+
+func (g *StackGenerator) Clone() *StackGenerator {
+	return &StackGenerator{
+		sizes:  slices.Clone(g.sizes),
+		values: slices.Clone(g.values),
+	}
+}
+
+func (g *StackGenerator) Restore(other *StackGenerator) {
+	if g == other {
+		return
+	}
+	g.sizes = slices.Clone(other.sizes)
+	g.values = slices.Clone(other.values)
+}
+
+func (g *StackGenerator) String() string {
+	var parts []string
+
+	sort.Slice(g.sizes, func(i, j int) bool { return g.sizes[i] < g.sizes[j] })
+	for _, size := range g.sizes {
+		parts = append(parts, fmt.Sprintf("size=%d", size))
+	}
+
+	sort.Slice(g.values, func(i, j int) bool { return g.values[i].Less(&g.values[j]) })
+	for _, value := range g.values {
+		parts = append(parts, fmt.Sprintf("value[%d]=%v", value.pos, value.value))
+	}
+
+	return "{" + strings.Join(parts, ",") + "}"
+}

--- a/go/ct/gen/stack_test.go
+++ b/go/ct/gen/stack_test.go
@@ -1,0 +1,180 @@
+package gen
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/ct"
+	"pgregory.net/rand"
+)
+
+func TestStackGenerator_UnconstrainedGeneratorCanProduceStack(t *testing.T) {
+	rnd := rand.New(0)
+	generator := NewStackGenerator()
+	if _, err := generator.Generate(rnd); err != nil {
+		t.Fatalf("unexpected error during build: %v", err)
+	}
+}
+
+func TestStackGenerator_SetSizeIsEnforced(t *testing.T) {
+	sizes := []int{0, 1, 2, 42}
+
+	rnd := rand.New(0)
+	for _, size := range sizes {
+		generator := NewStackGenerator()
+		generator.SetSize(size)
+		stack, err := generator.Generate(rnd)
+		if err != nil {
+			t.Fatalf("unexpected error during build: %v", err)
+		}
+		if want, got := size, stack.Size(); want != got {
+			t.Errorf("unexpected stack size, wanted %d, got %d", want, got)
+		}
+	}
+}
+
+func TestStackGenerator_NonConflictingSizesAreAccepted(t *testing.T) {
+	generator := NewStackGenerator()
+	generator.SetSize(12)
+	generator.SetSize(12)
+	rnd := rand.New(0)
+	if _, err := generator.Generate(rnd); err != nil {
+		t.Errorf("generation failed: %v", err)
+	}
+}
+
+func TestStackGenerator_ConflictingSizesAreDetected(t *testing.T) {
+	generator := NewStackGenerator()
+	generator.SetSize(12)
+	generator.SetSize(14)
+	rnd := rand.New(0)
+	if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
+		t.Errorf("unsatisfiable constraint not detected, got %v", err)
+	}
+}
+
+func TestStackGenerator_SetValueIsEnforced(t *testing.T) {
+	type value struct {
+		pos   int
+		value ct.U256
+	}
+	tests := [][]value{
+		{{0, ct.NewU256(1)}},
+		{{3, ct.NewU256(6)}},
+		{{42, ct.NewU256(21)}},
+	}
+
+	rnd := rand.New(0)
+	for _, test := range tests {
+		generator := NewStackGenerator()
+
+		for _, v := range test {
+			generator.SetValue(v.pos, v.value)
+		}
+
+		stack, err := generator.Generate(rnd)
+		if err != nil {
+			t.Fatalf("unexpected error during build: %v", err)
+		}
+
+		for _, v := range test {
+			if want, got := v.value, stack.Get(v.pos); want != got {
+				t.Errorf("invalid value at %d, wanted %s, got %s", v.pos, want, got)
+			}
+		}
+	}
+}
+
+func TestStackGenerator_NegativeValuePositionsAreDetected(t *testing.T) {
+	generator := NewStackGenerator()
+	generator.SetValue(-1, ct.NewU256(42))
+	rnd := rand.New(0)
+	if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
+		t.Errorf("unsatisfiable constraint not detected, got %v", err)
+	}
+}
+
+func TestStackGenerator_NonConflictingValuesAreAccepted(t *testing.T) {
+	generator := NewStackGenerator()
+	generator.SetValue(0, ct.NewU256(42))
+	generator.SetValue(0, ct.NewU256(42))
+	rnd := rand.New(0)
+	if _, err := generator.Generate(rnd); err != nil {
+		t.Errorf("generation failed: %v", err)
+	}
+}
+
+func TestStackGenerator_ConflictingValuesAreDetected(t *testing.T) {
+	generator := NewStackGenerator()
+	generator.SetValue(0, ct.NewU256(42))
+	generator.SetValue(0, ct.NewU256(21))
+	rnd := rand.New(0)
+	if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
+		t.Errorf("unsatisfiable constraint not detected, got %v", err)
+	}
+}
+
+func TestStackGenerator_ConflictingValuePositionsWithSizesAreDetected(t *testing.T) {
+	generator := NewStackGenerator()
+	generator.SetSize(10)
+	generator.SetValue(10, ct.NewU256(21))
+	rnd := rand.New(0)
+	if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
+		t.Errorf("unsatisfiable constraint not detected, got %v", err)
+	}
+}
+
+func TestStackGenerator_CloneCopiesGeneratorState(t *testing.T) {
+	original := NewStackGenerator()
+	original.SetSize(5)
+	original.SetValue(0, ct.NewU256(42))
+	original.SetValue(0, ct.NewU256(43))
+
+	clone := original.Clone()
+
+	if want, got := original.String(), clone.String(); want != got {
+		t.Errorf("invalid clone, wanted %s, got %s", want, got)
+	}
+}
+
+func TestStackGenerator_ClonesAreIndependent(t *testing.T) {
+	base := NewStackGenerator()
+	base.SetSize(5)
+
+	clone1 := base.Clone()
+	clone1.SetValue(0, ct.NewU256(16))
+
+	clone2 := base.Clone()
+	clone2.SetValue(0, ct.NewU256(17))
+
+	want := "{size=5,value[0]=0000000000000000 0000000000000000 0000000000000000 0000000000000010}"
+	if got := clone1.String(); got != want {
+		t.Errorf("invalid clone, wanted %s, got %s", want, got)
+	}
+
+	want = "{size=5,value[0]=0000000000000000 0000000000000000 0000000000000000 0000000000000011}"
+	if got := clone2.String(); got != want {
+		t.Errorf("invalid clone, wanted %s, got %s", want, got)
+	}
+}
+
+func TestStackGenerator_ClonesCanBeUsedToResetGenerator(t *testing.T) {
+	generator := NewStackGenerator()
+	generator.SetValue(0, ct.NewU256(42))
+
+	backup := generator.Clone()
+
+	generator.SetSize(5)
+	generator.SetValue(1, ct.NewU256(16))
+
+	want := "{size=5,value[0]=0000000000000000 0000000000000000 0000000000000000 000000000000002a,value[1]=0000000000000000 0000000000000000 0000000000000000 0000000000000010}"
+	if got := generator.String(); got != want {
+		t.Errorf("unexpected generator state, wanted %s, got %s", want, got)
+	}
+
+	generator.Restore(backup)
+	want = "{value[0]=0000000000000000 0000000000000000 0000000000000000 000000000000002a}"
+	if got := generator.String(); got != want {
+		t.Errorf("unexpected generator state, wanted %s, got %s", want, got)
+	}
+}

--- a/go/ct/gen/state_test.go
+++ b/go/ct/gen/state_test.go
@@ -225,19 +225,21 @@ func TestStateGenerator_ClonesAreIndependent(t *testing.T) {
 	clone1.SetRevision(st.London)
 	clone1.SetGas(5)
 	clone1.SetCodeSize(20)
+	clone1.SetStackSize(2)
 
 	clone2 := base.Clone()
 	clone2.SetStatus(st.Running)
 	clone2.SetRevision(st.Berlin)
 	clone2.SetGas(6)
 	clone2.SetCodeSize(30)
+	clone2.SetStackSize(3)
 
-	want := "{status=reverted,revision=London,pc=4,gas=5,code={size=20}}"
+	want := "{status=reverted,revision=London,pc=4,gas=5,code={size=20},stack={size=2}}"
 	if got := clone1.String(); want != got {
 		t.Errorf("invalid clone, wanted %s, got %s", want, got)
 	}
 
-	want = "{status=running,revision=Berlin,pc=4,gas=6,code={size=30}}"
+	want = "{status=running,revision=Berlin,pc=4,gas=6,code={size=30},stack={size=3}}"
 	if got := clone2.String(); want != got {
 		t.Errorf("invalid clone, wanted %s, got %s", want, got)
 	}
@@ -250,14 +252,14 @@ func TestStateGenerator_CloneCanBeUsedToResetBuilder(t *testing.T) {
 	backup := gen.Clone()
 
 	gen.SetGas(42)
-	want := "{pc=4,gas=42,code={}}"
+	want := "{pc=4,gas=42,code={},stack={}}"
 	if got := gen.String(); want != got {
 		t.Errorf("invalid clone, wanted %s, got %s", want, got)
 	}
 
 	gen.Restore(backup)
 
-	want = "{pc=4,code={}}"
+	want = "{pc=4,code={},stack={}}"
 	if got := gen.String(); want != got {
 		t.Errorf("invalid clone, wanted %s, got %s", want, got)
 	}

--- a/go/ct/st/stack.go
+++ b/go/ct/st/stack.go
@@ -1,0 +1,75 @@
+package st
+
+import (
+	"fmt"
+
+	"github.com/Fantom-foundation/Tosca/go/ct"
+	"golang.org/x/exp/slices"
+)
+
+// Stack represent's the EVM's execution stack.
+type Stack struct {
+	stack []ct.U256
+}
+
+// NewStack creates a new stack filled with the given values.
+func NewStack(values ...ct.U256) *Stack {
+	return &Stack{values}
+}
+
+// NewStackWithSize creates a new stack with the given size, all elements
+// initialized to zero.
+func NewStackWithSize(size int) *Stack {
+	return &Stack{make([]ct.U256, size)}
+}
+
+// Clone creates an independent copy of the stack.
+func (s *Stack) Clone() *Stack {
+	return &Stack{slices.Clone(s.stack)}
+}
+
+func (s *Stack) Size() int {
+	return len(s.stack)
+}
+
+// Get returns the value located the given index. The index must not be
+// out-of-bounds.
+func (s *Stack) Get(index int) ct.U256 {
+	return s.stack[s.Size()-index-1]
+}
+
+// Set places the given value at the given position on the stack. The index must
+// not be out-of-bounds.
+func (s *Stack) Set(index int, value ct.U256) {
+	s.stack[s.Size()-index-1] = value
+}
+
+// Push adds the given value to the top of the stack.
+func (s *Stack) Push(value ct.U256) {
+	s.stack = append(s.stack, value)
+}
+
+// Pop removes the top most value from the stack and returns it. The stack must
+// not be empty.
+func (s *Stack) Pop() ct.U256 {
+	value := s.stack[s.Size()-1]
+	s.stack = s.stack[:s.Size()-1]
+	return value
+}
+
+func (a *Stack) Eq(b *Stack) bool {
+	return slices.Equal(a.stack, b.stack)
+}
+
+func (a *Stack) Diff(b *Stack) (res []string) {
+	if a.Size() != b.Size() {
+		res = append(res, fmt.Sprintf("Different stack size: %v vs %v", a.Size(), b.Size()))
+		return
+	}
+	for i := 0; i < a.Size(); i++ {
+		if aValue, bValue := a.Get(i), b.Get(i); !aValue.Eq(bValue) {
+			res = append(res, fmt.Sprintf("Different stack value at position %d:\n    %v\n    vs\n    %v", i, aValue, bValue))
+		}
+	}
+	return
+}

--- a/go/ct/st/stack_test.go
+++ b/go/ct/st/stack_test.go
@@ -1,0 +1,132 @@
+package st
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/ct"
+)
+
+func TestStack_NewStack(t *testing.T) {
+	stack := NewStack()
+	if want, got := 0, stack.Size(); want != got {
+		t.Errorf("unexpected stack size, want %v, got %v", want, got)
+	}
+
+	stack = NewStack(ct.NewU256(1))
+	if want, got := 1, stack.Size(); want != got {
+		t.Errorf("unexpected stack size, want %v, got %v", want, got)
+	}
+}
+
+func TestStack_NewStackWithSize(t *testing.T) {
+	stack := NewStackWithSize(5)
+	if want, got := 5, stack.Size(); want != got {
+		t.Errorf("unexpected stack size, want %v, got %v", want, got)
+	}
+	for i := 0; i < stack.Size(); i++ {
+		if !stack.Get(i).Eq(ct.NewU256(0)) {
+			t.Errorf("unexpected non-zero value at index %d", i)
+		}
+	}
+}
+
+func TestStack_Clone(t *testing.T) {
+	stack := NewStack(ct.NewU256(42))
+	clone := stack.Clone()
+
+	if stack.Size() != clone.Size() {
+		t.Error("Clone does not have the same size")
+	}
+
+	stack.Push(ct.NewU256(21))
+	if clone.Size() != 1 {
+		t.Error("Clone is not independent from original")
+	}
+
+	stack.Set(1, ct.NewU256(43))
+	if !clone.Get(0).Eq(ct.NewU256(42)) {
+		t.Error("Clone is not independent from original")
+	}
+}
+
+func TestStack_Get(t *testing.T) {
+	stack := NewStack(ct.NewU256(1), ct.NewU256(2), ct.NewU256(3))
+	if want, got := uint64(3), stack.Get(0).Uint64(); want != got {
+		t.Errorf("unexpected stack value at position 0, want %v, got %v", want, got)
+	}
+	if want, got := uint64(2), stack.Get(1).Uint64(); want != got {
+		t.Errorf("unexpected stack value at position 1, want %v, got %v", want, got)
+	}
+	if want, got := uint64(1), stack.Get(2).Uint64(); want != got {
+		t.Errorf("unexpected stack value at position 2, want %v, got %v", want, got)
+	}
+}
+
+func TestStack_Set(t *testing.T) {
+	stack := NewStack(ct.NewU256(2))
+	stack.Set(0, ct.NewU256(4))
+	if want, got := uint64(4), stack.Get(0).Uint64(); want != got {
+		t.Errorf("unexpected stack value at position 0, want %v, got %v", want, got)
+	}
+}
+
+func TestStack_Push(t *testing.T) {
+	stack := NewStack()
+
+	stack.Push(ct.NewU256(42))
+	if want, got := 1, stack.Size(); want != got {
+		t.Errorf("unexpected stack size, want %v, got %v", want, got)
+	}
+	if want, got := uint64(42), stack.Get(0).Uint64(); want != got {
+		t.Errorf("unexpected stack value at position 0, want %v, got %v", want, got)
+	}
+
+	stack.Push(ct.NewU256(16))
+	if want, got := 2, stack.Size(); want != got {
+		t.Errorf("unexpected stack size, want %v, got %v", want, got)
+	}
+	if want, got := uint64(16), stack.Get(0).Uint64(); want != got {
+		t.Errorf("unexpected stack value at position 0, want %v, got %v", want, got)
+	}
+	if want, got := uint64(42), stack.Get(1).Uint64(); want != got {
+		t.Errorf("unexpected stack value at position 1, want %v, got %v", want, got)
+	}
+}
+
+func TestStack_Pop(t *testing.T) {
+	stack := NewStack(ct.NewU256(1), ct.NewU256(2))
+
+	value := stack.Pop().Uint64()
+	if value != 2 {
+		t.Errorf("unexpected value popped, want 2, got %v", value)
+	}
+	if want, got := 1, stack.Size(); want != got {
+		t.Errorf("unexpected stack size, want %v, got %v", want, got)
+	}
+
+	value = stack.Pop().Uint64()
+	if value != 1 {
+		t.Errorf("unexpected value popped, want 1, got %v", value)
+	}
+	if want, got := 0, stack.Size(); want != got {
+		t.Errorf("unexpected stack size, want %v, got %v", want, got)
+	}
+}
+
+func TestStack_Eq(t *testing.T) {
+	stack1 := NewStack(ct.NewU256(1), ct.NewU256(2))
+	stack2 := NewStack(ct.NewU256(1), ct.NewU256(2))
+	if !stack1.Eq(stack2) {
+		t.Errorf("unexpected stack inequality %v vs. %v", stack1.stack, stack2.stack)
+	}
+
+	stack2.Set(0, ct.NewU256(42))
+	if stack1.Eq(stack2) {
+		t.Errorf("unexpected stack equality %v vs. %v", stack1.stack, stack2.stack)
+	}
+
+	stack2.Pop()
+	if stack1.Eq(stack2) {
+		t.Errorf("unexpected stack equality %v vs. %v", stack1.stack, stack2.stack)
+	}
+}

--- a/go/ct/u256.go
+++ b/go/ct/u256.go
@@ -3,6 +3,8 @@ package ct
 import (
 	"fmt"
 
+	"pgregory.net/rand"
+
 	"github.com/holiman/uint256"
 )
 
@@ -24,6 +26,15 @@ func NewU256(args ...uint64) (result U256) {
 		result.internal[3-i-offset] = args[i]
 	}
 	return
+}
+
+func RandU256(rnd *rand.Rand) U256 {
+	var bytes [32]byte
+	rnd.Read(bytes[:])
+
+	var value U256
+	value.internal.SetBytes(bytes[:])
+	return value
 }
 
 func MaxU256() (result U256) {


### PR DESCRIPTION
This PR adds a `Stack` implementation along with a `StackGenerator`. The generator is hooked into the `StateGenerator`.

@BlackMark29A Please double check that this is correctly hooked into the `State`'s printing and diffing functions.