### PR TITLE
Disable long-running CT test in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,8 +32,9 @@ jobs:
     - name: Test
       run: make test-go
 
-    - name: CT rule coverage test
-      run: go run ./go/ct/driver test
+    # see issue #316
+    #- name: CT rule coverage test
+    #  run: go run ./go/ct/driver test
 
     #- name: CT on LFVM
     #  run: go run ./go/ct/driver run lfvm


### PR DESCRIPTION
This is a mitigation fix for #316 disabling the problematic test.