### PR TITLE
Improve load balancing of CT test runner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/btcsuite/btcd v0.20.1-beta // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/dsnet/golib/unitconv v1.0.2 // indirect
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/mock v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwu
 github.com/docker/docker v1.6.2/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/dop251/goja v0.0.0-20220405120441-9037c2b61cbf/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
 github.com/dop251/goja_nodejs v0.0.0-20210225215109-d91c329300e7/go.mod h1:hn7BA7c8pLvoGndExHudxTDKZ84Pyvv+90pbBjbTz0Y=
+github.com/dsnet/golib/unitconv v1.0.2 h1:45gXng3Op1vTrnX1PdM9Bla4mEpBFYA5aC8dlqacmwM=
+github.com/dsnet/golib/unitconv v1.0.2/go.mod h1:86KTUtTJFLreKjc4sS9xE0rhj4lR44Ox0rEQSEXSWwM=
 github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/go/ct/driver/run.go
+++ b/go/ct/driver/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"github.com/Fantom-foundation/Tosca/go/vm/evmzero"
 	"github.com/Fantom-foundation/Tosca/go/vm/lfvm"
+	"github.com/dsnet/golib/unitconv"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/exp/maps"
 	"pgregory.net/rand"
@@ -149,7 +150,7 @@ func runTests(
 
 	fmt.Printf("Starting Conformance Tests on %v with seed %d ..\n", evmName, seed)
 	if maxNumIssues > 0 {
-		fmt.Printf("Testing will abort after identifying %d issues\n", maxNumIssues)
+		fmt.Printf("Testing will abort after identifying %d issue(s)\n", maxNumIssues)
 	} else {
 		maxNumIssues = math.MaxInt
 	}
@@ -301,6 +302,7 @@ func runTest(input *st.State, evm ct.Evm, filter *regexp.Regexp) error {
 	errMsg := fmt.Sprintln("input state:", input)
 	errMsg += fmt.Sprintln("result state:", result)
 	errMsg += fmt.Sprintln("expected state:", expected)
+	errMsg += fmt.Sprintln("expectation defined by rule: ", rule.Name)
 	errMsg += "Differences:\n"
 	for _, diff := range result.Diff(expected) {
 		errMsg += fmt.Sprintf("\t%s\n", diff)


### PR DESCRIPTION
Improves the CT test runner by applying the following changes:
- instead of rules individual test states are distributed to the workers. This reduces load-imbalance. In particular, the high load of rule `log4_regular` is distributed among multiple workers
- errors are now collected in an internal list and printed at the end of the execution
- a periodic update message is now printed to the console to enable users to monitor the progress
- a few minor improvements of the way issues are reported

TODO:
- [x] complete a full test run without the `--full-mode` flag (took 4:42 instead of 8:38)
- [x] complete a full test run with the `--full-mode` flag