### PR TITLE
evmzero: Extend interpreter to allow executing N steps

### DIFF
--- a/cpp/vm/evmzero/interpreter.h
+++ b/cpp/vm/evmzero/interpreter.h
@@ -104,8 +104,8 @@ struct Context {
 // bound checks during the execution can be avoided.
 std::vector<uint8_t> PadCode(std::span<const uint8_t> code);
 
-template <Observer Observer>
-extern void RunInterpreter(Context&, Observer&);
+template <Observer Observer, bool Stepping = false>
+extern void RunInterpreter(Context&, Observer&, int steps = -1);
 
 }  // namespace internal
 


### PR DESCRIPTION
This PR adds the ability to execute `N` steps of the evmzero interpreter. This change is guarded by a template parameter to allow the compiler to strip out anything related to stepping when this is not required.

This approach works and there is no impact on performance:

gcc:

```
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Tosca/go/vm/test
cpu: 13th Gen Intel(R) Core(TM) i9-13900K
                             │ gcc_main.log │            gcc_step.log            │
                             │    sec/op    │   sec/op     vs base               │
Inc/1/evmzero-32                874.0n ± 1%   874.3n ± 0%       ~ (p=0.868 n=10)
Inc/10/evmzero-32               872.9n ± 1%   881.0n ± 1%       ~ (p=0.055 n=10)
Fib/1/evmzero-32                819.8n ± 1%   823.5n ± 0%       ~ (p=0.315 n=10)
Fib/5/evmzero-32                2.618µ ± 1%   2.566µ ± 1%  -1.97% (p=0.000 n=10)
Fib/10/evmzero-32               22.67µ ± 1%   22.41µ ± 2%       ~ (p=0.075 n=10)
Fib/15/evmzero-32               246.9µ ± 1%   240.9µ ± 1%  -2.44% (p=0.000 n=10)
Fib/20/evmzero-32               2.682m ± 0%   2.660m ± 2%       ~ (p=0.123 n=10)
Sha3/1/evmzero-32               669.9n ± 1%   663.2n ± 1%  -0.99% (p=0.003 n=10)
Sha3/10/evmzero-32              1.237µ ± 1%   1.216µ ± 0%  -1.70% (p=0.001 n=10)
Sha3/100/evmzero-32             6.595µ ± 1%   6.527µ ± 1%  -1.04% (p=0.025 n=10)
Sha3/1000/evmzero-32            60.30µ ± 1%   60.16µ ± 1%       ~ (p=0.325 n=10)
Arith/1/evmzero-32              961.4n ± 1%   949.9n ± 1%       ~ (p=0.063 n=10)
Arith/10/evmzero-32             1.899µ ± 0%   1.897µ ± 0%       ~ (p=0.538 n=10)
Arith/100/evmzero-32            11.26µ ± 1%   11.35µ ± 1%  +0.83% (p=0.034 n=10)
Arith/280/evmzero-32            30.84µ ± 1%   31.06µ ± 1%  +0.72% (p=0.035 n=10)
Memory/1/evmzero-32             1.307µ ± 0%   1.295µ ± 1%  -0.88% (p=0.002 n=10)
Memory/10/evmzero-32            2.923µ ± 1%   2.985µ ± 1%  +2.12% (p=0.000 n=10)
Memory/100/evmzero-32           18.47µ ± 1%   18.92µ ± 1%  +2.42% (p=0.001 n=10)
Memory/1000/evmzero-32          178.5µ ± 1%   177.3µ ± 1%  -0.70% (p=0.023 n=10)
Memory/10000/evmzero-32         1.777m ± 1%   1.754m ± 0%  -1.29% (p=0.002 n=10)
Analysis/jumpdest/evmzero-32    559.3n ± 2%   560.3n ± 0%       ~ (p=0.671 n=10)
Analysis/stop/evmzero-32        562.5n ± 1%   562.7n ± 1%       ~ (p=0.698 n=10)
Analysis/push1/evmzero-32       564.4n ± 1%   563.5n ± 1%       ~ (p=0.912 n=10)
Analysis/push32/evmzero-32      562.9n ± 1%   565.0n ± 1%       ~ (p=0.159 n=10)
geomean                         6.225µ        6.208µ       -0.28%
```

clang:

```
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Tosca/go/vm/test
cpu: 13th Gen Intel(R) Core(TM) i9-13900K
                             │ clang_main.log │           clang_step.log           │
                             │     sec/op     │   sec/op     vs base               │
Inc/1/evmzero-32                  797.0n ± 1%   791.8n ± 0%  -0.65% (p=0.002 n=10)
Inc/10/evmzero-32                 787.8n ± 0%   793.2n ± 1%  +0.69% (p=0.015 n=10)
Fib/1/evmzero-32                  744.9n ± 1%   747.5n ± 0%       ~ (p=0.143 n=10)
Fib/5/evmzero-32                  2.332µ ± 1%   2.295µ ± 1%  -1.59% (p=0.000 n=10)
Fib/10/evmzero-32                 20.26µ ± 1%   20.04µ ± 1%  -1.08% (p=0.001 n=10)
Fib/15/evmzero-32                 219.6µ ± 1%   222.0µ ± 1%  +1.09% (p=0.004 n=10)
Fib/20/evmzero-32                 2.416m ± 1%   2.433m ± 0%  +0.71% (p=0.002 n=10)
Sha3/1/evmzero-32                 605.4n ± 1%   598.1n ± 1%       ~ (p=0.052 n=10)
Sha3/10/evmzero-32               1003.5n ± 1%   984.9n ± 2%  -1.85% (p=0.004 n=10)
Sha3/100/evmzero-32               4.565µ ± 0%   4.558µ ± 1%       ~ (p=0.838 n=10)
Sha3/1000/evmzero-32              39.72µ ± 1%   40.09µ ± 1%  +0.93% (p=0.023 n=10)
Arith/1/evmzero-32                858.1n ± 1%   864.0n ± 1%  +0.69% (p=0.014 n=10)
Arith/10/evmzero-32               1.885µ ± 1%   1.895µ ± 0%       ~ (p=0.109 n=10)
Arith/100/evmzero-32              11.95µ ± 1%   11.85µ ± 1%  -0.84% (p=0.019 n=10)
Arith/280/evmzero-32              32.81µ ± 1%   32.53µ ± 1%  -0.83% (p=0.037 n=10)
Memory/1/evmzero-32               1.050µ ± 1%   1.059µ ± 0%  +0.81% (p=0.015 n=10)
Memory/10/evmzero-32              2.034µ ± 1%   2.006µ ± 1%  -1.35% (p=0.014 n=10)
Memory/100/evmzero-32             11.01µ ± 1%   10.58µ ± 3%  -3.89% (p=0.000 n=10)
Memory/1000/evmzero-32            101.0µ ± 1%   101.0µ ± 3%       ~ (p=1.000 n=10)
Memory/10000/evmzero-32          1010.3µ ± 1%   993.7µ ± 2%  -1.65% (p=0.005 n=10)
Analysis/jumpdest/evmzero-32      535.1n ± 0%   526.5n ± 2%  -1.61% (p=0.005 n=10)
Analysis/stop/evmzero-32          532.9n ± 0%   540.3n ± 1%  +1.40% (p=0.000 n=10)
Analysis/push1/evmzero-32         534.6n ± 0%   530.1n ± 1%  -0.84% (p=0.004 n=10)
Analysis/push32/evmzero-32        544.2n ± 1%   538.4n ± 2%  -1.07% (p=0.001 n=10)
geomean                           5.214µ        5.189µ       -0.48%
```