### PR TITLE
ct: Add Effect definition

### DIFF
--- a/go/ct/rlz/effect.go
+++ b/go/ct/rlz/effect.go
@@ -1,0 +1,33 @@
+package rlz
+
+import (
+	"fmt"
+
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+)
+
+type Effect interface {
+	// Apply modifies the given state with this effect.
+	Apply(*st.State)
+
+	fmt.Stringer
+}
+
+////////////////////////////////////////////////////////////
+// Change
+
+type change struct {
+	fun func(*st.State)
+}
+
+func Change(fun func(*st.State)) Effect {
+	return &change{fun}
+}
+
+func (c *change) Apply(state *st.State) {
+	c.fun(state)
+}
+
+func (c *change) String() string {
+	return "change"
+}

--- a/go/ct/rlz/effect_test.go
+++ b/go/ct/rlz/effect_test.go
@@ -1,0 +1,21 @@
+package rlz
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+)
+
+func TestEffect_Change(t *testing.T) {
+	pcAdd1 := Change(func(s *st.State) {
+		s.Pc += 1
+	})
+
+	state := st.NewState(st.NewCode([]byte{}))
+	state.Pc = 0
+
+	pcAdd1.Apply(state)
+	if state.Pc != 1 {
+		t.Errorf("effect did not apply")
+	}
+}

--- a/go/ct/rlz/rules.go
+++ b/go/ct/rlz/rules.go
@@ -12,6 +12,7 @@ import (
 type Rule struct {
 	Name      string
 	Condition Condition
+	Effect    Effect
 }
 
 // GenerateSatisfyingState produces an st.State satisfying this Rule.

--- a/go/ct/st/code.go
+++ b/go/ct/st/code.go
@@ -40,6 +40,10 @@ func NewCode(code []byte) *Code {
 	}
 }
 
+func (c *Code) Clone() *Code {
+	return c
+}
+
 func (c *Code) Length() int {
 	return len(c.code)
 }

--- a/go/ct/st/state.go
+++ b/go/ct/st/state.go
@@ -81,6 +81,16 @@ func NewState(code *Code) *State {
 	}
 }
 
+func (s *State) Clone() *State {
+	clone := NewState(s.Code.Clone())
+	clone.Status = s.Status
+	clone.Revision = s.Revision
+	clone.Pc = s.Pc
+	clone.Gas = s.Gas
+	clone.Stack = s.Stack.Clone()
+	return clone
+}
+
 func (s *State) Eq(other *State) bool {
 	// All failure states are considered equal.
 	if s.Status == Failed && other.Status == Failed {

--- a/go/ct/st/state_test.go
+++ b/go/ct/st/state_test.go
@@ -9,6 +9,32 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/ct"
 )
 
+func TestState_CloneIsIndependent(t *testing.T) {
+	state := NewState(NewCode([]byte{byte(ADD)}))
+	state.Status = Stopped
+	state.Revision = London
+	state.Pc = 1
+	state.Gas = 2
+	state.Stack.Push(ct.NewU256(3))
+
+	clone := state.Clone()
+	clone.Status = Running
+	clone.Revision = Berlin
+	clone.Pc = 4
+	clone.Gas = 5
+	clone.Stack.Push(ct.NewU256(6))
+
+	ok := state.Status == Stopped &&
+		state.Revision == London &&
+		state.Pc == 1 &&
+		state.Gas == 2 &&
+		state.Stack.Size() == 1 &&
+		state.Stack.Get(0).Uint64() == 3
+	if !ok {
+		t.Errorf("clone is not independent")
+	}
+}
+
 func TestState_Eq(t *testing.T) {
 	s1 := NewState(NewCode([]byte{}))
 	s2 := NewState(NewCode([]byte{}))


### PR DESCRIPTION
This PR adds the interface definition for `Effect` including the most basic `Change` effect, which will mutate an `st.State`.

Effects will be applied to a copy of the given state, the input state is untouched.