### PR TITLE
Remove CT-only field from public interpreter interface

### DIFF
--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -36,19 +36,18 @@ func ToVmParameters(state *st.State) vm.Parameters {
 	}
 
 	return vm.Parameters{
-		Context:            &ctRunContext{state},
-		Revision:           revision,
-		Kind:               vm.Call,
-		Static:             state.ReadOnly,
-		Depth:              0,
-		Gas:                vm.Gas(state.Gas),
-		Recipient:          vm.Address(state.CallContext.AccountAddress),
-		Sender:             vm.Address(state.CallContext.CallerAddress),
-		Input:              state.CallData,
-		LastCallReturnData: state.LastCallReturnData,
-		Value:              vm.Value(state.CallContext.Value.Bytes32be()),
-		CodeHash:           nil,
-		Code:               code,
+		Context:   &ctRunContext{state},
+		Revision:  revision,
+		Kind:      vm.Call,
+		Static:    state.ReadOnly,
+		Depth:     0,
+		Gas:       vm.Gas(state.Gas),
+		Recipient: vm.Address(state.CallContext.AccountAddress),
+		Sender:    vm.Address(state.CallContext.CallerAddress),
+		Input:     state.CallData,
+		Value:     vm.Value(state.CallContext.Value.Bytes32be()),
+		CodeHash:  nil,
+		Code:      code,
 	}
 }
 

--- a/go/vm/evmc/evmc_steppable_interpreter.go
+++ b/go/vm/evmc/evmc_steppable_interpreter.go
@@ -62,7 +62,7 @@ func (e *SteppableEvmcInterpreter) StepN(
 		Recipient:      evmc.Address(params.Recipient),
 		Sender:         evmc.Address(params.Sender),
 		Input:          params.Input,
-		LastCallResult: params.LastCallReturnData,
+		LastCallResult: state.LastCallReturnData,
 		Value:          evmc.Hash(params.Value),
 		CodeHash:       codeHash,
 		Code:           params.Code,

--- a/go/vm/interpreter.go
+++ b/go/vm/interpreter.go
@@ -20,19 +20,18 @@ type Interpreter interface {
 
 // Parameters summarizes the list of input parameters required for executing code.
 type Parameters struct {
-	Context            RunContext
-	Revision           Revision
-	Kind               CallKind
-	Static             bool
-	Depth              int
-	Gas                Gas
-	Recipient          Address
-	Sender             Address
-	Input              []byte
-	LastCallReturnData []byte
-	Value              Value
-	CodeHash           *Hash
-	Code               []byte
+	Context   RunContext
+	Revision  Revision
+	Kind      CallKind
+	Static    bool
+	Depth     int
+	Gas       Gas
+	Recipient Address
+	Sender    Address
+	Input     []byte
+	Value     Value
+	CodeHash  *Hash
+	Code      []byte
 }
 
 // Result summarizes the result of a EVM code computation.

--- a/go/vm/lfvm/ct.go
+++ b/go/vm/lfvm/ct.go
@@ -72,7 +72,7 @@ func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 		code:        converted,
 		isBerlin:    params.Revision >= vm.R09_Berlin,
 		isLondon:    params.Revision >= vm.R10_London,
-		return_data: params.LastCallReturnData,
+		return_data: state.LastCallReturnData,
 	}
 
 	defer func() {


### PR DESCRIPTION
This PR removes the `LastCallReturnData` field introduced to the top-level Interpreter [`Parameter`](https://github.com/Fantom-foundation/Tosca/blob/9495b6fb8b8149350bf6893a0aca4ff8659316a1/go/vm/interpreter.go#L22) struct by #285. 

This parameter parameter should have not been added to the top-level interface since it is only required in the CT setup. It should not be exposed to the regular use of interpreter instances.