### PR TITLE
evmzero: Fix truncation error in SIGNEXTEND implementation

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -273,7 +273,7 @@ struct Impl<OpCode::SIGNEXTEND> {
 
   static OpResult Run(uint256_t* top) noexcept {
     uint8_t leading_byte_index = static_cast<uint8_t>(top[0]);
-    if (leading_byte_index > 31) {
+    if (top[0] > 31) {
       leading_byte_index = 31;
     }
 

--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -814,6 +814,14 @@ TEST(InterpreterTest, SIGNEXTEND) {
       .stack_before = {0xFF7F, 1},
       .stack_after = {kUint256Max - 0x80},
   });
+  RunInterpreterTest({
+      .code = {op::SIGNEXTEND},
+      .state_after = RunState::kDone,
+      .gas_before = 10,
+      .gas_after = 5,
+      .stack_before = {0x100, 0x100},
+      .stack_after = {0x100},
+  });
 }
 
 TEST(InterpreterTest, SIGNEXTEND_OutOfGas) {


### PR DESCRIPTION
The implementation of the `SIGNEXTEND` instruction in evmzero contains a truncation bug. The leading byte index argument should be clamped to a maximum value of 31, however the value is being cast to `uint8_t` before clamping it, which causes values larger than 1 byte to potentially not be clamped to 31 when they should.

This PR fixes this bug by doing the comparison on the original 256-byte value.