### PR TITLE
Update go-ethereum-substate dependency to include static-mode fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,6 @@ require (
 	golang.org/x/sys v0.13.0 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240222145934-acff065cdf41
+replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240226135303-cd738dddd1b4
 
 replace github.com/ethereum/evmc/v10 => ./third_party/evmc

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Fantom-foundation/Substate v0.0.0-20230224090651-4c8c024214f4 h1:AA0BtERxmlf7jvDF4fwIB2k/Lsc7HTRE3QHTZnfcSVA=
 github.com/Fantom-foundation/Substate v0.0.0-20230224090651-4c8c024214f4/go.mod h1:/yIHWCDDJcdKMJYvOLdYOnHt5eUBF9XWnrvrNE+90ik=
-github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240222145934-acff065cdf41 h1:QNl0PhTUGrZDN8mR7D1Hd02dcYRB/CwZMzr21RkrrbU=
-github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240222145934-acff065cdf41/go.mod h1:Hu8U9SrXP6ABqtSNfJHw8lRGnr6tyma9PNZvwTweDjQ=
+github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240226135303-cd738dddd1b4 h1:vRkHPVvFwdbNb4drp/AacA31RxRiXeGjwR/K5pTbkNY=
+github.com/Fantom-foundation/go-ethereum-substate v1.1.1-0.20240226135303-cd738dddd1b4/go.mod h1:Hu8U9SrXP6ABqtSNfJHw8lRGnr6tyma9PNZvwTweDjQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIOA6tDi6QXUemppXK3P9BI7mr2hd6gx8=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=


### PR DESCRIPTION
Updates the go-ethereum version dependency to include another fix for supporting the static mode option in tests.