### PR TITLE
ct: Fix race condition due to shared chain config in geth

### DIFF
--- a/go/vm/geth/ct.go
+++ b/go/vm/geth/ct.go
@@ -215,11 +215,12 @@ func getGethEvm(revision ct.Revision, stateDb vm.StateDB) (*gethInterpreter, err
 	}
 
 	// Set hard forks for chainconfig
-	chainConfig := params.AllEthashProtocolChanges
+	chainConfig := &params.ChainConfig{}
 	chainConfig.ChainID = big.NewInt(0)
 	chainConfig.IstanbulBlock = big.NewInt(istanbulBlock)
 	chainConfig.BerlinBlock = big.NewInt(berlinBlock)
 	chainConfig.LondonBlock = big.NewInt(londonBlock)
+	chainConfig.Ethash = new(params.EthashConfig)
 
 	// Hashing function used in the context for BLOCKHASH instruction
 	getHash := func(num uint64) common.Hash {


### PR DESCRIPTION
This PR fixes a race condition in the geth integration for the CT framework caused by initializing the chain config using a global pointer.