### PR TITLE
lfvm: Fix padNoOpsUntil function not actually padding

### DIFF
--- a/go/vm/lfvm/converter.go
+++ b/go/vm/lfvm/converter.go
@@ -88,8 +88,8 @@ func (b *codeBuilder) appendData(data uint16) *codeBuilder {
 }
 
 func (b *codeBuilder) padNoOpsUntil(pos int) {
-	for _, op := range b.code[b.nextPos:pos] {
-		op.opcode = NOOP
+	for i := b.nextPos; i < pos; i++ {
+		b.code[i].opcode = NOOP
 	}
 	b.nextPos = pos
 }


### PR DESCRIPTION
This PR fixes a bug in the `padNoOpsUntil` function which was operating on a copy instead of the original value and thus did not actually insert `noops`, but rather left everything unchanged.