### PR TITLE
Allow test-state consumers to abort enumeration

### DIFF
--- a/go/ct/rlz/consumer.go
+++ b/go/ct/rlz/consumer.go
@@ -1,0 +1,10 @@
+package rlz
+
+// ConsumerResult is the return type of callback functions consuming
+// partial or fully generated test case inputs.
+type ConsumerResult bool
+
+const (
+	ConsumeContinue ConsumerResult = true
+	ConsumeAbort    ConsumerResult = false
+)

--- a/go/ct/rlz/rules_test.go
+++ b/go/ct/rlz/rules_test.go
@@ -1,7 +1,6 @@
 package rlz
 
 import (
-	"errors"
 	"testing"
 
 	"pgregory.net/rand"
@@ -56,7 +55,7 @@ func TestRule_EnumerateTestCases(t *testing.T) {
 		misses := 0
 
 		rule := Rule{Condition: test}
-		errs := rule.EnumerateTestCases(rnd, func(sample *st.State) error {
+		err := rule.EnumerateTestCases(rnd, func(sample *st.State) ConsumerResult {
 			match, err := test.Check(sample)
 			if err != nil {
 				t.Errorf("Condition check error %v", err)
@@ -66,9 +65,8 @@ func TestRule_EnumerateTestCases(t *testing.T) {
 			} else {
 				misses++
 			}
-			return nil
+			return ConsumeContinue
 		})
-		err := errors.Join(errs...)
 		if err != nil {
 			t.Errorf("EnumerateTestCases failed %v", err)
 		}

--- a/go/ct/spc/specification_test.go
+++ b/go/ct/spc/specification_test.go
@@ -6,6 +6,7 @@ import (
 	"pgregory.net/rand"
 
 	"github.com/Fantom-foundation/Tosca/go/ct/gen"
+	"github.com/Fantom-foundation/Tosca/go/ct/rlz"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 )
 
@@ -44,7 +45,7 @@ func TestSpecification_EachRuleProducesAMatchingTestCase(t *testing.T) {
 			hits := 0
 			misses := 0
 			rnd := rand.New(0)
-			rule.EnumerateTestCases(rnd, func(state *st.State) error {
+			rule.EnumerateTestCases(rnd, func(state *st.State) rlz.ConsumerResult {
 				match, err := rule.Condition.Check(state)
 				if err != nil {
 					t.Errorf("failed to check rule condition for %v: %v", rule.Name, err)
@@ -53,7 +54,10 @@ func TestSpecification_EachRuleProducesAMatchingTestCase(t *testing.T) {
 				} else {
 					misses++
 				}
-				return nil
+				if hits > 0 && misses > 0 {
+					return rlz.ConsumeAbort
+				}
+				return rlz.ConsumeContinue
 			})
 
 			if hits == 0 {


### PR DESCRIPTION
This PR updates the test case enumeration interface to allow the consumer function to signal that it would like to abort the enumeration of test case. 

This can be used to safe a lot of time, as shown by the `TestSpecification_EachRuleProducesAMatchingTestCase` test case. Before this change it took >300s on my PC to run this test. With this change, the test finishes in 35s.