### PR TITLE
ct: Prototype for supporting variables to communicate between generators

### DIFF
--- a/go/ct/gen/assignment.go
+++ b/go/ct/gen/assignment.go
@@ -1,0 +1,34 @@
+package gen
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Fantom-foundation/Tosca/go/ct"
+)
+
+type Variable string
+
+func (v Variable) String() string {
+	return "$" + string(v)
+}
+
+type Assignment map[Variable]ct.U256
+
+func (a Assignment) String() string {
+	if a == nil {
+		return "{}"
+	}
+	keys := make([]Variable, 0, len(a))
+	for key := range a {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+
+	entries := make([]string, 0, len(a))
+	for _, key := range keys {
+		entries = append(entries, fmt.Sprintf("%s->%v", string(key), a[key]))
+	}
+	return "{" + strings.Join(entries, ",") + "}"
+}

--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Fantom-foundation/Tosca/go/ct"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"pgregory.net/rand"
 )
@@ -14,13 +15,19 @@ import (
 // more information on generators.
 type CodeGenerator struct {
 	// Constraints
-	sizes []int
-	ops   []opConstraint
+	sizes    []int
+	constOps []constOpConstraint
+	varOps   []varOpConstraint
 }
 
-type opConstraint struct {
+type constOpConstraint struct {
 	pos int
 	op  st.OpCode
+}
+
+type varOpConstraint struct {
+	variable Variable
+	op       st.OpCode
 }
 
 func NewCodeGenerator() *CodeGenerator {
@@ -34,14 +41,19 @@ func (g *CodeGenerator) SetSize(size int) {
 	}
 }
 
+// AddOperation adds a constraint placing an operation at a variable position.
+func (g *CodeGenerator) AddOperation(v Variable, op st.OpCode) {
+	g.varOps = append(g.varOps, varOpConstraint{variable: v, op: op})
+}
+
 // SetOperation fixes an operation to be placed at a given offset.
 func (g *CodeGenerator) SetOperation(pos int, op st.OpCode) {
-	g.ops = append(g.ops, opConstraint{pos: pos, op: op})
+	g.constOps = append(g.constOps, constOpConstraint{pos: pos, op: op})
 }
 
 // Generate produces a Code instance satisfying the constraints set on this
 // generator or returns ErrUnsatisfiable on conflicting constraints.
-func (g *CodeGenerator) Generate(rnd *rand.Rand) (*st.Code, error) {
+func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Code, error) {
 	// Pick a size.
 	if len(g.sizes) > 1 {
 		return nil, fmt.Errorf("%w, multiple conflicting sizes defined: %v", ErrUnsatisfiable, g.sizes)
@@ -56,27 +68,114 @@ func (g *CodeGenerator) Generate(rnd *rand.Rand) (*st.Code, error) {
 	} else {
 		// Pick a random size that is large enough for all operation constraints.
 		minSize := 0
-		for _, constraint := range g.ops {
+		for _, constraint := range g.constOps {
 			if constraint.pos > minSize {
 				minSize = constraint.pos + 1
 			}
 		}
+		// Make extra space for worst-case size requirements of variable operation constraints.
+		for _, constraint := range g.varOps {
+			size := 1
+			if st.PUSH1 <= constraint.op && constraint.op <= st.PUSH32 {
+				size += int(constraint.op - st.PUSH1 + 1)
+			}
+			minSize += size
+		}
 		size = int(rnd.Int31n(int32(24576+1-minSize))) + minSize
+	}
+
+	// Convert the variable op-constraints into const constraints by fixing their position.
+	ops := slices.Clone(g.constOps)
+	sort.Slice(ops, func(i, j int) bool { return ops[i].pos < ops[j].pos })
+
+	if len(g.varOps) > 0 {
+		// Note: this solver for constraints with variables is sound but not complete.
+		// There may be cases where variable positions may be assigned to fit into a
+		// given code size which are missed due to a fragmentation of the code into
+		// too small code sections, eliminating the possibility to fit in larger push
+		// operations. However, this can only happen with sets of constraints with more
+		// than one variable, which should not be needed.
+		bound := map[Variable]st.OpCode{}
+
+		// track used code positions
+		used := map[int]bool{}
+		markUsed := func(pos int, op st.OpCode) {
+			used[pos] = true
+			if st.PUSH1 <= op && op <= st.PUSH32 {
+				width := int(op - st.PUSH1 + 1)
+				for i := 0; i < width; i++ {
+					used[pos+i+1] = true
+				}
+			}
+		}
+		fits := func(pos int, op st.OpCode) bool {
+			if used[pos] {
+				return false
+			}
+			if st.PUSH1 <= op && op <= st.PUSH32 {
+				width := int(op - st.PUSH1 + 1)
+				for i := 0; i < width; i++ {
+					if used[pos+i+1] {
+						return false
+					}
+				}
+			}
+			return true
+		}
+
+		for _, cur := range g.constOps {
+			markUsed(cur.pos, cur.op)
+		}
+		for _, cur := range g.varOps {
+			if op, found := bound[cur.variable]; found {
+				if op != cur.op {
+					return nil, fmt.Errorf(
+						"%w, unable to satisfy conflicting constraint for op[%v]=%v and op[%v]=%v",
+						ErrUnsatisfiable, cur.variable, op, cur.variable, cur.op,
+					)
+				}
+				continue
+			}
+			bound[cur.variable] = cur.op
+
+			// select a suitable code position for the current variable constraint
+			pos := int(rnd.Int31n(int32(size)))
+			startPos := pos
+			for !fits(pos, cur.op) {
+				pos++
+				if pos >= size {
+					pos = 0
+				}
+				if pos == startPos {
+					return nil, fmt.Errorf(
+						"%w, unable to fit operations in given code size",
+						ErrUnsatisfiable,
+					)
+				}
+			}
+			markUsed(pos, cur.op)
+
+			// Record and enforce the variable position.
+			if assignment != nil {
+				assignment[cur.variable] = ct.NewU256(uint64(pos))
+			}
+			ops = append(ops, constOpConstraint{pos, cur.op})
+		}
+		sort.Slice(ops, func(i, j int) bool { return ops[i].pos < ops[j].pos })
 	}
 
 	// Create the code and fill in content based on the operation constraints.
 	code := make([]byte, size)
 
 	// If there are no operation constraints producing random code is sufficient.
-	if len(g.ops) == 0 {
+	if len(ops) == 0 {
 		rnd.Read(code)
 		return st.NewCode(code), nil
 	}
 
 	// If there are constraints we need to make sure that all operations are
 	// indeed operations (not data) and that the operation code is correct.
-	sort.Slice(g.ops, func(i, j int) bool { return g.ops[i].pos < g.ops[j].pos })
-	if last := g.ops[len(g.ops)-1].pos; last >= size {
+	if last := ops[len(ops)-1].pos; last >= size {
 		return nil, fmt.Errorf(
 			"%w, operation constraint on position %d cannot be satisfied with a code length of %d",
 			ErrUnsatisfiable, last, size,
@@ -84,7 +183,6 @@ func (g *CodeGenerator) Generate(rnd *rand.Rand) (*st.Code, error) {
 	}
 
 	// Build random code incrementally.
-	ops := g.ops
 	for i := 0; i < size; i++ {
 		// Pick the next operation.
 		op := st.INVALID
@@ -123,7 +221,11 @@ func (g *CodeGenerator) Generate(rnd *rand.Rand) (*st.Code, error) {
 		// Fill data if needed and continue with the rest.
 		if st.PUSH1 <= op && op <= st.PUSH32 {
 			width := int(op - st.PUSH1 + 1)
-			rnd.Read(code[i+1 : i+1+width])
+			end := i + 1 + width
+			if end > len(code) {
+				end = len(code)
+			}
+			rnd.Read(code[i+1 : end])
 			i += width
 		}
 	}
@@ -135,8 +237,9 @@ func (g *CodeGenerator) Generate(rnd *rand.Rand) (*st.Code, error) {
 // Future modifications are isolated from each other.
 func (g *CodeGenerator) Clone() *CodeGenerator {
 	return &CodeGenerator{
-		sizes: slices.Clone(g.sizes),
-		ops:   slices.Clone(g.ops),
+		sizes:    slices.Clone(g.sizes),
+		constOps: slices.Clone(g.constOps),
+		varOps:   slices.Clone(g.varOps),
 	}
 }
 
@@ -146,7 +249,7 @@ func (g *CodeGenerator) Restore(other *CodeGenerator) {
 		return
 	}
 	g.sizes = slices.Clone(other.sizes)
-	g.ops = slices.Clone(other.ops)
+	g.constOps = slices.Clone(other.constOps)
 }
 
 func (g *CodeGenerator) String() string {
@@ -157,9 +260,14 @@ func (g *CodeGenerator) String() string {
 		parts = append(parts, fmt.Sprintf("size=%d", size))
 	}
 
-	sort.Slice(g.ops, func(i, j int) bool { return g.ops[i].pos < g.ops[j].pos })
-	for _, op := range g.ops {
-		parts = append(parts, fmt.Sprintf("op[%d]=%v", op.pos, op.op))
+	sort.Slice(g.constOps, func(i, j int) bool { return g.constOps[i].pos < g.constOps[j].pos })
+	for _, op := range g.constOps {
+		parts = append(parts, fmt.Sprintf("op[%v]=%v", op.pos, op.op))
+	}
+
+	sort.Slice(g.varOps, func(i, j int) bool { return g.varOps[i].variable < g.varOps[j].variable })
+	for _, op := range g.varOps {
+		parts = append(parts, fmt.Sprintf("op[%v]=%v", op.variable, op.op))
 	}
 
 	return "{" + strings.Join(parts, ",") + "}"

--- a/go/ct/gen/stack_test.go
+++ b/go/ct/gen/stack_test.go
@@ -11,7 +11,7 @@ import (
 func TestStackGenerator_UnconstrainedGeneratorCanProduceStack(t *testing.T) {
 	rnd := rand.New(0)
 	generator := NewStackGenerator()
-	if _, err := generator.Generate(rnd); err != nil {
+	if _, err := generator.Generate(nil, rnd); err != nil {
 		t.Fatalf("unexpected error during build: %v", err)
 	}
 }
@@ -23,7 +23,7 @@ func TestStackGenerator_SetSizeIsEnforced(t *testing.T) {
 	for _, size := range sizes {
 		generator := NewStackGenerator()
 		generator.SetSize(size)
-		stack, err := generator.Generate(rnd)
+		stack, err := generator.Generate(nil, rnd)
 		if err != nil {
 			t.Fatalf("unexpected error during build: %v", err)
 		}
@@ -38,7 +38,7 @@ func TestStackGenerator_NonConflictingSizesAreAccepted(t *testing.T) {
 	generator.SetSize(12)
 	generator.SetSize(12)
 	rnd := rand.New(0)
-	if _, err := generator.Generate(rnd); err != nil {
+	if _, err := generator.Generate(nil, rnd); err != nil {
 		t.Errorf("generation failed: %v", err)
 	}
 }
@@ -48,7 +48,7 @@ func TestStackGenerator_ConflictingSizesAreDetected(t *testing.T) {
 	generator.SetSize(12)
 	generator.SetSize(14)
 	rnd := rand.New(0)
-	if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
+	if _, err := generator.Generate(nil, rnd); !errors.Is(err, ErrUnsatisfiable) {
 		t.Errorf("unsatisfiable constraint not detected, got %v", err)
 	}
 }
@@ -72,7 +72,7 @@ func TestStackGenerator_SetValueIsEnforced(t *testing.T) {
 			generator.SetValue(v.pos, v.value)
 		}
 
-		stack, err := generator.Generate(rnd)
+		stack, err := generator.Generate(nil, rnd)
 		if err != nil {
 			t.Fatalf("unexpected error during build: %v", err)
 		}
@@ -89,7 +89,7 @@ func TestStackGenerator_NegativeValuePositionsAreDetected(t *testing.T) {
 	generator := NewStackGenerator()
 	generator.SetValue(-1, ct.NewU256(42))
 	rnd := rand.New(0)
-	if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
+	if _, err := generator.Generate(nil, rnd); !errors.Is(err, ErrUnsatisfiable) {
 		t.Errorf("unsatisfiable constraint not detected, got %v", err)
 	}
 }
@@ -99,7 +99,7 @@ func TestStackGenerator_NonConflictingValuesAreAccepted(t *testing.T) {
 	generator.SetValue(0, ct.NewU256(42))
 	generator.SetValue(0, ct.NewU256(42))
 	rnd := rand.New(0)
-	if _, err := generator.Generate(rnd); err != nil {
+	if _, err := generator.Generate(nil, rnd); err != nil {
 		t.Errorf("generation failed: %v", err)
 	}
 }
@@ -109,7 +109,7 @@ func TestStackGenerator_ConflictingValuesAreDetected(t *testing.T) {
 	generator.SetValue(0, ct.NewU256(42))
 	generator.SetValue(0, ct.NewU256(21))
 	rnd := rand.New(0)
-	if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
+	if _, err := generator.Generate(nil, rnd); !errors.Is(err, ErrUnsatisfiable) {
 		t.Errorf("unsatisfiable constraint not detected, got %v", err)
 	}
 }
@@ -119,7 +119,7 @@ func TestStackGenerator_ConflictingValuePositionsWithSizesAreDetected(t *testing
 	generator.SetSize(10)
 	generator.SetValue(10, ct.NewU256(21))
 	rnd := rand.New(0)
-	if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
+	if _, err := generator.Generate(nil, rnd); !errors.Is(err, ErrUnsatisfiable) {
 		t.Errorf("unsatisfiable constraint not detected, got %v", err)
 	}
 }

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -237,3 +237,23 @@ func (stackSizeDomain) SamplesForAll(as []int) []int {
 
 	return res
 }
+
+////////////////////////////////////////////////////////////
+// Op Codes
+
+type opCodeDomain struct{}
+
+func (opCodeDomain) Equal(a st.OpCode, b st.OpCode) bool     { return a == b }
+func (opCodeDomain) Less(a st.OpCode, b st.OpCode) bool      { panic("not useful") }
+func (opCodeDomain) Predecessor(a st.OpCode) st.OpCode       { panic("not useful") }
+func (opCodeDomain) Successor(a st.OpCode) st.OpCode         { panic("not useful") }
+func (opCodeDomain) SomethingNotEqual(a st.OpCode) st.OpCode { return a + 1 }
+func (opCodeDomain) Samples(a st.OpCode) []st.OpCode         { return []st.OpCode{a, a + 1} }
+
+func (opCodeDomain) SamplesForAll([]st.OpCode) []st.OpCode {
+	res := make([]st.OpCode, 0, 256)
+	for i := 0; i < 256; i++ {
+		res = append(res, st.OpCode(i))
+	}
+	return res
+}

--- a/go/ct/rlz/rules_test.go
+++ b/go/ct/rlz/rules_test.go
@@ -15,6 +15,8 @@ func TestRule_GenerateSatisfyingState(t *testing.T) {
 		Eq(Status(), st.Failed),
 		Eq(Pc(), ct.NewU256(42)),
 		And(Eq(Status(), st.Failed), Eq(Pc(), ct.NewU256(42))),
+		And(Eq(Op(Pc()), st.ADD)),
+		And(Eq(Op(Pc()), st.JUMP), Eq(Op(Param(0)), st.JUMPDEST)),
 	}
 
 	rnd := rand.New(0)
@@ -23,7 +25,7 @@ func TestRule_GenerateSatisfyingState(t *testing.T) {
 		rule := Rule{Condition: test}
 		state, err := rule.GenerateSatisfyingState(rnd)
 		if err != nil {
-			t.Errorf("Failed to generate state: %v", err)
+			t.Fatalf("Failed to generate state: %v", err)
 		}
 		if !test.Check(state) {
 			t.Errorf("Generated state does not satisfy condition %v: %v", test, &state)
@@ -37,6 +39,8 @@ func TestRule_EnumerateTestCases(t *testing.T) {
 		Eq(Status(), st.Failed),
 		Eq(Pc(), ct.NewU256(42)),
 		And(Eq(Status(), st.Failed), Eq(Pc(), ct.NewU256(42))),
+		And(Eq(Op(Pc()), st.ADD)),
+		And(Eq(Op(Pc()), st.JUMP), Eq(Op(Param(0)), st.JUMPDEST)),
 	}
 
 	rnd := rand.New(0)

--- a/go/ct/st/opcodes.go
+++ b/go/ct/st/opcodes.go
@@ -5,14 +5,16 @@ import "fmt"
 type OpCode byte
 
 const (
-	STOP    OpCode = 0x00
-	ADD     OpCode = 0x01
-	PUSH1   OpCode = 0x60
-	PUSH2   OpCode = 0x61
-	PUSH3   OpCode = 0x62
-	PUSH31  OpCode = 0x7E
-	PUSH32  OpCode = 0x7F
-	INVALID OpCode = 0xFE
+	STOP     OpCode = 0x00
+	ADD      OpCode = 0x01
+	JUMP     OpCode = 0x56
+	JUMPDEST OpCode = 0x5B
+	PUSH1    OpCode = 0x60
+	PUSH2    OpCode = 0x61
+	PUSH3    OpCode = 0x62
+	PUSH31   OpCode = 0x7E
+	PUSH32   OpCode = 0x7F
+	INVALID  OpCode = 0xFE
 )
 
 func (op OpCode) String() string {
@@ -21,6 +23,10 @@ func (op OpCode) String() string {
 		return "STOP"
 	case ADD:
 		return "ADD"
+	case JUMP:
+		return "JUMP"
+	case JUMPDEST:
+		return "JUMPDEST"
 	case PUSH1:
 		return "PUSH1"
 	case PUSH2:


### PR DESCRIPTION
This is a proposal on how to support conditions like
 - `code[PC] = ADD`
 - `code[PC] = JUMP ∧ code[param[0]] = JUMPDEST`

resulting in constraints linking multiple generators. 

For instance, to get a satisfying state for the condition `code[PC] = JUMP ∧ code[param[0]] = JUMPDEST`, the `CodeGenerator` producing example code, the `StateGenerator` selecting the PC counter, and the `StackGenerator` defining the stack content need to work together to align their results. In particular, the resulting PC and stack value at position 0 need to point to proper code locations (not data) storing the specified operations.

In order to solve the communication between different generators variables and assignments are introduced. The condition `code[PC] = JUMP ∧ code[param[0]] = JUMPDEST` is translated into the following constraints (note that the names of variables do not carry any semantic, they could be arbitrarily (consistently) renamed without changing the semantics):
- CodeGenerator: `{op[$PC]=JUMP,op[$param_0]=JUMPDEST}`
- StackGenerator: `{value[0]=$param_0}`
- StateGenerator: `{pc=$PC}`

By convention, variables in the lhs of a constraint are considered output values of a solver. Thus, while generating a valid state, those variables are bound to values and a corresponding assignment is produced as a side-effect of the generation process. Variables on the rhs of constraints are considered input values of constraint solvers, loaded from a given assignment.

Thus, in the example, the CodeGenerator will produce an assignment mapping the variables $PC and $param_0 to code locations containing a JUMP and JUMPDEST instruction respectively. This assignment can then be used by the StackGenerator to derive the value for its top element, and by the StateGenerator to derive its program counter.