### PR TITLE
Print serialization output in human readable form

### DIFF
--- a/go/ct/common/revisions_test.go
+++ b/go/ct/common/revisions_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -65,5 +66,65 @@ func TestRevisions_GetForkBlockInvalid(t *testing.T) {
 	_, err := GetForkBlock(R99_UnknownNextRevision + 1)
 	if err == nil {
 		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestRevisions_Marshal(t *testing.T) {
+	tests := map[Revision]string{
+		R07_Istanbul:            "\"Istanbul\"",
+		R09_Berlin:              "\"Berlin\"",
+		R10_London:              "\"London\"",
+		R99_UnknownNextRevision: "\"UnknownNextRevision\"",
+	}
+
+	for input, expected := range tests {
+		marshaled, err := input.MarshalJSON()
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if !bytes.Equal(marshaled, []byte(expected)) {
+			t.Errorf("Unexpected marshaled revision, wanted: %v vs got: %v", expected, marshaled)
+		}
+	}
+}
+
+func TestRevisions_MarshalError(t *testing.T) {
+	revisions := []Revision{Revision(42), Revision(100)}
+	for _, rev := range revisions {
+		marshaled, err := rev.MarshalJSON()
+		if err == nil {
+			t.Errorf("Expected error but got: %v", marshaled)
+		}
+	}
+}
+
+func TestRevisions_Unmarshal(t *testing.T) {
+	tests := map[string]Revision{
+		"\"Istanbul\"":            R07_Istanbul,
+		"\"Berlin\"":              R09_Berlin,
+		"\"London\"":              R10_London,
+		"\"UnknownNextRevision\"": R99_UnknownNextRevision,
+	}
+
+	for input, expected := range tests {
+		var rev Revision
+		err := rev.UnmarshalJSON([]byte(input))
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if rev != expected {
+			t.Errorf("Unexpected unmarshaled revision, wanted: %v vs got: %v", expected, rev)
+		}
+	}
+}
+
+func TestRevisions_UnmarshalError(t *testing.T) {
+	inputs := []string{"Error", "Revision(42)", "Istanbul"}
+	for _, input := range inputs {
+		var rev Revision
+		err := rev.UnmarshalJSON([]byte(input))
+		if err == nil {
+			t.Errorf("Expected error but got: %v", rev)
+		}
 	}
 }

--- a/go/ct/st/state.go
+++ b/go/ct/st/state.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -51,7 +52,12 @@ func (s StatusCode) String() string {
 }
 
 func (s StatusCode) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s.String())
+	statusString := s.String()
+	reg := regexp.MustCompile(`StatusCode\([0-9]+\)`)
+	if reg.MatchString(statusString) {
+		return nil, &json.UnsupportedValueError{}
+	}
+	return json.Marshal(statusString)
 }
 
 func (s *StatusCode) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
Revisions are serialized using their string name and code is printed in hex without differentiation between operations and data.

An example state is shown below:
```
{
  "Status": 0,
  "Revision": "London",
  "ReadOnly": true,
  "Pc": 3,
  "Gas": 42,
  "GasRefund": 63,
  "Code": [
    "61",
    "7",
    "4",
    "1",
    "0"
  ],
  "Stack": [
    "0000000000000000 0000000000000000 0000000000000000 000000000000002a"
  ],
  "Memory": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAECAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
  "Storage": {
    "Current": {
      "0000000000000000 0000000000000000 0000000000000000 000000000000002a": "0000000000000000 0000000000000000 0000000000000000 0000000000000007"
    },
    "Original": {
      "0000000000000000 0000000000000000 0000000000000000 000000000000004d": "0000000000000000 0000000000000000 0000000000000000 0000000000000004"
    },
    "Warm": {
      "0000000000000000 0000000000000000 0000000000000000 0000000000000009": true
    }
  },
  "Balance": {
    "Current": {
      "0x0100000000000000000000000000000000000000": "0000000000000000 0000000000000000 0000000000000000 000000000000002a"
    },
    "Warm": {
      "0x0200000000000000000000000000000000000000": true
    }
  },
  "Logs": {
    "Entries": [
      {
        "Topics": [
          "0000000000000000 0000000000000000 0000000000000000 0000000000000015",
          "0000000000000000 0000000000000000 0000000000000000 0000000000000016"
        ],
        "Data": "BAUG"
      }
    ]
  },
  "CallContext": {
    "AccountAddress": "0x0100000000000000000000000000000000000000",
    "OriginAddress": "0x0000000000000000000000000000000000000000",
    "CallerAddress": "0x0000000000000000000000000000000000000000",
    "Value": "0000000000000000 0000000000000000 0000000000000000 0000000000000000"
  },
  "BlockContext": {
    "BaseFee": "0000000000000000 0000000000000000 0000000000000000 0000000000000000",
    "BlockNumber": 1,
    "ChainID": "0000000000000000 0000000000000000 0000000000000000 0000000000000000",
    "CoinBase": "0x0000000000000000000000000000000000000000",
    "GasLimit": 0,
    "GasPrice": "0000000000000000 0000000000000000 0000000000000000 0000000000000000",
    "Difficulty": "0000000000000000 0000000000000000 0000000000000000 0000000000000000",
    "TimeStamp": 0
  },
  "CallData": "AQ=="
}
```