### PR TITLE
lfvm: Fix jumpi checking destination even when not jumping

### DIFF
--- a/go/vm/lfvm/instructions.go
+++ b/go/vm/lfvm/instructions.go
@@ -61,12 +61,12 @@ func opJump(c *context) {
 func opJumpi(c *context) {
 	destination := c.stack.pop()
 	condition := c.stack.pop()
-	// overflow check
-	if !destination.IsUint64() || destination.Uint64()>>33 > 0 {
-		c.SignalError(vm.ErrInvalidJump)
-		return
-	}
 	if !condition.IsZero() {
+		// overflow check
+		if !destination.IsUint64() || destination.Uint64()>>33 > 0 {
+			c.SignalError(vm.ErrInvalidJump)
+			return
+		}
 		// Update the PC to the jump destination -1 since interpreter will increase PC by 1 afterward.
 		c.pc = int32(destination.Uint64()) - 1
 		checkJumpDest(c)


### PR DESCRIPTION
This PR fixes the behavior of LFVM where the destination of a `jumpi` instruction is checked for overflow, even when the jump is not taken. The specification says that the destination is only checked when the jump is taken.