### PR TITLE
Generalize basic fail rules cases

### DIFF
--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -762,8 +762,8 @@ func pushOp(n int) []Rule {
 	})
 }
 
-// we call rulesFor with n pops values because they call stack.Get and for that
-// we need to ensure that there are enough elements in the stack.
+// An implementation does not necessarily do `n` pops and `n+1` pushes, since arbitrary stack positions could be accessed directly.
+// However, the result is as if `n` pops and `n+1` pushes were performed.
 func dupOp(n int) []Rule {
 	op := OpCode(int(DUP1) + n - 1)
 	return rulesFor(instruction{
@@ -777,8 +777,8 @@ func dupOp(n int) []Rule {
 	})
 }
 
-// we call rulesFor with n+1 pops values because they call stack.Get and for that
-// we need to ensure that there are enough elements in the stack.
+// An implementation does not necessarily do `n` pops and `n+1` pushes, since arbitrary stack positions could be accessed directly.
+// However, the result is as if `n` pops and `n+1` pushes were performed.
 func swapOp(n int) []Rule {
 	op := OpCode(int(SWAP1) + n - 1)
 	return rulesFor(instruction{
@@ -983,7 +983,7 @@ func tooFewElements(i instruction) []Rule {
 
 // rulesFor instantiates the basic rules depending on the instruction info.
 // any rule that cannot be expressed using this function must be implemented manually.
-// This function substract i.static_gas from state.Gas and increases state.Pc in one,
+// This function subtracts i.static_gas from state.Gas and increases state.Pc by one,
 // these two are always done before calling i.effect. This should be kept
 // in mind when implementing the effects of new rules.
 func rulesFor(i instruction) []Rule {


### PR DESCRIPTION
`too_llittle_gas`, `not_enough_space` and `too_few_elements` are the 3 basic fail cases, common among almost all the instructions.

Moving the instantiation of those rules to a generalized function for each allows to reduce the code size, while adding clarity since one has to go through a lot less code but what each added rule is doing, is still clear. 

Also since quite a few more instructions are on the way, this would also increase a lot the length of this rules list, with this we can greatly reduce by how much it will increase. 

