### PR TITLE
lfvm: Implement CT interface

### DIFF
--- a/go/ct/st/evm.go
+++ b/go/ct/st/evm.go
@@ -1,0 +1,8 @@
+package st
+
+// Evm represents the interface through which the CT can test a specific EVM implementation.
+type Evm interface {
+	// StepN executes up to N instructions on the given state, returning the resulting state or an error.
+	// The function may modify the provided state to produce the result state.
+	StepN(state *State, numSteps int) (*State, error)
+}

--- a/go/vm/lfvm/converter.go
+++ b/go/vm/lfvm/converter.go
@@ -176,6 +176,11 @@ func GenPcMap(code []byte, with_super_instructions bool) (*PcMap, error) {
 		inc := appendInstructions(&res, i, code, with_super_instructions)
 		i += inc + 1
 	}
+
+	// One past the end is a valid state for the PC after the execution has stopped.
+	pcMap.evmToLfvm[uint16(len(code))] = uint16(res.length())
+	pcMap.lfvmToEvm[uint16(res.length())] = uint16(len(code))
+
 	return &pcMap, nil
 }
 

--- a/go/vm/lfvm/ct_adapter.go
+++ b/go/vm/lfvm/ct_adapter.go
@@ -1,0 +1,22 @@
+package lfvm
+
+import "github.com/Fantom-foundation/Tosca/go/ct/st"
+
+type ctAdapter struct{}
+
+func NewConformanceTestingTarget() st.Evm {
+	return ctAdapter{}
+}
+
+func (ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
+	c, err := ConvertCtStateToLfvmContext(state)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; c.status == RUNNING && i < numSteps; i++ {
+		step(c)
+	}
+
+	return ConvertLfvmContextToCtState(c, state.Code)
+}

--- a/go/vm/lfvm/ct_adapter_test.go
+++ b/go/vm/lfvm/ct_adapter_test.go
@@ -1,0 +1,44 @@
+package lfvm
+
+import (
+	"testing"
+
+	ct "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+)
+
+func TestCtAdapter_Add(t *testing.T) {
+	s := &st.State{
+		Status:   st.Running,
+		Revision: st.Istanbul,
+		Pc:       0,
+		Gas:      100,
+		Code: st.NewCode([]byte{
+			byte(ct.PUSH1), 3,
+			byte(ct.PUSH1), 4,
+			byte(ct.ADD),
+		}),
+		Stack: st.NewStack(),
+	}
+
+	c := NewConformanceTestingTarget()
+
+	s, err := c.StepN(s, 4)
+
+	if err != nil {
+		t.Fatalf("unexpected conversion error: %v", err)
+	}
+
+	if want, got := st.Stopped, s.Status; want != got {
+		t.Fatalf("unexpected status: wanted %v, got %v", want, got)
+	}
+
+	if want, got := ct.NewU256(3+4), s.Stack.Get(0); !want.Eq(got) {
+		t.Errorf("unexpected result: wanted %s, got %s", want, got)
+	}
+}
+
+func TestCtAdapter_Interface(t *testing.T) {
+	// Compile time check that ctAdapter implements the st.Evm interface.
+	var _ st.Evm = ctAdapter{}
+}

--- a/go/vm/lfvm/ct_test.go
+++ b/go/vm/lfvm/ct_test.go
@@ -80,9 +80,10 @@ func TestConvertToLfvm_Pc(t *testing.T) {
 		evmPc   uint16
 		lfvmPc  uint16
 	}{
-		"empty": {{}},
-		"pos-0": {{[]byte{byte(ct.STOP)}, 0, 0}},
-		"pos-1": {{[]byte{byte(ct.STOP), byte(ct.STOP), byte(ct.STOP)}, 1, 1}},
+		"empty":        {{}},
+		"pos-0":        {{[]byte{byte(ct.STOP)}, 0, 0}},
+		"pos-1":        {{[]byte{byte(ct.STOP), byte(ct.STOP), byte(ct.STOP)}, 1, 1}},
+		"one-past-end": {{[]byte{byte(ct.STOP)}, 1, 1}},
 		"shifted": {{[]byte{
 			byte(ct.PUSH1), 0x01,
 			byte(ct.PUSH1), 0x02,
@@ -377,9 +378,10 @@ func TestConvertToCt_Pc(t *testing.T) {
 		lfvmPc  uint16
 		evmPc   uint16
 	}{
-		"empty": {{}},
-		"pos-0": {{[]byte{byte(ct.STOP)}, 0, 0}},
-		"pos-1": {{[]byte{byte(ct.STOP), byte(ct.STOP), byte(ct.STOP)}, 1, 1}},
+		"empty":        {{}},
+		"pos-0":        {{[]byte{byte(ct.STOP)}, 0, 0}},
+		"pos-1":        {{[]byte{byte(ct.STOP), byte(ct.STOP), byte(ct.STOP)}, 1, 1}},
+		"one-past-end": {{[]byte{byte(ct.STOP)}, 1, 1}},
 		"shifted": {{[]byte{
 			byte(ct.PUSH1), 0x01,
 			byte(ct.PUSH1), 0x02,


### PR DESCRIPTION
This PR defines an interface to tie a specific EVM implementation to the CT framework, and implements this interface for lfvm.