### PR TITLE
ct: Use parameter samples in test case enumeration

### DIFF
--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -139,7 +139,7 @@ func (d u256Domain) SamplesForAll(as []U256) []U256 {
 	}
 
 	// Add more interesting values.
-	res = append(res, NumericParameter{}.SampleValues()...)
+	res = append(res, NumericParameter{}.Samples()...)
 
 	// TODO: consider removing duplicates.
 

--- a/go/ct/rlz/parameters.go
+++ b/go/ct/rlz/parameters.go
@@ -5,16 +5,12 @@ import (
 )
 
 type Parameter interface {
-	Samples(example U256) []U256
+	Samples() []U256
 }
 
 type NumericParameter struct{}
 
-func (n NumericParameter) Samples(U256) []U256 {
-	return n.SampleValues()
-}
-
-func (NumericParameter) SampleValues() []U256 {
+func (NumericParameter) Samples() []U256 {
 	return []U256{
 		NewU256(0),
 		NewU256(1),


### PR DESCRIPTION
I just noticed that we are still not utilizing the parameter samples when enumerating tests cases.

In the prototype `Parameter.Samples` used an example value, which is unused for `NumericParameter`. `Samples` is called here:

https://github.com/Fantom-foundation/Tosca/blob/2afbb33a1e2e2f69eb2c4ff158e533ebcd134b4c/go/ct/rule.go#L77-L88

Yet, our current architecture has no way of asking a generator for a specific stack value. I decided to drop the example value for now since we only support `NumericParameter` at the moment.