### PR TITLE
ct: Reorganize common package

### DIFF
--- a/go/ct/common/opcodes.go
+++ b/go/ct/common/opcodes.go
@@ -1,18 +1,20 @@
-package st
+package common
 
 import "fmt"
 
 type OpCode byte
 
 const (
-	STOP    OpCode = 0x00
-	ADD     OpCode = 0x01
-	PUSH1   OpCode = 0x60
-	PUSH2   OpCode = 0x61
-	PUSH3   OpCode = 0x62
-	PUSH31  OpCode = 0x7E
-	PUSH32  OpCode = 0x7F
-	INVALID OpCode = 0xFE
+	STOP     OpCode = 0x00
+	ADD      OpCode = 0x01
+	JUMP     OpCode = 0x56
+	JUMPDEST OpCode = 0x5B
+	PUSH1    OpCode = 0x60
+	PUSH2    OpCode = 0x61
+	PUSH3    OpCode = 0x62
+	PUSH31   OpCode = 0x7E
+	PUSH32   OpCode = 0x7F
+	INVALID  OpCode = 0xFE
 )
 
 func (op OpCode) String() string {
@@ -21,6 +23,10 @@ func (op OpCode) String() string {
 		return "STOP"
 	case ADD:
 		return "ADD"
+	case JUMP:
+		return "JUMP"
+	case JUMPDEST:
+		return "JUMPDEST"
 	case PUSH1:
 		return "PUSH1"
 	case PUSH2:

--- a/go/ct/common/opcodes_test.go
+++ b/go/ct/common/opcodes_test.go
@@ -1,4 +1,4 @@
-package st
+package common
 
 import (
 	"regexp"

--- a/go/ct/common/u256.go
+++ b/go/ct/common/u256.go
@@ -1,4 +1,4 @@
-package ct
+package common
 
 import (
 	"fmt"

--- a/go/ct/common/u256_test.go
+++ b/go/ct/common/u256_test.go
@@ -1,4 +1,4 @@
-package ct
+package common
 
 import (
 	"bytes"

--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -6,8 +6,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"pgregory.net/rand"
+
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
 )
 
 // CodeGenerator is a utility class for generating Codes. See StateGenerator for
@@ -20,7 +22,7 @@ type CodeGenerator struct {
 
 type opConstraint struct {
 	pos int
-	op  st.OpCode
+	op  OpCode
 }
 
 func NewCodeGenerator() *CodeGenerator {
@@ -35,7 +37,7 @@ func (g *CodeGenerator) SetSize(size int) {
 }
 
 // SetOperation fixes an operation to be placed at a given offset.
-func (g *CodeGenerator) SetOperation(pos int, op st.OpCode) {
+func (g *CodeGenerator) SetOperation(pos int, op OpCode) {
 	g.ops = append(g.ops, opConstraint{pos: pos, op: op})
 }
 
@@ -87,7 +89,7 @@ func (g *CodeGenerator) Generate(rnd *rand.Rand) (*st.Code, error) {
 	ops := g.ops
 	for i := 0; i < size; i++ {
 		// Pick the next operation.
-		op := st.INVALID
+		op := INVALID
 		nextFixedPosition := ops[0].pos
 		if nextFixedPosition < i {
 			return nil, fmt.Errorf(
@@ -101,13 +103,13 @@ func (g *CodeGenerator) Generate(rnd *rand.Rand) (*st.Code, error) {
 			ops = ops[1:]
 		} else {
 			// Pick a random operation, but make sure to not overshoot to next position.
-			limit := st.PUSH32
+			limit := PUSH32
 			if maxDataSize := nextFixedPosition - i - 1; maxDataSize < 32 {
-				limit = st.OpCode(int(st.PUSH1) + maxDataSize - 1)
+				limit = OpCode(int(PUSH1) + maxDataSize - 1)
 			}
 
-			op = st.OpCode(rnd.Int())
-			if limit < op && op <= st.PUSH32 {
+			op = OpCode(rnd.Int())
+			if limit < op && op <= PUSH32 {
 				op = limit
 			}
 		}
@@ -121,8 +123,8 @@ func (g *CodeGenerator) Generate(rnd *rand.Rand) (*st.Code, error) {
 		}
 
 		// Fill data if needed and continue with the rest.
-		if st.PUSH1 <= op && op <= st.PUSH32 {
-			width := int(op - st.PUSH1 + 1)
+		if PUSH1 <= op && op <= PUSH32 {
+			width := int(op - PUSH1 + 1)
 			rnd.Read(code[i+1 : i+1+width])
 			i += width
 		}

--- a/go/ct/gen/code_test.go
+++ b/go/ct/gen/code_test.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"pgregory.net/rand"
+
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 )
 
 func TestCodeGenerator_UnconstrainedGeneratorCanProduceCode(t *testing.T) {
@@ -65,14 +66,14 @@ func TestCodeGenerator_NonConflictingSizesAreAccepted(t *testing.T) {
 func TestCodeGenerator_OperationConstraintsAreEnforced(t *testing.T) {
 	tests := map[string][]struct {
 		pos int
-		op  st.OpCode
+		op  OpCode
 	}{
 		"empty":            {},
-		"single":           {{4, st.STOP}},
-		"multiple-no-data": {{4, st.STOP}, {6, st.ADD}, {2, st.INVALID}},
-		"pair":             {{4, st.PUSH1}, {7, st.PUSH32}},
-		"tight":            {{0, st.PUSH1}, {2, st.PUSH1}, {4, st.PUSH1}},
-		"wide":             {{2, st.PUSH1}, {20000, st.PUSH1}},
+		"single":           {{4, STOP}},
+		"multiple-no-data": {{4, STOP}, {6, ADD}, {2, INVALID}},
+		"pair":             {{4, PUSH1}, {7, PUSH32}},
+		"tight":            {{0, PUSH1}, {2, PUSH1}, {4, PUSH1}},
+		"wide":             {{2, PUSH1}, {20000, PUSH1}},
 	}
 
 	rnd := rand.New(0)
@@ -104,21 +105,21 @@ func TestCodeGenerator_OperationConstraintsAreEnforced(t *testing.T) {
 func TestCodeGenerator_ImpossibleConstraintsAreDetected(t *testing.T) {
 	type op struct {
 		pos int
-		op  st.OpCode
+		op  OpCode
 	}
 	tests := map[string]struct {
 		size int
 		ops  []op
 	}{
-		"too_small_code":                            {size: 2, ops: []op{{4, st.STOP}}},
-		"just_too_small":                            {size: 4, ops: []op{{4, st.STOP}}},
-		"conflicting_ops":                           {size: 4, ops: []op{{2, st.STOP}, {2, st.INVALID}}},
-		"operation_in_short_data_begin":             {size: 4, ops: []op{{0, st.PUSH2}, {1, st.STOP}}},
-		"operation_in_short_data_end":               {size: 4, ops: []op{{0, st.PUSH2}, {2, st.STOP}}},
-		"operation_in_long_data_begin":              {size: 40, ops: []op{{0, st.PUSH32}, {1, st.STOP}}},
-		"operation_in_long_data_mid":                {size: 40, ops: []op{{0, st.PUSH32}, {16, st.PUSH1}}},
-		"operation_in_long_data_end":                {size: 40, ops: []op{{0, st.PUSH32}, {32, st.PUSH32}}},
-		"add_operation_making_other_operation_data": {size: 40, ops: []op{{16, st.PUSH32}, {0, st.PUSH32}}},
+		"too_small_code":                            {size: 2, ops: []op{{4, STOP}}},
+		"just_too_small":                            {size: 4, ops: []op{{4, STOP}}},
+		"conflicting_ops":                           {size: 4, ops: []op{{2, STOP}, {2, INVALID}}},
+		"operation_in_short_data_begin":             {size: 4, ops: []op{{0, PUSH2}, {1, STOP}}},
+		"operation_in_short_data_end":               {size: 4, ops: []op{{0, PUSH2}, {2, STOP}}},
+		"operation_in_long_data_begin":              {size: 40, ops: []op{{0, PUSH32}, {1, STOP}}},
+		"operation_in_long_data_mid":                {size: 40, ops: []op{{0, PUSH32}, {16, PUSH1}}},
+		"operation_in_long_data_end":                {size: 40, ops: []op{{0, PUSH32}, {32, PUSH32}}},
+		"add_operation_making_other_operation_data": {size: 40, ops: []op{{16, PUSH32}, {0, PUSH32}}},
 	}
 
 	rnd := rand.New(0)
@@ -142,8 +143,8 @@ func TestCodeGenerator_ImpossibleConstraintsAreDetected(t *testing.T) {
 func TestCodeGenerator_CloneCopiesGeneratorState(t *testing.T) {
 	original := NewCodeGenerator()
 	original.SetSize(12)
-	original.SetOperation(4, st.PUSH2)
-	original.SetOperation(7, st.STOP)
+	original.SetOperation(4, PUSH2)
+	original.SetOperation(7, STOP)
 
 	clone := original.Clone()
 
@@ -154,15 +155,15 @@ func TestCodeGenerator_CloneCopiesGeneratorState(t *testing.T) {
 
 func TestCodeGenerator_ClonesAreIndependent(t *testing.T) {
 	base := NewCodeGenerator()
-	base.SetOperation(4, st.STOP)
+	base.SetOperation(4, STOP)
 
 	clone1 := base.Clone()
 	clone1.SetSize(12)
-	clone1.SetOperation(7, st.INVALID)
+	clone1.SetOperation(7, INVALID)
 
 	clone2 := base.Clone()
 	clone2.SetSize(14)
-	clone2.SetOperation(7, st.PUSH2)
+	clone2.SetOperation(7, PUSH2)
 
 	want := "{size=12,op[4]=STOP,op[7]=INVALID}"
 	if got := clone1.String(); got != want {
@@ -177,12 +178,12 @@ func TestCodeGenerator_ClonesAreIndependent(t *testing.T) {
 
 func TestCodeGenerator_ClonesCanBeUsedToResetGenerator(t *testing.T) {
 	generator := NewCodeGenerator()
-	generator.SetOperation(4, st.STOP)
+	generator.SetOperation(4, STOP)
 
 	backup := generator.Clone()
 
 	generator.SetSize(12)
-	generator.SetOperation(7, st.INVALID)
+	generator.SetOperation(7, INVALID)
 	want := "{size=12,op[4]=STOP,op[7]=INVALID}"
 	if got := generator.String(); got != want {
 		t.Errorf("unexpected generator state, wanted %s, got %s", want, got)

--- a/go/ct/gen/stack.go
+++ b/go/ct/gen/stack.go
@@ -8,7 +8,7 @@ import (
 
 	"pgregory.net/rand"
 
-	"github.com/Fantom-foundation/Tosca/go/ct"
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 )
 
@@ -19,7 +19,7 @@ type StackGenerator struct {
 
 type valueConstraint struct {
 	pos   int
-	value ct.U256
+	value U256
 }
 
 func (c *valueConstraint) Less(o *valueConstraint) bool {
@@ -39,7 +39,7 @@ func (g *StackGenerator) SetSize(size int) {
 	}
 }
 
-func (g *StackGenerator) SetValue(pos int, value ct.U256) {
+func (g *StackGenerator) SetValue(pos int, value U256) {
 	v := valueConstraint{pos, value}
 	if !slices.Contains(g.values, v) {
 		g.values = append(g.values, v)
@@ -84,7 +84,7 @@ func (g *StackGenerator) Generate(rnd *rand.Rand) (*st.Stack, error) {
 	// Fill in remaining slots
 	for i, isSet := range stackMask {
 		if !isSet {
-			stack.Set(i, ct.RandU256(rnd))
+			stack.Set(i, RandU256(rnd))
 		}
 	}
 

--- a/go/ct/gen/stack_test.go
+++ b/go/ct/gen/stack_test.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Fantom-foundation/Tosca/go/ct"
 	"pgregory.net/rand"
+
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 )
 
 func TestStackGenerator_UnconstrainedGeneratorCanProduceStack(t *testing.T) {
@@ -56,12 +57,12 @@ func TestStackGenerator_ConflictingSizesAreDetected(t *testing.T) {
 func TestStackGenerator_SetValueIsEnforced(t *testing.T) {
 	type value struct {
 		pos   int
-		value ct.U256
+		value U256
 	}
 	tests := [][]value{
-		{{0, ct.NewU256(1)}},
-		{{3, ct.NewU256(6)}},
-		{{42, ct.NewU256(21)}},
+		{{0, NewU256(1)}},
+		{{3, NewU256(6)}},
+		{{42, NewU256(21)}},
 	}
 
 	rnd := rand.New(0)
@@ -87,7 +88,7 @@ func TestStackGenerator_SetValueIsEnforced(t *testing.T) {
 
 func TestStackGenerator_NegativeValuePositionsAreDetected(t *testing.T) {
 	generator := NewStackGenerator()
-	generator.SetValue(-1, ct.NewU256(42))
+	generator.SetValue(-1, NewU256(42))
 	rnd := rand.New(0)
 	if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
 		t.Errorf("unsatisfiable constraint not detected, got %v", err)
@@ -96,8 +97,8 @@ func TestStackGenerator_NegativeValuePositionsAreDetected(t *testing.T) {
 
 func TestStackGenerator_NonConflictingValuesAreAccepted(t *testing.T) {
 	generator := NewStackGenerator()
-	generator.SetValue(0, ct.NewU256(42))
-	generator.SetValue(0, ct.NewU256(42))
+	generator.SetValue(0, NewU256(42))
+	generator.SetValue(0, NewU256(42))
 	rnd := rand.New(0)
 	if _, err := generator.Generate(rnd); err != nil {
 		t.Errorf("generation failed: %v", err)
@@ -106,8 +107,8 @@ func TestStackGenerator_NonConflictingValuesAreAccepted(t *testing.T) {
 
 func TestStackGenerator_ConflictingValuesAreDetected(t *testing.T) {
 	generator := NewStackGenerator()
-	generator.SetValue(0, ct.NewU256(42))
-	generator.SetValue(0, ct.NewU256(21))
+	generator.SetValue(0, NewU256(42))
+	generator.SetValue(0, NewU256(21))
 	rnd := rand.New(0)
 	if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
 		t.Errorf("unsatisfiable constraint not detected, got %v", err)
@@ -117,7 +118,7 @@ func TestStackGenerator_ConflictingValuesAreDetected(t *testing.T) {
 func TestStackGenerator_ConflictingValuePositionsWithSizesAreDetected(t *testing.T) {
 	generator := NewStackGenerator()
 	generator.SetSize(10)
-	generator.SetValue(10, ct.NewU256(21))
+	generator.SetValue(10, NewU256(21))
 	rnd := rand.New(0)
 	if _, err := generator.Generate(rnd); !errors.Is(err, ErrUnsatisfiable) {
 		t.Errorf("unsatisfiable constraint not detected, got %v", err)
@@ -127,8 +128,8 @@ func TestStackGenerator_ConflictingValuePositionsWithSizesAreDetected(t *testing
 func TestStackGenerator_CloneCopiesGeneratorState(t *testing.T) {
 	original := NewStackGenerator()
 	original.SetSize(5)
-	original.SetValue(0, ct.NewU256(42))
-	original.SetValue(0, ct.NewU256(43))
+	original.SetValue(0, NewU256(42))
+	original.SetValue(0, NewU256(43))
 
 	clone := original.Clone()
 
@@ -142,10 +143,10 @@ func TestStackGenerator_ClonesAreIndependent(t *testing.T) {
 	base.SetSize(5)
 
 	clone1 := base.Clone()
-	clone1.SetValue(0, ct.NewU256(16))
+	clone1.SetValue(0, NewU256(16))
 
 	clone2 := base.Clone()
-	clone2.SetValue(0, ct.NewU256(17))
+	clone2.SetValue(0, NewU256(17))
 
 	want := "{size=5,value[0]=0000000000000000 0000000000000000 0000000000000000 0000000000000010}"
 	if got := clone1.String(); got != want {
@@ -160,12 +161,12 @@ func TestStackGenerator_ClonesAreIndependent(t *testing.T) {
 
 func TestStackGenerator_ClonesCanBeUsedToResetGenerator(t *testing.T) {
 	generator := NewStackGenerator()
-	generator.SetValue(0, ct.NewU256(42))
+	generator.SetValue(0, NewU256(42))
 
 	backup := generator.Clone()
 
 	generator.SetSize(5)
-	generator.SetValue(1, ct.NewU256(16))
+	generator.SetValue(1, NewU256(16))
 
 	want := "{size=5,value[0]=0000000000000000 0000000000000000 0000000000000000 000000000000002a,value[1]=0000000000000000 0000000000000000 0000000000000000 0000000000000010}"
 	if got := generator.String(); got != want {

--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -6,9 +6,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Fantom-foundation/Tosca/go/ct"
-	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"pgregory.net/rand"
+
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
 )
 
 // StateGenerator is a utility class for generating States. It provides two
@@ -81,7 +82,7 @@ func (g *StateGenerator) SetCodeSize(size int) {
 }
 
 // SetCodeOperation wraps CodeGenerator.SetOperation.
-func (g *StateGenerator) SetCodeOperation(pos int, op st.OpCode) {
+func (g *StateGenerator) SetCodeOperation(pos int, op OpCode) {
 	g.codeGen.SetOperation(pos, op)
 }
 
@@ -91,7 +92,7 @@ func (g *StateGenerator) SetStackSize(size int) {
 }
 
 // SetStackValue wraps StackGenerator.SetValue.
-func (g *StateGenerator) SetStackValue(pos int, value ct.U256) {
+func (g *StateGenerator) SetStackValue(pos int, value U256) {
 	g.stackGen.SetValue(pos, value)
 }
 

--- a/go/ct/gen/state_test.go
+++ b/go/ct/gen/state_test.go
@@ -5,8 +5,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"pgregory.net/rand"
+
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
 )
 
 func TestStateGenerator_UnconstrainedGeneratorCanProduceState(t *testing.T) {

--- a/go/ct/rlz/conditions_test.go
+++ b/go/ct/rlz/conditions_test.go
@@ -3,7 +3,7 @@ package rlz
 import (
 	"testing"
 
-	"github.com/Fantom-foundation/Tosca/go/ct"
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 )
 
@@ -26,20 +26,20 @@ func TestCondition_Check(t *testing.T) {
 		valid     *st.State
 		invalid   *st.State
 	}{
-		{Eq(Pc(), ct.NewU256(42)), newStateWithPc(42), newStateWithPc(41)},
-		{Ne(Pc(), ct.NewU256(42)), newStateWithPc(41), newStateWithPc(42)},
-		{Lt(Pc(), ct.NewU256(42)), newStateWithPc(41), newStateWithPc(42)},
-		{Lt(Pc(), ct.NewU256(42)), newStateWithPc(41), newStateWithPc(43)},
-		{Le(Pc(), ct.NewU256(42)), newStateWithPc(41), newStateWithPc(43)},
-		{Le(Pc(), ct.NewU256(42)), newStateWithPc(42), newStateWithPc(43)},
-		{Le(Pc(), ct.NewU256(42)), newStateWithPc(42), newStateWithPc(44)},
-		{Gt(Pc(), ct.NewU256(42)), newStateWithPc(43), newStateWithPc(42)},
-		{Gt(Pc(), ct.NewU256(42)), newStateWithPc(43), newStateWithPc(41)},
-		{Ge(Pc(), ct.NewU256(42)), newStateWithPc(42), newStateWithPc(41)},
-		{Ge(Pc(), ct.NewU256(42)), newStateWithPc(43), newStateWithPc(41)},
-		{Ge(Pc(), ct.NewU256(42)), newStateWithPc(43), newStateWithPc(40)},
-		{And(Eq(Status(), st.Reverted), Eq(Pc(), ct.NewU256(42))), newStateWithStatusAndPc(st.Reverted, 42), newStateWithStatusAndPc(st.Returned, 42)},
-		{And(Eq(Status(), st.Reverted), Eq(Pc(), ct.NewU256(42))), newStateWithStatusAndPc(st.Reverted, 42), newStateWithStatusAndPc(st.Reverted, 41)},
+		{Eq(Pc(), NewU256(42)), newStateWithPc(42), newStateWithPc(41)},
+		{Ne(Pc(), NewU256(42)), newStateWithPc(41), newStateWithPc(42)},
+		{Lt(Pc(), NewU256(42)), newStateWithPc(41), newStateWithPc(42)},
+		{Lt(Pc(), NewU256(42)), newStateWithPc(41), newStateWithPc(43)},
+		{Le(Pc(), NewU256(42)), newStateWithPc(41), newStateWithPc(43)},
+		{Le(Pc(), NewU256(42)), newStateWithPc(42), newStateWithPc(43)},
+		{Le(Pc(), NewU256(42)), newStateWithPc(42), newStateWithPc(44)},
+		{Gt(Pc(), NewU256(42)), newStateWithPc(43), newStateWithPc(42)},
+		{Gt(Pc(), NewU256(42)), newStateWithPc(43), newStateWithPc(41)},
+		{Ge(Pc(), NewU256(42)), newStateWithPc(42), newStateWithPc(41)},
+		{Ge(Pc(), NewU256(42)), newStateWithPc(43), newStateWithPc(41)},
+		{Ge(Pc(), NewU256(42)), newStateWithPc(43), newStateWithPc(40)},
+		{And(Eq(Status(), st.Reverted), Eq(Pc(), NewU256(42))), newStateWithStatusAndPc(st.Reverted, 42), newStateWithStatusAndPc(st.Returned, 42)},
+		{And(Eq(Status(), st.Reverted), Eq(Pc(), NewU256(42))), newStateWithStatusAndPc(st.Reverted, 42), newStateWithStatusAndPc(st.Reverted, 41)},
 	}
 
 	for _, test := range tests {
@@ -59,12 +59,12 @@ func TestCondition_String(t *testing.T) {
 	}{
 		{And(), "true"},
 		{And(And(), And()), "true"},
-		{Eq(Pc(), ct.NewU256(42)), "PC = 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
-		{Ne(Pc(), ct.NewU256(42)), "PC ≠ 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
-		{Lt(Pc(), ct.NewU256(42)), "PC < 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
-		{Le(Pc(), ct.NewU256(42)), "PC ≤ 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
-		{Gt(Pc(), ct.NewU256(42)), "PC > 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
-		{Ge(Pc(), ct.NewU256(42)), "PC ≥ 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
+		{Eq(Pc(), NewU256(42)), "PC = 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
+		{Ne(Pc(), NewU256(42)), "PC ≠ 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
+		{Lt(Pc(), NewU256(42)), "PC < 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
+		{Le(Pc(), NewU256(42)), "PC ≤ 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
+		{Gt(Pc(), NewU256(42)), "PC > 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
+		{Ge(Pc(), NewU256(42)), "PC ≥ 0000000000000000 0000000000000000 0000000000000000 000000000000002a"},
 		{And(Eq(Status(), st.Running), Eq(Status(), st.Failed)), "status = running ∧ status = failed"},
 	}
 

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -3,7 +3,7 @@ package rlz
 import (
 	"math"
 
-	"github.com/Fantom-foundation/Tosca/go/ct"
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 )
 
@@ -115,21 +115,21 @@ func (uint64Domain) SamplesForAll(as []uint64) []uint64 {
 
 type u256Domain struct{}
 
-func (u256Domain) Equal(a ct.U256, b ct.U256) bool { return a.Eq(b) }
-func (u256Domain) Less(a ct.U256, b ct.U256) bool  { return a.Lt(b) }
-func (u256Domain) Predecessor(a ct.U256) ct.U256   { return a.Sub(ct.NewU256(1)) }
-func (u256Domain) Successor(a ct.U256) ct.U256     { return a.Add(ct.NewU256(1)) }
+func (u256Domain) Equal(a U256, b U256) bool { return a.Eq(b) }
+func (u256Domain) Less(a U256, b U256) bool  { return a.Lt(b) }
+func (u256Domain) Predecessor(a U256) U256   { return a.Sub(NewU256(1)) }
+func (u256Domain) Successor(a U256) U256     { return a.Add(NewU256(1)) }
 
-func (u256Domain) SomethingNotEqual(a ct.U256) ct.U256 {
-	return a.Add(ct.NewU256(1))
+func (u256Domain) SomethingNotEqual(a U256) U256 {
+	return a.Add(NewU256(1))
 }
 
-func (d u256Domain) Samples(a ct.U256) []ct.U256 {
-	return d.SamplesForAll([]ct.U256{a})
+func (d u256Domain) Samples(a U256) []U256 {
+	return d.SamplesForAll([]U256{a})
 }
 
-func (d u256Domain) SamplesForAll(as []ct.U256) []ct.U256 {
-	res := []ct.U256{}
+func (d u256Domain) SamplesForAll(as []U256) []U256 {
+	res := []U256{}
 
 	// Test every element off by one.
 	for _, a := range as {
@@ -176,17 +176,17 @@ func (statusCodeDomain) SamplesForAll(a []st.StatusCode) []st.StatusCode {
 
 type pcDomain struct{}
 
-func (pcDomain) Equal(a ct.U256, b ct.U256) bool     { return a.Eq(b) }
-func (pcDomain) Less(a ct.U256, b ct.U256) bool      { return a.Lt(b) }
-func (pcDomain) Predecessor(a ct.U256) ct.U256       { return a.Sub(ct.NewU256(1)) }
-func (pcDomain) Successor(a ct.U256) ct.U256         { return a.Add(ct.NewU256(1)) }
-func (pcDomain) SomethingNotEqual(a ct.U256) ct.U256 { return a.Add(ct.NewU256(1)) }
+func (pcDomain) Equal(a U256, b U256) bool     { return a.Eq(b) }
+func (pcDomain) Less(a U256, b U256) bool      { return a.Lt(b) }
+func (pcDomain) Predecessor(a U256) U256       { return a.Sub(NewU256(1)) }
+func (pcDomain) Successor(a U256) U256         { return a.Add(NewU256(1)) }
+func (pcDomain) SomethingNotEqual(a U256) U256 { return a.Add(NewU256(1)) }
 
-func (d pcDomain) Samples(a ct.U256) []ct.U256 {
-	return d.SamplesForAll([]ct.U256{a})
+func (d pcDomain) Samples(a U256) []U256 {
+	return d.SamplesForAll([]U256{a})
 }
 
-func (pcDomain) SamplesForAll(as []ct.U256) []ct.U256 {
+func (pcDomain) SamplesForAll(as []U256) []U256 {
 	pcs := []uint16{}
 	for _, a := range as {
 		if a.IsUint64() && a.Uint64() <= uint64(math.MaxUint16) {
@@ -196,9 +196,9 @@ func (pcDomain) SamplesForAll(as []ct.U256) []ct.U256 {
 
 	pcs = uint16Domain{}.SamplesForAll(pcs)
 
-	res := make([]ct.U256, 0, len(pcs))
+	res := make([]U256, 0, len(pcs))
 	for _, cur := range pcs {
-		res = append(res, ct.NewU256(uint64(cur)))
+		res = append(res, NewU256(uint64(cur)))
 	}
 	return res
 }

--- a/go/ct/rlz/expressions.go
+++ b/go/ct/rlz/expressions.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/Fantom-foundation/Tosca/go/ct"
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/gen"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 )
@@ -51,17 +51,17 @@ func (status) String() string {
 
 type pc struct{}
 
-func Pc() Expression[ct.U256] {
+func Pc() Expression[U256] {
 	return pc{}
 }
 
-func (pc) Domain() Domain[ct.U256] { return pcDomain{} }
+func (pc) Domain() Domain[U256] { return pcDomain{} }
 
-func (pc) Eval(s *st.State) ct.U256 {
-	return ct.NewU256(uint64(s.Pc))
+func (pc) Eval(s *st.State) U256 {
+	return NewU256(uint64(s.Pc))
 }
 
-func (pc) Restrict(pc ct.U256, generator *gen.StateGenerator) {
+func (pc) Restrict(pc U256, generator *gen.StateGenerator) {
 	if !pc.IsUint64() || pc.Uint64() > uint64(math.MaxUint16) {
 		panic("invalid value for PC")
 	}

--- a/go/ct/rlz/expressions_test.go
+++ b/go/ct/rlz/expressions_test.go
@@ -5,7 +5,7 @@ import (
 
 	"pgregory.net/rand"
 
-	"github.com/Fantom-foundation/Tosca/go/ct"
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/gen"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 )
@@ -34,14 +34,14 @@ func TestExpression_StatusRestrict(t *testing.T) {
 func TestExpression_PcEval(t *testing.T) {
 	state := st.NewState(st.NewCode([]byte{}))
 	state.Pc = 42
-	if Pc().Eval(state) != ct.NewU256(42) {
+	if Pc().Eval(state) != NewU256(42) {
 		t.Fail()
 	}
 }
 
 func TestExpression_PcRestrict(t *testing.T) {
 	generator := gen.NewStateGenerator()
-	Pc().Restrict(ct.NewU256(42), generator)
+	Pc().Restrict(NewU256(42), generator)
 
 	state, err := generator.Generate(rand.New(0))
 	if err != nil {
@@ -75,9 +75,9 @@ func TestExpression_GasRestrict(t *testing.T) {
 
 func TestExpression_StackSizeEval(t *testing.T) {
 	state := st.NewState(st.NewCode([]byte{}))
-	state.Stack.Push(ct.NewU256(1))
-	state.Stack.Push(ct.NewU256(2))
-	state.Stack.Push(ct.NewU256(4))
+	state.Stack.Push(NewU256(1))
+	state.Stack.Push(NewU256(2))
+	state.Stack.Push(NewU256(4))
 	if StackSize().Eval(state) != 3 {
 		t.Fail()
 	}

--- a/go/ct/rlz/parameters.go
+++ b/go/ct/rlz/parameters.go
@@ -1,31 +1,31 @@
 package rlz
 
 import (
-	"github.com/Fantom-foundation/Tosca/go/ct"
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 )
 
 type Parameter interface {
-	Samples(example ct.U256) []ct.U256
+	Samples(example U256) []U256
 }
 
 type NumericParameter struct{}
 
-func (n NumericParameter) Samples(ct.U256) []ct.U256 {
+func (n NumericParameter) Samples(U256) []U256 {
 	return n.SampleValues()
 }
 
-func (NumericParameter) SampleValues() []ct.U256 {
-	return []ct.U256{
-		ct.NewU256(0),
-		ct.NewU256(1),
-		ct.NewU256(1 << 8),
-		ct.NewU256(1 << 16),
-		ct.NewU256(1 << 32),
-		ct.NewU256(1 << 48),
-		ct.NewU256(1).Shl(ct.NewU256(64)),
-		ct.NewU256(1).Shl(ct.NewU256(128)),
-		ct.NewU256(1).Shl(ct.NewU256(192)),
-		ct.NewU256(1).Shl(ct.NewU256(255)),
-		ct.NewU256(0).Not(),
+func (NumericParameter) SampleValues() []U256 {
+	return []U256{
+		NewU256(0),
+		NewU256(1),
+		NewU256(1 << 8),
+		NewU256(1 << 16),
+		NewU256(1 << 32),
+		NewU256(1 << 48),
+		NewU256(1).Shl(NewU256(64)),
+		NewU256(1).Shl(NewU256(128)),
+		NewU256(1).Shl(NewU256(192)),
+		NewU256(1).Shl(NewU256(255)),
+		NewU256(0).Not(),
 	}
 }

--- a/go/ct/rlz/rules_test.go
+++ b/go/ct/rlz/rules_test.go
@@ -5,7 +5,7 @@ import (
 
 	"pgregory.net/rand"
 
-	"github.com/Fantom-foundation/Tosca/go/ct"
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 )
 
@@ -13,8 +13,8 @@ func TestRule_GenerateSatisfyingState(t *testing.T) {
 	tests := []Condition{
 		And(), // = anything
 		Eq(Status(), st.Failed),
-		Eq(Pc(), ct.NewU256(42)),
-		And(Eq(Status(), st.Failed), Eq(Pc(), ct.NewU256(42))),
+		Eq(Pc(), NewU256(42)),
+		And(Eq(Status(), st.Failed), Eq(Pc(), NewU256(42))),
 	}
 
 	rnd := rand.New(0)
@@ -35,8 +35,8 @@ func TestRule_EnumerateTestCases(t *testing.T) {
 	tests := []Condition{
 		And(), // = anything
 		Eq(Status(), st.Failed),
-		Eq(Pc(), ct.NewU256(42)),
-		And(Eq(Status(), st.Failed), Eq(Pc(), ct.NewU256(42))),
+		Eq(Pc(), NewU256(42)),
+		And(Eq(Status(), st.Failed), Eq(Pc(), NewU256(42))),
 	}
 
 	rnd := rand.New(0)

--- a/go/ct/st/code.go
+++ b/go/ct/st/code.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/Fantom-foundation/Tosca/go/ct/common"
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 )
 
 // Code is an immutable representation of EVM byte code which may be freely
@@ -17,7 +17,7 @@ type Code struct {
 
 // ErrInvalidPosition is an error produced by observer functions on the Code if
 // specified positions are invalid.
-const ErrInvalidPosition = common.ConstErr("invalid position")
+const ErrInvalidPosition = ConstErr("invalid position")
 
 // NewCode creates an immutable code representation based on the given raw
 // code representation. The resulting code contains a copy of the provided code

--- a/go/ct/st/code_test.go
+++ b/go/ct/st/code_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"testing"
+
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 )
 
 func TestCode_IsCode(t *testing.T) {

--- a/go/ct/st/stack.go
+++ b/go/ct/st/stack.go
@@ -3,24 +3,25 @@ package st
 import (
 	"fmt"
 
-	"github.com/Fantom-foundation/Tosca/go/ct"
 	"golang.org/x/exp/slices"
+
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 )
 
 // Stack represent's the EVM's execution stack.
 type Stack struct {
-	stack []ct.U256
+	stack []U256
 }
 
 // NewStack creates a new stack filled with the given values.
-func NewStack(values ...ct.U256) *Stack {
+func NewStack(values ...U256) *Stack {
 	return &Stack{values}
 }
 
 // NewStackWithSize creates a new stack with the given size, all elements
 // initialized to zero.
 func NewStackWithSize(size int) *Stack {
-	return &Stack{make([]ct.U256, size)}
+	return &Stack{make([]U256, size)}
 }
 
 // Clone creates an independent copy of the stack.
@@ -34,24 +35,24 @@ func (s *Stack) Size() int {
 
 // Get returns the value located the given index. The index must not be
 // out-of-bounds.
-func (s *Stack) Get(index int) ct.U256 {
+func (s *Stack) Get(index int) U256 {
 	return s.stack[s.Size()-index-1]
 }
 
 // Set places the given value at the given position on the stack. The index must
 // not be out-of-bounds.
-func (s *Stack) Set(index int, value ct.U256) {
+func (s *Stack) Set(index int, value U256) {
 	s.stack[s.Size()-index-1] = value
 }
 
 // Push adds the given value to the top of the stack.
-func (s *Stack) Push(value ct.U256) {
+func (s *Stack) Push(value U256) {
 	s.stack = append(s.stack, value)
 }
 
 // Pop removes the top most value from the stack and returns it. The stack must
 // not be empty.
-func (s *Stack) Pop() ct.U256 {
+func (s *Stack) Pop() U256 {
 	value := s.stack[s.Size()-1]
 	s.stack = s.stack[:s.Size()-1]
 	return value

--- a/go/ct/st/stack_test.go
+++ b/go/ct/st/stack_test.go
@@ -3,7 +3,7 @@ package st
 import (
 	"testing"
 
-	"github.com/Fantom-foundation/Tosca/go/ct"
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 )
 
 func TestStack_NewStack(t *testing.T) {
@@ -12,7 +12,7 @@ func TestStack_NewStack(t *testing.T) {
 		t.Errorf("unexpected stack size, want %v, got %v", want, got)
 	}
 
-	stack = NewStack(ct.NewU256(1))
+	stack = NewStack(NewU256(1))
 	if want, got := 1, stack.Size(); want != got {
 		t.Errorf("unexpected stack size, want %v, got %v", want, got)
 	}
@@ -24,33 +24,33 @@ func TestStack_NewStackWithSize(t *testing.T) {
 		t.Errorf("unexpected stack size, want %v, got %v", want, got)
 	}
 	for i := 0; i < stack.Size(); i++ {
-		if !stack.Get(i).Eq(ct.NewU256(0)) {
+		if !stack.Get(i).Eq(NewU256(0)) {
 			t.Errorf("unexpected non-zero value at index %d", i)
 		}
 	}
 }
 
 func TestStack_Clone(t *testing.T) {
-	stack := NewStack(ct.NewU256(42))
+	stack := NewStack(NewU256(42))
 	clone := stack.Clone()
 
 	if stack.Size() != clone.Size() {
 		t.Error("Clone does not have the same size")
 	}
 
-	stack.Push(ct.NewU256(21))
+	stack.Push(NewU256(21))
 	if clone.Size() != 1 {
 		t.Error("Clone is not independent from original")
 	}
 
-	stack.Set(1, ct.NewU256(43))
-	if !clone.Get(0).Eq(ct.NewU256(42)) {
+	stack.Set(1, NewU256(43))
+	if !clone.Get(0).Eq(NewU256(42)) {
 		t.Error("Clone is not independent from original")
 	}
 }
 
 func TestStack_Get(t *testing.T) {
-	stack := NewStack(ct.NewU256(1), ct.NewU256(2), ct.NewU256(3))
+	stack := NewStack(NewU256(1), NewU256(2), NewU256(3))
 	if want, got := uint64(3), stack.Get(0).Uint64(); want != got {
 		t.Errorf("unexpected stack value at position 0, want %v, got %v", want, got)
 	}
@@ -63,8 +63,8 @@ func TestStack_Get(t *testing.T) {
 }
 
 func TestStack_Set(t *testing.T) {
-	stack := NewStack(ct.NewU256(2))
-	stack.Set(0, ct.NewU256(4))
+	stack := NewStack(NewU256(2))
+	stack.Set(0, NewU256(4))
 	if want, got := uint64(4), stack.Get(0).Uint64(); want != got {
 		t.Errorf("unexpected stack value at position 0, want %v, got %v", want, got)
 	}
@@ -73,7 +73,7 @@ func TestStack_Set(t *testing.T) {
 func TestStack_Push(t *testing.T) {
 	stack := NewStack()
 
-	stack.Push(ct.NewU256(42))
+	stack.Push(NewU256(42))
 	if want, got := 1, stack.Size(); want != got {
 		t.Errorf("unexpected stack size, want %v, got %v", want, got)
 	}
@@ -81,7 +81,7 @@ func TestStack_Push(t *testing.T) {
 		t.Errorf("unexpected stack value at position 0, want %v, got %v", want, got)
 	}
 
-	stack.Push(ct.NewU256(16))
+	stack.Push(NewU256(16))
 	if want, got := 2, stack.Size(); want != got {
 		t.Errorf("unexpected stack size, want %v, got %v", want, got)
 	}
@@ -94,7 +94,7 @@ func TestStack_Push(t *testing.T) {
 }
 
 func TestStack_Pop(t *testing.T) {
-	stack := NewStack(ct.NewU256(1), ct.NewU256(2))
+	stack := NewStack(NewU256(1), NewU256(2))
 
 	value := stack.Pop().Uint64()
 	if value != 2 {
@@ -114,13 +114,13 @@ func TestStack_Pop(t *testing.T) {
 }
 
 func TestStack_Eq(t *testing.T) {
-	stack1 := NewStack(ct.NewU256(1), ct.NewU256(2))
-	stack2 := NewStack(ct.NewU256(1), ct.NewU256(2))
+	stack1 := NewStack(NewU256(1), NewU256(2))
+	stack2 := NewStack(NewU256(1), NewU256(2))
 	if !stack1.Eq(stack2) {
 		t.Errorf("unexpected stack inequality %v vs. %v", stack1.stack, stack2.stack)
 	}
 
-	stack2.Set(0, ct.NewU256(42))
+	stack2.Set(0, NewU256(42))
 	if stack1.Eq(stack2) {
 		t.Errorf("unexpected stack equality %v vs. %v", stack1.stack, stack2.stack)
 	}

--- a/go/ct/st/state.go
+++ b/go/ct/st/state.go
@@ -3,6 +3,8 @@ package st
 import (
 	"fmt"
 	"strings"
+
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 )
 
 ////////////////////////////////////////////////////////////

--- a/go/ct/st/state_test.go
+++ b/go/ct/st/state_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Fantom-foundation/Tosca/go/ct"
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 )
 
 func TestState_CloneIsIndependent(t *testing.T) {
@@ -15,14 +15,14 @@ func TestState_CloneIsIndependent(t *testing.T) {
 	state.Revision = London
 	state.Pc = 1
 	state.Gas = 2
-	state.Stack.Push(ct.NewU256(3))
+	state.Stack.Push(NewU256(3))
 
 	clone := state.Clone()
 	clone.Status = Running
 	clone.Revision = Berlin
 	clone.Pc = 4
 	clone.Gas = 5
-	clone.Stack.Push(ct.NewU256(6))
+	clone.Stack.Push(NewU256(6))
 
 	ok := state.Status == Stopped &&
 		state.Revision == London &&
@@ -70,11 +70,11 @@ func TestState_Eq(t *testing.T) {
 	}
 	s2.Gas = 1
 
-	s1.Stack.Push(ct.NewU256(1))
+	s1.Stack.Push(NewU256(1))
 	if s1.Eq(s2) {
 		t.Fail()
 	}
-	s2.Stack.Push(ct.NewU256(1))
+	s2.Stack.Push(NewU256(1))
 
 	if !s1.Eq(s2) {
 		t.Fail()
@@ -271,9 +271,9 @@ func TestState_PrinterAbbreviatedCode(t *testing.T) {
 
 func TestState_PrinterStackSize(t *testing.T) {
 	s := NewState(NewCode([]byte{}))
-	s.Stack.Push(ct.NewU256(1))
-	s.Stack.Push(ct.NewU256(2))
-	s.Stack.Push(ct.NewU256(3))
+	s.Stack.Push(NewU256(1))
+	s.Stack.Push(NewU256(2))
+	s.Stack.Push(NewU256(3))
 
 	r := regexp.MustCompile(`Stack size: ([[:digit:]]+)`)
 	match := r.FindStringSubmatch(s.String())
@@ -293,14 +293,14 @@ func TestState_DiffMatch(t *testing.T) {
 	s1.Revision = London
 	s1.Pc = 3
 	s1.Gas = 42
-	s1.Stack.Push(ct.NewU256(42))
+	s1.Stack.Push(NewU256(42))
 
 	s2 := NewState(NewCode([]byte{byte(PUSH2), 7, 4, byte(ADD), byte(STOP)}))
 	s2.Status = Running
 	s2.Revision = London
 	s2.Pc = 3
 	s2.Gas = 42
-	s2.Stack.Push(ct.NewU256(42))
+	s2.Stack.Push(NewU256(42))
 
 	diffs := s1.Diff(s2)
 
@@ -319,14 +319,14 @@ func TestState_DiffMismatch(t *testing.T) {
 	s1.Revision = Berlin
 	s1.Pc = 0
 	s1.Gas = 7
-	s1.Stack.Push(ct.NewU256(42))
+	s1.Stack.Push(NewU256(42))
 
 	s2 := NewState(NewCode([]byte{byte(PUSH2), 7, 4, byte(ADD), byte(STOP)}))
 	s2.Status = Running
 	s2.Revision = London
 	s2.Pc = 3
 	s2.Gas = 42
-	s2.Stack.Push(ct.NewU256(16))
+	s2.Stack.Push(NewU256(16))
 
 	diffs := s1.Diff(s2)
 

--- a/go/ct/staticcheck.conf
+++ b/go/ct/staticcheck.conf
@@ -1,0 +1,1 @@
+dot_import_whitelist = ["github.com/Fantom-foundation/Tosca/go/ct/common"]


### PR DESCRIPTION
This PR affects many lines since OpCodes and U256 used heavily across the code-base; however, I think accessing U256 and OpCodes without prefix reduces code noise.

- Move `st.OpCode` to `common`
- Add `JUMP` and `JUMPDEST` OpCodes
- Move `ct.U256` to `common`
- Import `common` sub-package without prefix
- Add linter config to suppress warnings about importing `common` without prefix