### PR TITLE
ct: Add --max-errors cli flag to driver

### DIFF
--- a/go/ct/rlz/rules.go
+++ b/go/ct/rlz/rules.go
@@ -25,8 +25,8 @@ func (rule *Rule) GenerateSatisfyingState(rnd *rand.Rand) (*st.State, error) {
 
 // EnumerateTestCases generates interesting st.States according to this Rule.
 // Each valid st.State is passed to the given consume function. consume must
-// *not* modify the provided state. Errors are accumulated.
-func (rule *Rule) EnumerateTestCases(rnd *rand.Rand, consume func(*st.State) error) error {
+// *not* modify the provided state. Errors are accumulated and a list of all errors is returned.
+func (rule *Rule) EnumerateTestCases(rnd *rand.Rand, consume func(*st.State) error) []error {
 	var accumulatedErrors []error
 
 	onError := func(err error) {
@@ -50,7 +50,7 @@ func (rule *Rule) EnumerateTestCases(rnd *rand.Rand, consume func(*st.State) err
 		}
 	})
 
-	return errors.Join(accumulatedErrors...)
+	return accumulatedErrors
 }
 
 func enumerateParameters(pos int, params []Parameter, state *st.State, consume func(*st.State) error, onError func(error)) {

--- a/go/ct/rlz/rules_test.go
+++ b/go/ct/rlz/rules_test.go
@@ -1,6 +1,7 @@
 package rlz
 
 import (
+	"errors"
 	"testing"
 
 	"pgregory.net/rand"
@@ -55,7 +56,7 @@ func TestRule_EnumerateTestCases(t *testing.T) {
 		misses := 0
 
 		rule := Rule{Condition: test}
-		err := rule.EnumerateTestCases(rnd, func(sample *st.State) error {
+		errs := rule.EnumerateTestCases(rnd, func(sample *st.State) error {
 			match, err := test.Check(sample)
 			if err != nil {
 				t.Errorf("Condition check error %v", err)
@@ -67,6 +68,7 @@ func TestRule_EnumerateTestCases(t *testing.T) {
 			}
 			return nil
 		})
+		err := errors.Join(errs...)
 		if err != nil {
 			t.Errorf("EnumerateTestCases failed %v", err)
 		}


### PR DESCRIPTION
This PR adds a `--max-errors` command line flag to the driver, to limit how many errors are being displayed. The default value is `1`, which means only the first error will be displayed.