### PR TITLE
ct: Consistently consider out-of-bounds code as code not data

### DIFF
--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -384,7 +384,7 @@ func (c *isCode) Check(s *st.State) (bool, error) {
 		return false, err
 	}
 	if !pos.IsUint64() || pos.Uint64() > math.MaxInt {
-		return false, nil
+		return true, nil // Out-of-bounds is considered code.
 	}
 	return s.Code.IsCode(int(pos.Uint64())), nil
 }
@@ -426,7 +426,7 @@ func (c *isData) Check(s *st.State) (bool, error) {
 		return false, err
 	}
 	if !pos.IsUint64() || pos.Uint64() > math.MaxInt {
-		return false, nil
+		return false, nil // Out-of-bounds is considered code.
 	}
 	return s.Code.IsData(int(pos.Uint64())), nil
 }

--- a/go/ct/rlz/conditions_test.go
+++ b/go/ct/rlz/conditions_test.go
@@ -28,6 +28,12 @@ func TestCondition_Check(t *testing.T) {
 		return state
 	}
 
+	newStateWithStack := func(stack *st.Stack) *st.State {
+		state := st.NewState(st.NewCode([]byte{byte(PUSH1), byte(0)}))
+		state.Stack = stack
+		return state
+	}
+
 	tests := []struct {
 		condition Condition
 		valid     *st.State
@@ -48,7 +54,11 @@ func TestCondition_Check(t *testing.T) {
 		{And(Eq(Status(), st.Reverted), Eq(Pc(), NewU256(42))), newStateWithStatusAndPc(st.Reverted, 42), newStateWithStatusAndPc(st.Returned, 42)},
 		{And(Eq(Status(), st.Reverted), Eq(Pc(), NewU256(42))), newStateWithStatusAndPc(st.Reverted, 42), newStateWithStatusAndPc(st.Reverted, 41)},
 		{IsCode(Pc()), newStateWithPcAndCode(1, byte(ADD), byte(ADD)), newStateWithPcAndCode(1, byte(PUSH1), byte(0))},
+		{IsCode(Pc()), newStateWithPcAndCode(2, byte(ADD), byte(ADD)), newStateWithPcAndCode(1, byte(PUSH1), byte(0))},
+		{IsCode(Param(0)), newStateWithStack(st.NewStack(NewU256(1, 1))), newStateWithStack(st.NewStack(NewU256(1)))},
 		{IsData(Pc()), newStateWithPcAndCode(1, byte(PUSH1), byte(0)), newStateWithPcAndCode(1, byte(ADD), byte(ADD))},
+		{IsData(Pc()), newStateWithPcAndCode(1, byte(PUSH1), byte(0)), newStateWithPcAndCode(2, byte(ADD), byte(ADD))},
+		{IsData(Param(0)), newStateWithStack(st.NewStack(NewU256(1))), newStateWithStack(st.NewStack(NewU256(1, 1)))},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR fixes an inconsistency found through #291 where out-of-bounds code was not considered as code. The `IsCode` implementation considered code between `code.Length` and `MaxInt` as code, but values bigger than `MaxInt` as data. This PR makes it so out-of-bounds is always considered to be code.

This is needed for the rules for `JUMP` and `JUMPI`, where the jump goes outside the bounds. Those states were not correctly matched to their respective rules.