### PR TITLE
ct: Make zeroes in storage always considered present

### DIFF
--- a/go/ct/st/storage_test.go
+++ b/go/ct/st/storage_test.go
@@ -1,7 +1,7 @@
 package st
 
 import (
-	"regexp"
+	"strings"
 	"testing"
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
@@ -66,64 +66,75 @@ func TestStorage_Diff(t *testing.T) {
 
 	s2.Current[NewU256(42)] = NewU256(3)
 	diff = s1.Diff(s2)
-	match, err := regexp.MatchString("current", diff[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !match {
+	if !strings.Contains(diff[0], "current") {
 		t.Fatalf("Difference in current not found: %v", diff)
 	}
 
 	delete(s2.Current, NewU256(42))
 	diff = s1.Diff(s2)
-	match, err = regexp.MatchString("current", diff[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !match {
+	if !strings.Contains(diff[0], "current") {
 		t.Fatalf("Difference in current not found: %v", diff)
 	}
 
 	s2 = s1.Clone()
 	s2.Original[NewU256(42)] = NewU256(4)
 	diff = s1.Diff(s2)
-	match, err = regexp.MatchString("original", diff[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !match {
+	if !strings.Contains(diff[0], "original") {
 		t.Fatalf("Difference in original not found: %v", diff)
 	}
 
 	delete(s2.Original, NewU256(42))
 	diff = s1.Diff(s2)
-	match, err = regexp.MatchString("original", diff[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !match {
+	if !strings.Contains(diff[0], "original") {
 		t.Fatalf("Difference in original not found: %v", diff)
 	}
 
 	s2 = s1.Clone()
 	s2.MarkCold(NewU256(42))
 	diff = s1.Diff(s2)
-	match, err = regexp.MatchString("warm", diff[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !match {
+	if !strings.Contains(diff[0], "warm") {
 		t.Fatalf("Difference in warm not found: %v", diff)
 	}
 
 	s2 = s1.Clone()
 	s2.MarkWarm(NewU256(43))
 	diff = s1.Diff(s2)
-	match, err = regexp.MatchString("warm", diff[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !match {
+	if !strings.Contains(diff[0], "warm") {
 		t.Fatalf("Difference in warm not found: %v", diff)
+	}
+}
+
+func TestStorage_ZeroConsideredPresent(t *testing.T) {
+	s1 := NewStorage()
+
+	s2 := s1.Clone()
+	s2.Current[NewU256(42)] = NewU256(0)
+
+	diff := s1.Diff(s2)
+	if len(diff) != 0 {
+		t.Fatalf("Missing zero considered different: %v", diff)
+	}
+	if !s1.Eq(s2) || !s2.Eq(s1) {
+		t.Fatalf("%v and %v considered different", s1.Current[NewU256(42)], s2.Current[NewU256(42)])
+	}
+
+	s2.Current[NewU256(42)] = NewU256(3)
+	diff = s1.Diff(s2)
+	if !strings.Contains(diff[0], "current") {
+		t.Fatalf("Difference in current not found: %v", diff)
+	}
+	if s1.Eq(s2) || s2.Eq(s1) {
+		t.Fatalf("%v and %v considered equal", s1.Current[NewU256(42)], s2.Current[NewU256(42)])
+	}
+
+	s1.Current[NewU256(42)] = NewU256(0)
+	s2.Current[NewU256(42)] = NewU256(0)
+
+	diff = s1.Diff(s2)
+	if len(diff) != 0 {
+		t.Fatalf("Zero values considered different: %v", diff)
+	}
+	if !s1.Eq(s2) || !s2.Eq(s1) {
+		t.Fatalf("%v and %v considered different", s1.Current[NewU256(42)], s2.Current[NewU256(42)])
 	}
 }


### PR DESCRIPTION
By default storage is initialized with zero, which means that writing zero values to storage could be omitted by an implementation as an optimization. This is the case for evmzero. This means that two storage states should still be considered equal, even if they don't have the same entries for zero values.

This PR changes how equality is defined for the current values in storage, making missing entries and zero valued entries being considered equivalent.

