### PR TITLE
ct: Add Specification interface w/ some rules

### DIFF
--- a/go/ct/common/u256.go
+++ b/go/ct/common/u256.go
@@ -29,11 +29,11 @@ func NewU256(args ...uint64) (result U256) {
 }
 
 func RandU256(rnd *rand.Rand) U256 {
-	var bytes [32]byte
-	rnd.Read(bytes[:])
-
 	var value U256
-	value.internal.SetBytes(bytes[:])
+	value.internal[0] = rnd.Uint64()
+	value.internal[1] = rnd.Uint64()
+	value.internal[2] = rnd.Uint64()
+	value.internal[3] = rnd.Uint64()
 	return value
 }
 

--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -63,7 +63,8 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 		}
 		minSize += size
 	}
-	size := int(rnd.Int31n(int32(24576+1-minSize))) + minSize
+	//size := int(rnd.Int31n(int32(24576+1-minSize))) + minSize // TODO max code size (see also code gen test-cases)
+	size := int(rnd.Int31n(int32(100+1-minSize))) + minSize
 
 	ops, err := g.solveVarConstraints(assignment, rnd, size)
 	if err != nil {
@@ -97,8 +98,7 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 		if nextFixedPosition < i {
 			return nil, fmt.Errorf(
 				"%w, unable to satisfy op[%d]=%v constraint",
-				ErrUnsatisfiable, ops[0].pos, ops[0].op,
-			)
+				ErrUnsatisfiable, ops[0].pos, ops[0].op)
 		}
 
 		if i == nextFixedPosition {
@@ -135,6 +135,13 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 			rnd.Read(code[i+1 : end])
 			i += width
 		}
+	}
+
+	// After filling in the code, we expect all ops to have been processed.
+	if len(ops) > 0 {
+		return nil, fmt.Errorf(
+			"%w, unable to satisfy last %v constraint",
+			ErrUnsatisfiable, len(ops))
 	}
 
 	return st.NewCode(code), nil

--- a/go/ct/gen/code_test.go
+++ b/go/ct/gen/code_test.go
@@ -83,10 +83,10 @@ func TestCodeGenerator_OperationConstraintsAreEnforced(t *testing.T) {
 		"multiple-no-data": {{p: 4, op: STOP}, {p: 6, op: ADD}, {p: 2, op: INVALID}},
 		"pair":             {{p: 4, op: PUSH1}, {p: 7, op: PUSH32}},
 		"tight":            {{p: 0, op: PUSH1}, {p: 2, op: PUSH1}, {p: 4, op: PUSH1}},
-		"wide":             {{p: 2, op: PUSH1}, {p: 20000, op: PUSH1}},
-		"single-var":       {{v: "A", op: STOP}},
-		"multi-var":        {{v: "A", op: STOP}, {v: "B", op: ADD}},
-		"const-var-mix":    {{p: 5, op: STOP}, {v: "A", op: ADD}},
+		// "wide":             {{p: 2, op: PUSH1}, {p: 20000, op: PUSH1}}, // TODO re-enable when max code size is restored
+		"single-var":    {{v: "A", op: STOP}},
+		"multi-var":     {{v: "A", op: STOP}, {v: "B", op: ADD}},
+		"const-var-mix": {{p: 5, op: STOP}, {v: "A", op: ADD}},
 	}
 
 	rnd := rand.New(0)
@@ -145,7 +145,6 @@ func TestCodeGenerator_ImpossibleConstraintsAreDetected(t *testing.T) {
 		"add_operation_making_other_operation_data": {ops: []op{{p: 16, op: PUSH32}, {p: 0, op: PUSH32}}},
 	}
 
-	rnd := rand.New(0)
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			generator := NewCodeGenerator()
@@ -154,7 +153,7 @@ func TestCodeGenerator_ImpossibleConstraintsAreDetected(t *testing.T) {
 				generator.SetOperation(cur.p, cur.op)
 			}
 
-			if _, err := generator.Generate(nil, rnd); !errors.Is(err, ErrUnsatisfiable) {
+			if _, err := generator.Generate(nil, rand.New(0)); !errors.Is(err, ErrUnsatisfiable) {
 				t.Fatalf("expected error indicating unsatisfiability, but got %v", err)
 			}
 		})

--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -165,7 +165,9 @@ func (g *StateGenerator) Generate(rnd *rand.Rand) (*st.State, error) {
 		}
 		if len(values) == 0 {
 			// Generate a random program counter that points into the code slice.
-			resultPc = uint16(rnd.Int31n(int32(resultCode.Length())))
+			if resultCode.Length() > 0 {
+				resultPc = uint16(rnd.Int31n(int32(resultCode.Length())))
+			}
 		} else if len(values) == 1 {
 			resultPc = values[0]
 		} else {

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -238,7 +238,7 @@ func (d stackSizeDomain) Samples(a int) []int {
 	return d.SamplesForAll([]int{a})
 }
 func (stackSizeDomain) SamplesForAll(as []int) []int {
-	res := []int{0, 1024} // extreme values
+	res := []int{0, 10} // extreme values // TODO max stack size
 
 	// Test every element off by one.
 	for _, a := range as {

--- a/go/ct/rlz/effect.go
+++ b/go/ct/rlz/effect.go
@@ -31,3 +31,16 @@ func (c *change) Apply(state *st.State) {
 func (c *change) String() string {
 	return "change"
 }
+
+////////////////////////////////////////////////////////////
+
+func NoEffect() Effect {
+	return Change(func(*st.State) {})
+}
+
+func FailEffect() Effect {
+	return Change(func(s *st.State) {
+		s.Status = st.Failed
+		s.Gas = 0
+	})
+}

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -1,0 +1,150 @@
+package spc
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
+	. "github.com/Fantom-foundation/Tosca/go/ct/rlz"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+)
+
+// Specification defines the interface for handling specifications.
+type Specification interface {
+	// GetRules provides access to all rules within the specification.
+	GetRules() []Rule
+
+	// GetRulesFor gives you all rules that apply to the given State (i.e. where
+	// the rule's Condition holds).
+	GetRulesFor(*st.State) []Rule
+}
+
+type specification struct {
+	rules []Rule
+}
+
+func NewSpecification(rules ...Rule) Specification {
+	return &specification{rules}
+}
+
+func (s *specification) GetRules() []Rule {
+	return s.rules
+}
+
+func (s *specification) GetRulesFor(state *st.State) []Rule {
+	result := []Rule{}
+	for _, rule := range s.rules {
+		if valid, err := rule.Condition.Check(state); valid && err == nil {
+			result = append(result, rule)
+		}
+	}
+	return result
+}
+
+////////////////////////////////////////////////////////////
+
+var Spec = func() Specification {
+	rules := []Rule{}
+
+	// --- Terminal States ---
+
+	rules = append(rules, []Rule{
+		{
+			Name:      "stopped_is_end",
+			Condition: Eq(Status(), st.Stopped),
+			Effect:    NoEffect(),
+		},
+
+		{
+			Name:      "returned_is_end",
+			Condition: Eq(Status(), st.Returned),
+			Effect:    NoEffect(),
+		},
+
+		{
+			Name:      "reverted_is_end",
+			Condition: Eq(Status(), st.Reverted),
+			Effect:    NoEffect(),
+		},
+
+		{
+			Name:      "failed_is_end",
+			Condition: Eq(Status(), st.Failed),
+			Effect:    NoEffect(),
+		},
+	}...)
+
+	// --- STOP ---
+
+	rules = append(rules, Rule{
+		Name: "stop_terminates_interpreter",
+		Condition: And(
+			Eq(Status(), st.Running),
+			Eq(Op(Pc()), STOP),
+		),
+		Effect: Change(func(s *st.State) {
+			s.Status = st.Stopped
+		}),
+	})
+
+	// --- Arithmetic ---
+
+	rules = append(rules, binaryOp(ADD, 3, func(a, b U256) U256 {
+		return a.Add(b)
+	})...)
+
+	// --- End ---
+
+	return NewSpecification(rules...)
+}()
+
+func binaryOp(
+	op OpCode,
+	costs uint64,
+	effect func(a, b U256) U256,
+) []Rule {
+	name := strings.ToLower(op.String())
+	return []Rule{
+		{
+			Name: fmt.Sprintf("%v_regular", name),
+			Condition: And(
+				Eq(Status(), st.Running),
+				Eq(Op(Pc()), op),
+				Ge(Gas(), costs),
+				Ge(StackSize(), 2),
+			),
+			Parameter: []Parameter{
+				NumericParameter{},
+				NumericParameter{},
+			},
+			Effect: Change(func(s *st.State) {
+				s.Gas = s.Gas - costs
+				s.Pc++
+				a := s.Stack.Pop()
+				b := s.Stack.Pop()
+				s.Stack.Push(effect(a, b))
+			}),
+		},
+
+		{
+			Name: fmt.Sprintf("%v_with_too_little_gas", name),
+			Condition: And(
+				Eq(Status(), st.Running),
+				Eq(Op(Pc()), op),
+				Lt(Gas(), costs),
+			),
+			Effect: FailEffect(),
+		},
+
+		{
+			Name: fmt.Sprintf("%v_with_too_few_elements", name),
+			Condition: And(
+				Eq(Status(), st.Running),
+				Eq(Op(Pc()), op),
+				Ge(Gas(), costs),
+				Lt(StackSize(), 2),
+			),
+			Effect: FailEffect(),
+		},
+	}
+}

--- a/go/ct/spc/specification_test.go
+++ b/go/ct/spc/specification_test.go
@@ -1,0 +1,61 @@
+package spc
+
+import (
+	"testing"
+
+	"pgregory.net/rand"
+
+	"github.com/Fantom-foundation/Tosca/go/ct/gen"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+)
+
+func TestSpecification_RulesCoverTestCases(t *testing.T) {
+	rules := Spec.GetRules()
+	for _, rule := range rules {
+		rule := rule
+		t.Run(rule.Name, func(t *testing.T) {
+			t.Parallel()
+
+			// TODO: For now, check that we get at least one rule matching for
+			// the full set of test cases (and at most one rule for every test
+			// case). Later we'll enforce that exactly one rule applies to every
+			// single test case.
+			atLeastOne := false
+
+			rule.EnumerateTestCases(rand.New(0), func(state *st.State) {
+				rules := Spec.GetRulesFor(state)
+				if len(rules) > 0 {
+					atLeastOne = true
+				}
+				if len(rules) > 1 {
+					t.Fatalf("multiple rules for state %v: %v", &state, rules)
+				}
+			})
+
+			if !atLeastOne {
+				t.Fail()
+			}
+		})
+	}
+}
+
+func TestSpecification_RulesCoverRandomStates(t *testing.T) {
+	const N = 10000
+
+	rnd := rand.New(0)
+	generator := gen.NewStateGenerator()
+
+	for i := 0; i < N; i++ {
+		state, err := generator.Generate(rnd)
+		if err != nil {
+			t.Fatalf("failed building state: %v", err)
+		}
+
+		rules := Spec.GetRulesFor(state)
+
+		// TODO: Enforce that exactly one rule applies
+		if len(rules) > 1 {
+			t.Fatalf("multiple rules for state %v: %v", &state, rules)
+		}
+	}
+}

--- a/go/ct/spc/staticcheck.conf
+++ b/go/ct/spc/staticcheck.conf
@@ -1,0 +1,4 @@
+dot_import_whitelist = [
+    "github.com/Fantom-foundation/Tosca/go/ct/common",
+    "github.com/Fantom-foundation/Tosca/go/ct/rlz",
+]


### PR DESCRIPTION
This PR adds the Specification interface along with a very basic set of rules.

For performance reasons, the maximum code size and maximum stack size is limited for the generation process. This will be address in the future.