### PR TITLE
ct: Mutate parameters on generated state

### DIFF
--- a/go/ct/evm_test.go
+++ b/go/ct/evm_test.go
@@ -32,7 +32,7 @@ func TestSpecOnLfvm(t *testing.T) {
 				expected := state.Clone()
 				rule.Effect.Apply(expected)
 
-				result, err := evm.StepN(state, 1)
+				result, err := evm.StepN(input.Clone(), 1)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -63,8 +63,7 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 		}
 		minSize += size
 	}
-	//size := int(rnd.Int31n(int32(24576+1-minSize))) + minSize // TODO max code size (see also code gen test-cases)
-	size := int(rnd.Int31n(int32(100+1-minSize))) + minSize
+	size := int(rnd.Int31n(int32(24576+1-minSize))) + minSize
 
 	ops, err := g.solveVarConstraints(assignment, rnd, size)
 	if err != nil {

--- a/go/ct/gen/code_test.go
+++ b/go/ct/gen/code_test.go
@@ -83,10 +83,10 @@ func TestCodeGenerator_OperationConstraintsAreEnforced(t *testing.T) {
 		"multiple-no-data": {{p: 4, op: STOP}, {p: 6, op: ADD}, {p: 2, op: INVALID}},
 		"pair":             {{p: 4, op: PUSH1}, {p: 7, op: PUSH32}},
 		"tight":            {{p: 0, op: PUSH1}, {p: 2, op: PUSH1}, {p: 4, op: PUSH1}},
-		// "wide":             {{p: 2, op: PUSH1}, {p: 20000, op: PUSH1}}, // TODO re-enable when max code size is restored
-		"single-var":    {{v: "A", op: STOP}},
-		"multi-var":     {{v: "A", op: STOP}, {v: "B", op: ADD}},
-		"const-var-mix": {{p: 5, op: STOP}, {v: "A", op: ADD}},
+		"wide":             {{p: 2, op: PUSH1}, {p: 20000, op: PUSH1}},
+		"single-var":       {{v: "A", op: STOP}},
+		"multi-var":        {{v: "A", op: STOP}, {v: "B", op: ADD}},
+		"const-var-mix":    {{p: 5, op: STOP}, {v: "A", op: ADD}},
 	}
 
 	rnd := rand.New(0)

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -238,7 +238,7 @@ func (d stackSizeDomain) Samples(a int) []int {
 	return d.SamplesForAll([]int{a})
 }
 func (stackSizeDomain) SamplesForAll(as []int) []int {
-	res := []int{0, 10} // extreme values // TODO max stack size
+	res := []int{0, 1024} // extreme values
 
 	// Test every element off by one.
 	for _, a := range as {


### PR DESCRIPTION
This is an alternative idea to freezing the generators.

Since setting parameters is the last step in the generation process, we could just generate a state which has enough stack space to support the needed parameters and then mutate the parameter's values directly instead of re-generating a new state.