### PR TITLE
ct: Add Pick operation for restricting generators with non-trivial expressions

### DIFF
--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -39,6 +39,18 @@ func (g *CodeGenerator) SetOperation(pos int, op st.OpCode) {
 	g.ops = append(g.ops, opConstraint{pos: pos, op: op})
 }
 
+func (g *CodeGenerator) PickOperation(pos int, rnd *rand.Rand) st.OpCode {
+	for _, op := range g.ops {
+		if op.pos == pos {
+			return op.op
+		}
+	}
+
+	op := st.STOP // TODO random
+	g.SetOperation(pos, op)
+	return op
+}
+
 // Generate produces a Code instance satisfying the constraints set on this
 // generator or returns ErrUnsatisfiable on conflicting constraints.
 func (g *CodeGenerator) Generate(rnd *rand.Rand) (*st.Code, error) {

--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -54,6 +54,15 @@ func (g *StateGenerator) SetStatus(status st.StatusCode) {
 	}
 }
 
+// PickStatus provides an st.StatusCode satisfying the constraints (assuming
+// generator is satisfiable). Constraints are added if needed.
+func (g *StateGenerator) PickStatus(rnd *rand.Rand) st.StatusCode {
+	if len(g.statusConstraints) == 0 {
+		g.SetStatus(st.StatusCode(rnd.Int31n(int32(st.NumStatusCodes))))
+	}
+	return g.statusConstraints[0]
+}
+
 // SetRevision adds a constraint on the State's revision.
 func (g *StateGenerator) SetRevision(revision st.Revision) {
 	if !slices.Contains(g.revisionConstraints, revision) {
@@ -85,6 +94,10 @@ func (g *StateGenerator) SetCodeOperation(pos int, op st.OpCode) {
 	g.codeGen.SetOperation(pos, op)
 }
 
+func (g *StateGenerator) PickCodeOperation(pos int, rnd *rand.Rand) st.OpCode {
+	return g.codeGen.PickOperation(pos, rnd)
+}
+
 // SetStackSize wraps StackGenerator.SetSize.
 func (g *StateGenerator) SetStackSize(size int) {
 	g.stackGen.SetSize(size)
@@ -102,7 +115,7 @@ func (g *StateGenerator) Generate(rnd *rand.Rand) (*st.State, error) {
 	// Pick a status.
 	var resultStatus st.StatusCode
 	if len(g.statusConstraints) == 0 {
-		resultStatus = st.StatusCode(rnd.Int31n(int32(st.NumStatusCodes)))
+		resultStatus = g.PickStatus(rnd)
 	} else if len(g.statusConstraints) == 1 {
 		resultStatus = g.statusConstraints[0]
 		if resultStatus < 0 || resultStatus >= st.NumStatusCodes {

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -202,3 +202,23 @@ func (pcDomain) SamplesForAll(as []ct.U256) []ct.U256 {
 	}
 	return res
 }
+
+////////////////////////////////////////////////////////////
+// Op Codes
+
+type opCodeDomain struct{}
+
+func (opCodeDomain) Equal(a st.OpCode, b st.OpCode) bool     { return a == b }
+func (opCodeDomain) Less(a st.OpCode, b st.OpCode) bool      { panic("not useful") }
+func (opCodeDomain) Predecessor(a st.OpCode) st.OpCode       { panic("not useful") }
+func (opCodeDomain) Successor(a st.OpCode) st.OpCode         { panic("not useful") }
+func (opCodeDomain) SomethingNotEqual(a st.OpCode) st.OpCode { return a + 1 }
+func (opCodeDomain) Samples(a st.OpCode) []st.OpCode         { return []st.OpCode{a, a + 1} }
+
+func (opCodeDomain) SamplesForAll([]st.OpCode) []st.OpCode {
+	res := make([]st.OpCode, 0, 256)
+	for i := 0; i < 256; i++ {
+		res = append(res, st.OpCode(i))
+	}
+	return res
+}

--- a/go/ct/rlz/expressions.go
+++ b/go/ct/rlz/expressions.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math"
 
+	"pgregory.net/rand"
+
 	"github.com/Fantom-foundation/Tosca/go/ct"
 	"github.com/Fantom-foundation/Tosca/go/ct/gen"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
@@ -18,7 +20,12 @@ type Expression[T any] interface {
 	// Restrict applies constraints to the given generator such that this
 	// expression evaluates to the given value when invoked on the generated
 	// states.
-	Restrict(value T, generator *gen.StateGenerator)
+	Restrict(value T, generator *gen.StateGenerator, rnd *rand.Rand)
+
+	// Pick returns a specific value for this expression. If the generator is
+	// already constrained, the value satisfies the constraints (if possible);
+	// otherwise the generator is constraint accordingly.
+	Pick(generator *gen.StateGenerator, rnd *rand.Rand) T
 
 	fmt.Stringer
 }
@@ -38,8 +45,12 @@ func (status) Eval(s *st.State) st.StatusCode {
 	return s.Status
 }
 
-func (status) Restrict(status st.StatusCode, generator *gen.StateGenerator) {
+func (status) Restrict(status st.StatusCode, generator *gen.StateGenerator, rnd *rand.Rand) {
 	generator.SetStatus(status)
+}
+
+func (status) Pick(generator *gen.StateGenerator, rnd *rand.Rand) st.StatusCode {
+	return generator.PickStatus(rnd)
 }
 
 func (status) String() string {
@@ -61,13 +72,65 @@ func (pc) Eval(s *st.State) ct.U256 {
 	return ct.NewU256(uint64(s.Pc))
 }
 
-func (pc) Restrict(pc ct.U256, generator *gen.StateGenerator) {
+func (pc) Restrict(pc ct.U256, generator *gen.StateGenerator, rnd *rand.Rand) {
 	if !pc.IsUint64() || pc.Uint64() > uint64(math.MaxUint16) {
 		panic("invalid value for PC")
 	}
 	generator.SetPc(uint16(pc.Uint64()))
 }
 
+func (pc) Pick(generator *gen.StateGenerator, rnd *rand.Rand) ct.U256 {
+	panic("TODO")
+}
+
 func (pc) String() string {
 	return "PC"
+}
+
+////////////////////////////////////////////////////////////
+// Code Operation
+
+type op struct {
+	position Expression[ct.U256]
+}
+
+func Op(position Expression[ct.U256]) Expression[st.OpCode] {
+	return op{position}
+}
+
+func (op) Domain() Domain[st.OpCode] { return opCodeDomain{} }
+
+func (e op) Eval(s *st.State) st.OpCode {
+	pos := e.position.Eval(s)
+	if pos.Gt(ct.NewU256(math.MaxInt)) {
+		return st.STOP
+	}
+
+	op, err := s.Code.GetOperation(int(pos.Uint64()))
+	if err != nil {
+		panic(err) // TODO
+	}
+	return op
+}
+
+func (e op) Restrict(op st.OpCode, generator *gen.StateGenerator, rnd *rand.Rand) {
+	pos := e.position.Pick(generator, rnd)
+	if pos.Gt(ct.NewU256(math.MaxUint16)) {
+		panic("invalid pos") // TODO
+	}
+
+	generator.SetCodeOperation(int(pos.Uint64()), op)
+}
+
+func (e op) Pick(generator *gen.StateGenerator, rnd *rand.Rand) st.OpCode {
+	pos := e.position.Pick(generator, rnd)
+	if pos.Gt(ct.NewU256(math.MaxUint16)) {
+		panic("invalid pos") // TODO
+	}
+
+	return generator.PickCodeOperation(int(pos.Uint64()), rnd)
+}
+
+func (e op) String() string {
+	return fmt.Sprintf("code[%v]", e.position)
 }

--- a/go/ct/rlz/expressions_test.go
+++ b/go/ct/rlz/expressions_test.go
@@ -20,7 +20,8 @@ func TestExpression_StatusEval(t *testing.T) {
 
 func TestExpression_StatusRestrict(t *testing.T) {
 	generator := gen.NewStateGenerator()
-	Status().Restrict(st.Reverted, generator)
+	rnd := rand.New(0)
+	Status().Restrict(st.Reverted, generator, rnd)
 
 	state, err := generator.Generate(rand.New(0))
 	if err != nil {
@@ -41,7 +42,8 @@ func TestExpression_PcEval(t *testing.T) {
 
 func TestExpression_PcRestrict(t *testing.T) {
 	generator := gen.NewStateGenerator()
-	Pc().Restrict(ct.NewU256(42), generator)
+	rnd := rand.New(0)
+	Pc().Restrict(ct.NewU256(42), generator, rnd)
 
 	state, err := generator.Generate(rand.New(0))
 	if err != nil {

--- a/go/ct/rlz/rules.go
+++ b/go/ct/rlz/rules.go
@@ -17,7 +17,7 @@ type Rule struct {
 // GenerateSatisfyingState produces an st.State satisfying this Rule.
 func (rule *Rule) GenerateSatisfyingState(rnd *rand.Rand) (*st.State, error) {
 	generator := gen.NewStateGenerator()
-	rule.Condition.Restrict(generator)
+	rule.Condition.Restrict(generator, rnd)
 	return generator.Generate(rnd)
 }
 
@@ -27,7 +27,7 @@ func (rule *Rule) EnumerateTestCases(rnd *rand.Rand, consume func(s *st.State)) 
 	var generatorErrors []error
 
 	generator := gen.NewStateGenerator()
-	rule.Condition.EnumerateTestCases(generator, func(g *gen.StateGenerator) {
+	rule.Condition.EnumerateTestCases(generator, rnd, func(g *gen.StateGenerator) {
 		state, err := g.Generate(rnd)
 		if errors.Is(err, gen.ErrUnsatisfiable) {
 			return // ignored


### PR DESCRIPTION
Could this approach work to realize non-trivial expressions, like the `Op` expression with a `pos` expression as member?

Also, any better ideas for dragging `rnd` along?