### PR TITLE
ct: Propagate condition check errors

### DIFF
--- a/go/ct/rlz/conditions_test.go
+++ b/go/ct/rlz/conditions_test.go
@@ -43,10 +43,19 @@ func TestCondition_Check(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if !test.condition.Check(test.valid) {
+		valid, err := test.condition.Check(test.valid)
+		if err != nil {
+			t.Errorf("Condition check error %v", err)
+		}
+		if !valid {
 			t.Errorf("Condition %v should be valid for\n%v", test.condition, test.valid)
 		}
-		if test.condition.Check(test.invalid) {
+
+		invalid, err := test.condition.Check(test.invalid)
+		if err != nil {
+			t.Errorf("Condition check error %v", err)
+		}
+		if invalid {
 			t.Errorf("Condition %v should not be valid for\n%v", test.condition, test.invalid)
 		}
 	}

--- a/go/ct/rlz/expressions.go
+++ b/go/ct/rlz/expressions.go
@@ -13,7 +13,7 @@ type Expression[T any] interface {
 	Domain() Domain[T]
 
 	// Eval evaluates this expression on the given state.
-	Eval(*st.State) T
+	Eval(*st.State) (T, error)
 
 	// Restrict applies constraints to the given generator such that this
 	// expression evaluates to the given value when invoked on the generated
@@ -34,8 +34,8 @@ func Status() Expression[st.StatusCode] {
 
 func (status) Domain() Domain[st.StatusCode] { return statusCodeDomain{} }
 
-func (status) Eval(s *st.State) st.StatusCode {
-	return s.Status
+func (status) Eval(s *st.State) (st.StatusCode, error) {
+	return s.Status, nil
 }
 
 func (status) Restrict(status st.StatusCode, generator *gen.StateGenerator) {
@@ -57,8 +57,8 @@ func Pc() Expression[U256] {
 
 func (pc) Domain() Domain[U256] { return pcDomain{} }
 
-func (pc) Eval(s *st.State) U256 {
-	return NewU256(uint64(s.Pc))
+func (pc) Eval(s *st.State) (U256, error) {
+	return NewU256(uint64(s.Pc)), nil
 }
 
 func (pc) Restrict(pc U256, generator *gen.StateGenerator) {
@@ -83,8 +83,8 @@ func Gas() Expression[uint64] {
 
 func (gas) Domain() Domain[uint64] { return uint64Domain{} }
 
-func (gas) Eval(s *st.State) uint64 {
-	return s.Gas
+func (gas) Eval(s *st.State) (uint64, error) {
+	return s.Gas, nil
 }
 
 func (gas) Restrict(amount uint64, generator *gen.StateGenerator) {
@@ -106,8 +106,8 @@ func StackSize() Expression[int] {
 
 func (stackSize) Domain() Domain[int] { return stackSizeDomain{} }
 
-func (stackSize) Eval(s *st.State) int {
-	return s.Stack.Size()
+func (stackSize) Eval(s *st.State) (int, error) {
+	return s.Stack.Size(), nil
 }
 
 func (stackSize) Restrict(size int, generator *gen.StateGenerator) {

--- a/go/ct/rlz/expressions_test.go
+++ b/go/ct/rlz/expressions_test.go
@@ -13,7 +13,7 @@ import (
 func TestExpression_StatusEval(t *testing.T) {
 	state := st.NewState(st.NewCode([]byte{}))
 	state.Status = st.Reverted
-	if Status().Eval(state) != st.Reverted {
+	if s, err := Status().Eval(state); err != nil || s != st.Reverted {
 		t.Fail()
 	}
 }
@@ -34,7 +34,7 @@ func TestExpression_StatusRestrict(t *testing.T) {
 func TestExpression_PcEval(t *testing.T) {
 	state := st.NewState(st.NewCode([]byte{}))
 	state.Pc = 42
-	if Pc().Eval(state) != NewU256(42) {
+	if pc, err := Pc().Eval(state); err != nil || pc != NewU256(42) {
 		t.Fail()
 	}
 }
@@ -55,7 +55,7 @@ func TestExpression_PcRestrict(t *testing.T) {
 func TestExpression_GasEval(t *testing.T) {
 	state := st.NewState(st.NewCode([]byte{}))
 	state.Gas = 42
-	if Gas().Eval(state) != 42 {
+	if gas, err := Gas().Eval(state); err != nil || gas != 42 {
 		t.Fail()
 	}
 }
@@ -78,7 +78,7 @@ func TestExpression_StackSizeEval(t *testing.T) {
 	state.Stack.Push(NewU256(1))
 	state.Stack.Push(NewU256(2))
 	state.Stack.Push(NewU256(4))
-	if StackSize().Eval(state) != 3 {
+	if size, err := StackSize().Eval(state); err != nil || size != 3 {
 		t.Fail()
 	}
 }

--- a/go/ct/rlz/rules_test.go
+++ b/go/ct/rlz/rules_test.go
@@ -25,7 +25,12 @@ func TestRule_GenerateSatisfyingState(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to generate state: %v", err)
 		}
-		if !test.Check(state) {
+
+		satisfied, err := test.Check(state)
+		if err != nil {
+			t.Errorf("Condition check error %v", err)
+		}
+		if !satisfied {
 			t.Errorf("Generated state does not satisfy condition %v: %v", test, &state)
 		}
 	}
@@ -47,7 +52,11 @@ func TestRule_EnumerateTestCases(t *testing.T) {
 
 		rule := Rule{Condition: test}
 		err := rule.EnumerateTestCases(rnd, func(sample *st.State) {
-			if test.Check(sample) {
+			match, err := test.Check(sample)
+			if err != nil {
+				t.Errorf("Condition check error %v", err)
+			}
+			if match {
 				matches++
 			} else {
 				misses++


### PR DESCRIPTION
This PR adjusts the Condition interface to propagate errors encountered during `Check`.

For conjunctions: the whole conjunction results in an error if one or more operands emit an error. No short-circuit evaluation in the non-error case here!