### PR TITLE
ct: Refactor U256 from big int constructor

### DIFF
--- a/go/ct/common/u256.go
+++ b/go/ct/common/u256.go
@@ -41,6 +41,19 @@ func NewU256FromBytes(bytes ...byte) (result U256) {
 	return
 }
 
+// NewU256FromBigInt creates a new U256 instance from a big.Int.
+// The constructor panics if the big.Int is negative or has more than 256 bits.
+func NewU256FromBigInt(b *big.Int) (result U256) {
+	if b.Cmp(big.NewInt(0)) == -1 {
+		panic("Cannot construct U256 from negative big.Int")
+	}
+	overflow := result.internal.SetFromBig(b)
+	if overflow {
+		panic("Cannot construct U256 from big.Int with more than 256 bits")
+	}
+	return
+}
+
 func RandU256(rnd *rand.Rand) U256 {
 	var value U256
 	value.internal[0] = rnd.Uint64()
@@ -210,21 +223,4 @@ func (i U256) String() string {
 // ToBigInt returns a bigInt version of i
 func (i U256) ToBigInt() *big.Int {
 	return i.internal.ToBig()
-}
-
-// U256FromBigInt returns a U256 version of b.
-// This conversion can panic on overflow conversion.
-func U256FromBigInt(b *big.Int) *U256 {
-	ret := NewU256()
-	if b.Cmp(big.NewInt(0)) == -1 {
-		panic("Tried converting negative big.Ing to unsigend.")
-	}
-	newInternal, overflow := uint256.FromBig(b)
-	if overflow {
-		// since EVMs handle at most 256-bit values, this case should never happen.
-		// IF it ever did, it would most certainly be an error, and execution halted.
-		panic("big.Int has more than 256-bits.")
-	}
-	ret.internal = *newInternal
-	return &ret
 }

--- a/go/vm/geth/ct.go
+++ b/go/vm/geth/ct.go
@@ -97,13 +97,13 @@ func ConvertGethToCtState(geth *gethInterpreter, state *vm.GethState) (*st.State
 	ctState.CallContext.AccountAddress = (ct.Address)(state.Contract.Address().Bytes())
 	ctState.CallContext.OriginAddress = (ct.Address)(geth.evm.Origin.Bytes())
 	ctState.CallContext.CallerAddress = (ct.Address)(state.Contract.CallerAddress.Bytes())
-	ctState.CallContext.Value = *ct.U256FromBigInt(state.Contract.Value())
+	ctState.CallContext.Value = ct.NewU256FromBigInt(state.Contract.Value())
 
 	ctState.BlockContext.BlockNumber = geth.evm.Context.BlockNumber.Uint64()
 	ctState.BlockContext.CoinBase = (ct.Address)(geth.evm.Context.Coinbase)
 	ctState.BlockContext.GasLimit = geth.evm.Context.GasLimit
-	ctState.BlockContext.GasPrice = *ct.U256FromBigInt(geth.evm.GasPrice)
-	ctState.BlockContext.Difficulty = *ct.U256FromBigInt(geth.evm.Context.Difficulty)
+	ctState.BlockContext.GasPrice = ct.NewU256FromBigInt(geth.evm.GasPrice)
+	ctState.BlockContext.Difficulty = ct.NewU256FromBigInt(geth.evm.Context.Difficulty)
 	ctState.BlockContext.TimeStamp = geth.evm.Context.Time.Uint64()
 
 	return ctState, nil

--- a/go/vm/lfvm/ct.go
+++ b/go/vm/lfvm/ct.go
@@ -109,14 +109,14 @@ func ConvertLfvmContextToCtState(ctx *context, originalCode *st.Code, pcMap *PcM
 	}
 	state.CallContext.AccountAddress = (ct.Address)(ctx.contract.Address().Bytes())
 	state.CallContext.CallerAddress = (ct.Address)(ctx.contract.CallerAddress.Bytes())
-	state.CallContext.Value = *ct.U256FromBigInt(getIfNotNil(ctx.contract.Value()))
+	state.CallContext.Value = ct.NewU256FromBigInt(getIfNotNil(ctx.contract.Value()))
 	state.CallContext.OriginAddress = (ct.Address)(ctx.evm.Origin.Bytes())
 
 	state.BlockContext.BlockNumber = getIfNotNil(ctx.evm.Context.BlockNumber).Uint64()
 	state.BlockContext.CoinBase = (ct.Address)(ctx.evm.Context.Coinbase)
 	state.BlockContext.GasLimit = ctx.evm.Context.GasLimit
-	state.BlockContext.GasPrice = *ct.U256FromBigInt(getIfNotNil(ctx.evm.GasPrice))
-	state.BlockContext.Difficulty = *ct.U256FromBigInt(getIfNotNil(ctx.evm.Context.Difficulty))
+	state.BlockContext.GasPrice = ct.NewU256FromBigInt(getIfNotNil(ctx.evm.GasPrice))
+	state.BlockContext.Difficulty = ct.NewU256FromBigInt(getIfNotNil(ctx.evm.Context.Difficulty))
 	state.BlockContext.TimeStamp = getIfNotNil(ctx.evm.Context.Time).Uint64()
 
 	return state, nil


### PR DESCRIPTION
The previously introduced `U256FromBigInt` conversion constructor doesn't follow the Go convention of using `New` as a prefix for constructor names. This PR refactors this constructor to follow this convention, and brings it in-line with the rest of our infrastructure.