### PR TITLE
ct: Fix lfvm -> ct PC conversion failing

### DIFF
--- a/go/vm/lfvm/ct.go
+++ b/go/vm/lfvm/ct.go
@@ -71,7 +71,9 @@ func ConvertLfvmContextToCtState(ctx *context, originalCode *st.Code, pcMap *PcM
 	}
 
 	pc, ok := pcMap.lfvmToEvm[uint16(ctx.pc)]
-	if !ok {
+
+	// Since two failed states are considered equal, the PC conversion may fail when the status is failed.
+	if !ok && status != st.Failed {
 		return nil, fmt.Errorf("unable to convert lfvm pc %d to evm pc", ctx.pc)
 	}
 


### PR DESCRIPTION
This PR creates an exception when converting the program counter back from lfvm to evm. Since two failed states are considered equal, it is not necessary to successfully convert the program counter, if the status is failed.