### PR TITLE
ct: Limit lfvm conversion cache length

### DIFF
--- a/go/vm/lfvm/converter.go
+++ b/go/vm/lfvm/converter.go
@@ -26,6 +26,12 @@ func clearConversionCache() {
 	cache = map[common.Hash]cache_val{}
 }
 
+func getConversionCacheLength() int {
+	mu.Lock()
+	defer mu.Unlock()
+	return len(cache)
+}
+
 func Convert(addr common.Address, code []byte, with_super_instructions bool, blk uint64, create bool, noCodeCache bool, codeHash common.Hash) (Code, error) {
 	mu.Lock()
 	res, exists := cache[codeHash]

--- a/go/vm/lfvm/ct.go
+++ b/go/vm/lfvm/ct.go
@@ -106,6 +106,11 @@ func ConvertLfvmContextToCtState(ctx *context, originalCode *st.Code, pcMap *PcM
 // ct -> lfvm : helper functions
 
 func convertCtCodeToLfvmCode(state *st.State) (Code, error) {
+	const maxConversionCacheLength = 1024
+	if getConversionCacheLength() > maxConversionCacheLength {
+		clearConversionCache()
+	}
+
 	code := make([]byte, state.Code.Length())
 	state.Code.CopyTo(code)
 	address := common.Address{}


### PR DESCRIPTION
This PR limits the code conversion cache used by LFVM to 1024 entries. This fixes issue #278. The memory usage for running the CT framework with LFVM after this change never exceeds 3GB in my tests, and the majority of that is not due to the conversion cache.

Note: The current implementation releases the mutex between checking the cache size and clearing it. I don't think that should be an issue, but I could also change the interface to something like `clearConversionCacheIfGreater(1024)` or something like that.