### PR TITLE
Fix extcodecopy overflow check

### DIFF
--- a/go/vm/lfvm/instructions.go
+++ b/go/vm/lfvm/instructions.go
@@ -855,7 +855,7 @@ func opExtCodeCopy(c *context) {
 		codeOffset = stack.pop()
 		length     = stack.pop()
 	)
-	if checkSizeOffsetUint64Overflow(memOffset, length) != nil || checkSizeOffsetUint64Overflow(codeOffset, length) != nil {
+	if checkSizeOffsetUint64Overflow(memOffset, length) != nil {
 		c.SignalError(errGasUintOverflow)
 		return
 	}


### PR DESCRIPTION
This PR fixes the overflow check in the lfvm, this issue has been discovered in PR #313.