### PR TITLE
Recover stack in evmzero in all error conditions

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -1910,15 +1910,16 @@ void RunInterpreter(Context& ctx, Observer& observer, int steps) {
 
 end:
   if constexpr (Stepping) {
-    // When the stack under/overflows the top pointer will be invalid, so we reset it here.
-    if (state == RunState::kErrorStackUnderflow || state == RunState::kErrorStackOverflow) {
-      top = ctx.stack.Top();
-    }
-
     if (IsSuccess(state) || state == RunState::kRunning) {
       ctx.gas = gas;
     } else {
       ctx.gas = 0;
+
+      // If the execution of the instruction has identified an issue
+      // leading to the termination of the execution the stack pointer
+      // should have not been moved after the operation. If this
+      // happened, we are undoing it.
+      top = ctx.stack.Top();
     }
   } else {
     if (IsSuccess(state)) {

--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -4992,6 +4992,7 @@ TEST(InterpreterTest, Step_JUMP_OutOfGas) {
           .pc_before = 0,
           .gas_before = 7,
           .stack_before = {2},
+          .stack_after = {2},
       },
       1);
 }
@@ -5042,6 +5043,7 @@ TEST(InterpreterTest, Step_JUMPI_OutOfGas) {
           .state_after = RunState::kErrorGas,
           .gas_before = 9,
           .stack_before = {0, 3},
+          .stack_after = {0, 3},
       },
       1);
 }


### PR DESCRIPTION
This PR fixes an issue in the evmzero causing the stack only to be recovered if there is a stack under or overflow. However, other error states may hides over or underflows (e.g. read-only violations), which as well requires the stack to be recovered.