### PR TITLE
ct: Fix not all fields being correctly serialized

### DIFF
--- a/go/ct/common/address.go
+++ b/go/ct/common/address.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 
 	"pgregory.net/rand"
 )
@@ -43,4 +45,27 @@ func (a *Address) Clone() Address {
 
 func (a Address) String() string {
 	return fmt.Sprintf("0x%x", ([20]byte)(a))
+}
+
+func (a Address) MarshalText() ([]byte, error) {
+	return []byte(a.String()), nil
+}
+
+func (a *Address) UnmarshalText(text []byte) error {
+	r := regexp.MustCompile("^0x([[:xdigit:]]{40})$")
+	match := r.FindSubmatch(text)
+
+	if len(match) != 2 {
+		return fmt.Errorf("invalid address: %s", text)
+	}
+
+	for i := 0; i < 20; i++ {
+		b := match[1][i*2 : i*2+2]
+		parsed, err := strconv.ParseUint(string(b), 16, 8)
+		if err != nil {
+			return err
+		}
+		a[i] = byte(parsed)
+	}
+	return nil
 }

--- a/go/ct/st_test/serialization_test.go
+++ b/go/ct/st_test/serialization_test.go
@@ -1,0 +1,41 @@
+package st_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"pgregory.net/rand"
+
+	"github.com/Fantom-foundation/Tosca/go/ct/gen"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+)
+
+func TestSerialization_EndToEndTest(t *testing.T) {
+	const N = 100
+	rnd := rand.New(0)
+	gen := gen.NewStateGenerator()
+
+	for i := 0; i < N; i++ {
+		state, err := gen.Generate(rnd)
+		if err != nil {
+			t.Fatalf("failed to generate random state: %v", err)
+		}
+
+		path := filepath.Join(t.TempDir(), "state.json")
+		if err := st.ExportStateJSON(state, path); err != nil {
+			t.Fatalf("failed to write state to file: %v", err)
+		}
+
+		restored, err := st.ImportStateJSON(path)
+		if err != nil {
+			t.Fatalf("failed to read state from file: %v", err)
+		}
+
+		if !state.Eq(restored) {
+			t.Errorf("failed to restore state\nwanted: %v\ngot: %v\n", state, restored)
+			for _, cur := range state.Diff(restored) {
+				t.Errorf("%s\n", cur)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds support for `Balance` and `CallData` to the state serialization. It also adds a new test that makes use of the generator infrastructure to generate test inputs for serialization/deserialization. This test will fail when new things get added to the CT state without updating the serialization.

I think this PR should be merged before #285 and #313, because both of these are not updating the serialization, and the test introduced in this PR would catch this.