### PR TITLE
ct: Implement specification for arithmetic opcodes

### DIFF
--- a/go/ct/common/opcodes.go
+++ b/go/ct/common/opcodes.go
@@ -5,16 +5,40 @@ import "fmt"
 type OpCode byte
 
 const (
-	STOP     OpCode = 0x00
-	ADD      OpCode = 0x01
-	JUMP     OpCode = 0x56
-	JUMPDEST OpCode = 0x5B
-	PUSH1    OpCode = 0x60
-	PUSH2    OpCode = 0x61
-	PUSH3    OpCode = 0x62
-	PUSH31   OpCode = 0x7E
-	PUSH32   OpCode = 0x7F
-	INVALID  OpCode = 0xFE
+	STOP       OpCode = 0x00
+	ADD        OpCode = 0x01
+	MUL        OpCode = 0x02
+	SUB        OpCode = 0x03
+	DIV        OpCode = 0x04
+	SDIV       OpCode = 0x05
+	MOD        OpCode = 0x06
+	SMOD       OpCode = 0x07
+	ADDMOD     OpCode = 0x08
+	MULMOD     OpCode = 0x09
+	EXP        OpCode = 0x0A
+	SIGNEXTEND OpCode = 0x0B
+	LT         OpCode = 0x10
+	GT         OpCode = 0x11
+	SLT        OpCode = 0x12
+	SGT        OpCode = 0x13
+	EQ         OpCode = 0x14
+	ISZERO     OpCode = 0x15
+	AND        OpCode = 0x16
+	OR         OpCode = 0x17
+	XOR        OpCode = 0x18
+	NOT        OpCode = 0x19
+	BYTE       OpCode = 0x1A
+	SHL        OpCode = 0x1B
+	SHR        OpCode = 0x1C
+	SAR        OpCode = 0x1D
+	JUMP       OpCode = 0x56
+	JUMPDEST   OpCode = 0x5B
+	PUSH1      OpCode = 0x60
+	PUSH2      OpCode = 0x61
+	PUSH3      OpCode = 0x62
+	PUSH31     OpCode = 0x7E
+	PUSH32     OpCode = 0x7F
+	INVALID    OpCode = 0xFE
 )
 
 func (op OpCode) String() string {
@@ -23,6 +47,54 @@ func (op OpCode) String() string {
 		return "STOP"
 	case ADD:
 		return "ADD"
+	case MUL:
+		return "MUL"
+	case SUB:
+		return "SUB"
+	case DIV:
+		return "DIV"
+	case SDIV:
+		return "SDIV"
+	case MOD:
+		return "MOD"
+	case SMOD:
+		return "SMOD"
+	case ADDMOD:
+		return "ADDMOD"
+	case MULMOD:
+		return "MULMOD"
+	case EXP:
+		return "EXP"
+	case SIGNEXTEND:
+		return "SIGNEXTEND"
+	case LT:
+		return "LT"
+	case GT:
+		return "GT"
+	case SLT:
+		return "SLT"
+	case SGT:
+		return "SGT"
+	case EQ:
+		return "EQ"
+	case ISZERO:
+		return "ISZERO"
+	case AND:
+		return "AND"
+	case OR:
+		return "OR"
+	case XOR:
+		return "XOR"
+	case NOT:
+		return "NOT"
+	case BYTE:
+		return "BYTE"
+	case SHL:
+		return "SHL"
+	case SHR:
+		return "SHR"
+	case SAR:
+		return "SAR"
 	case JUMP:
 		return "JUMP"
 	case JUMPDEST:

--- a/go/ct/common/u256.go
+++ b/go/ct/common/u256.go
@@ -179,6 +179,17 @@ func (a U256) Shr(b U256) (z U256) {
 	return
 }
 
+func (a U256) Srsh(b U256) (z U256) {
+	if b.internal.GtUint64(256) {
+		if a.internal.IsZero() || a.internal.Sign() >= 0 {
+			return NewU256(0)
+		}
+		return MaxU256()
+	}
+	z.internal.SRsh(&a.internal, uint(b.internal.Uint64()))
+	return
+}
+
 func (i U256) String() string {
 	return fmt.Sprintf("%016x %016x %016x %016x", i.internal[3], i.internal[2], i.internal[1], i.internal[0])
 }

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -43,6 +43,13 @@ func (s *specification) GetRulesFor(state *st.State) []Rule {
 
 ////////////////////////////////////////////////////////////
 
+func boolToU256(value bool) U256 {
+	if value {
+		return NewU256(1)
+	}
+	return NewU256(0)
+}
+
 var Spec = func() Specification {
 	rules := []Rule{}
 
@@ -94,15 +101,124 @@ var Spec = func() Specification {
 		return a.Add(b)
 	})...)
 
+	rules = append(rules, binaryOp(MUL, 5, func(a, b U256) U256 {
+		return a.Mul(b)
+	})...)
+
+	rules = append(rules, binaryOp(SUB, 3, func(a, b U256) U256 {
+		return a.Sub(b)
+	})...)
+
+	rules = append(rules, binaryOp(DIV, 5, func(a, b U256) U256 {
+		return a.Div(b)
+	})...)
+
+	rules = append(rules, binaryOp(SDIV, 5, func(a, b U256) U256 {
+		return a.SDiv(b)
+	})...)
+
+	rules = append(rules, binaryOp(MOD, 5, func(a, b U256) U256 {
+		return a.Mod(b)
+	})...)
+
+	rules = append(rules, binaryOp(SMOD, 5, func(a, b U256) U256 {
+		return a.SMod(b)
+	})...)
+
+	rules = append(rules, trinaryOp(ADDMOD, 8, func(a, b, n U256) U256 {
+		return a.AddMod(b, n)
+	})...)
+
+	rules = append(rules, trinaryOp(MULMOD, 8, func(a, b, n U256) U256 {
+		return a.MulMod(b, n)
+	})...)
+
+	rules = append(rules, binaryOpWithDynamicCost(EXP, 10, func(a, e U256) U256 {
+		return a.Exp(e)
+	}, func(a, e U256) uint64 {
+		const gasFactor = uint64(50)
+		expBytes := e.Bytes32be()
+		for i := 0; i < 32; i++ {
+			if expBytes[i] != 0 {
+				return gasFactor * uint64(32-i)
+			}
+		}
+		return 0
+	})...)
+
+	rules = append(rules, binaryOp(SIGNEXTEND, 5, func(b, x U256) U256 {
+		return x.SignExtend(b)
+	})...)
+
+	rules = append(rules, binaryOp(LT, 3, func(a, b U256) U256 {
+		return boolToU256(a.Lt(b))
+	})...)
+
+	rules = append(rules, binaryOp(GT, 3, func(a, b U256) U256 {
+		return boolToU256(a.Gt(b))
+	})...)
+
+	rules = append(rules, binaryOp(SLT, 3, func(a, b U256) U256 {
+		return boolToU256(a.Slt(b))
+	})...)
+
+	rules = append(rules, binaryOp(SGT, 3, func(a, b U256) U256 {
+		return boolToU256(a.Sgt(b))
+	})...)
+
+	rules = append(rules, binaryOp(EQ, 3, func(a, b U256) U256 {
+		return boolToU256(a.Eq(b))
+	})...)
+
+	rules = append(rules, unaryOp(ISZERO, 3, func(a U256) U256 {
+		return boolToU256(a.IsZero())
+	})...)
+
+	rules = append(rules, binaryOp(AND, 3, func(a, b U256) U256 {
+		return a.And(b)
+	})...)
+
+	rules = append(rules, binaryOp(OR, 3, func(a, b U256) U256 {
+		return a.Or(b)
+	})...)
+
+	rules = append(rules, binaryOp(XOR, 3, func(a, b U256) U256 {
+		return a.Xor(b)
+	})...)
+
+	rules = append(rules, unaryOp(NOT, 3, func(a U256) U256 {
+		return a.Not()
+	})...)
+
+	rules = append(rules, binaryOp(BYTE, 3, func(i, x U256) U256 {
+		if i.Gt(NewU256(31)) {
+			return NewU256(0)
+		}
+		return NewU256(uint64(x.Bytes32be()[i.Uint64()]))
+	})...)
+
+	rules = append(rules, binaryOp(SHL, 3, func(shift, value U256) U256 {
+		return value.Shl(shift)
+	})...)
+
+	rules = append(rules, binaryOp(SHR, 3, func(shift, value U256) U256 {
+		return value.Shr(shift)
+	})...)
+
+	rules = append(rules, binaryOp(SAR, 3, func(shift, value U256) U256 {
+		return value.Srsh(shift)
+	})...)
+
 	// --- End ---
 
 	return NewSpecification(rules...)
 }()
 
-func binaryOp(
+func binaryOpWithDynamicCost(
 	op OpCode,
 	costs uint64,
 	effect func(a, b U256) U256,
+	dynamicCost func(a, b U256) uint64,
 ) []Rule {
 	name := strings.ToLower(op.String())
 	return []Rule{
@@ -119,10 +235,17 @@ func binaryOp(
 				NumericParameter{},
 			},
 			Effect: Change(func(s *st.State) {
-				s.Gas = s.Gas - costs
 				s.Pc++
 				a := s.Stack.Pop()
 				b := s.Stack.Pop()
+				cost := costs + dynamicCost(a, b)
+				// TODO: Improve handling of dynamic gas through dedicated constraint.
+				if s.Gas < cost {
+					s.Status = st.Failed
+					s.Gas = 0
+					return
+				}
+				s.Gas = s.Gas - cost
 				s.Stack.Push(effect(a, b))
 			}),
 		},
@@ -144,6 +267,116 @@ func binaryOp(
 				Eq(Op(Pc()), op),
 				Ge(Gas(), costs),
 				Lt(StackSize(), 2),
+			),
+			Effect: FailEffect(),
+		},
+	}
+}
+
+func binaryOp(
+	op OpCode,
+	costs uint64,
+	effect func(a, b U256) U256,
+) []Rule {
+	return binaryOpWithDynamicCost(op, costs, effect, func(_, _ U256) uint64 { return 0 })
+}
+
+func trinaryOp(
+	op OpCode,
+	costs uint64,
+	effect func(a, b, c U256) U256,
+) []Rule {
+	name := strings.ToLower(op.String())
+	return []Rule{
+		{
+			Name: fmt.Sprintf("%v_regular", name),
+			Condition: And(
+				Eq(Status(), st.Running),
+				Eq(Op(Pc()), op),
+				Ge(Gas(), costs),
+				Ge(StackSize(), 3),
+			),
+			Parameter: []Parameter{
+				NumericParameter{},
+				NumericParameter{},
+				NumericParameter{},
+			},
+			Effect: Change(func(s *st.State) {
+				s.Gas = s.Gas - costs
+				s.Pc++
+				a := s.Stack.Pop()
+				b := s.Stack.Pop()
+				c := s.Stack.Pop()
+				s.Stack.Push(effect(a, b, c))
+			}),
+		},
+
+		{
+			Name: fmt.Sprintf("%v_with_too_little_gas", name),
+			Condition: And(
+				Eq(Status(), st.Running),
+				Eq(Op(Pc()), op),
+				Lt(Gas(), costs),
+			),
+			Effect: FailEffect(),
+		},
+
+		{
+			Name: fmt.Sprintf("%v_with_too_few_elements", name),
+			Condition: And(
+				Eq(Status(), st.Running),
+				Eq(Op(Pc()), op),
+				Ge(Gas(), costs),
+				Lt(StackSize(), 3),
+			),
+			Effect: FailEffect(),
+		},
+	}
+}
+
+func unaryOp(
+	op OpCode,
+	costs uint64,
+	effect func(a U256) U256,
+) []Rule {
+	name := strings.ToLower(op.String())
+	return []Rule{
+		{
+			Name: fmt.Sprintf("%v_regular", name),
+			Condition: And(
+				Eq(Status(), st.Running),
+				Eq(Op(Pc()), op),
+				Ge(Gas(), costs),
+				Ge(StackSize(), 1),
+			),
+			Parameter: []Parameter{
+				NumericParameter{},
+			},
+			Effect: Change(func(s *st.State) {
+				s.Pc++
+				a := s.Stack.Pop()
+				s.Gas = s.Gas - costs
+				s.Stack.Push(effect(a))
+			}),
+		},
+
+		{
+			Name: fmt.Sprintf("%v_with_too_little_gas", name),
+			Condition: And(
+				Eq(Status(), st.Running),
+				Eq(Op(Pc()), op),
+				Lt(Gas(), costs),
+			),
+			Effect: FailEffect(),
+		},
+
+		{
+			Name: fmt.Sprintf("%v_with_too_few_elements", name),
+			Condition: And(
+				Eq(Status(), st.Running),
+				Eq(Op(Pc()), op),
+				Ge(Gas(), costs),
+				Lt(StackSize(), 1),
 			),
 			Effect: FailEffect(),
 		},


### PR DESCRIPTION
This PR is based on #241 so that one has to be merged first.

This PR extends the specification to cover all arithmetic opcodes.