### PR TITLE
Handle overflows in dynamic gas costs for CALLDATACOPY

### DIFF
--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -2025,6 +2025,15 @@ TEST(InterpreterTest, CALLDATACOPY_OutOfGas_Dynamic) {
   });
 }
 
+TEST(InterpreterTest, CALLDATACOPY_DynamicGas_Overflow) {
+  RunInterpreterTest({
+      .code = {op::CALLDATACOPY},
+      .state_after = RunState::kErrorGas,
+      .gas_before = 100,
+      .stack_before = {672, 0, 320000000000000000},
+  });
+}
+
 TEST(InterpreterTest, CALLDATACOPY_StackError) {
   RunInterpreterTest({
       .code = {op::CALLDATACOPY},


### PR DESCRIPTION
This PR adds over-flow checks during the dynamic gas price computation of the CALLDATACOPY instruction.

Fixes #272 