### PR TITLE
Enforce valid gas range in state generator

### DIFF
--- a/go/ct/gen/state_test.go
+++ b/go/ct/gen/state_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 )
 
 func TestStateGenerator_UnconstrainedGeneratorCanProduceState(t *testing.T) {
@@ -185,7 +186,7 @@ func TestStateGenerator_NonConflictingPcesAreAccepted(t *testing.T) {
 // Gas Counter
 
 func TestStateGenerator_SetGasIsEnforced(t *testing.T) {
-	gasCounts := []uint64{0, 42, GasUpperbound}
+	gasCounts := []vm.Gas{0, 42, st.MaxGas}
 
 	rnd := rand.New(0)
 	for _, gas := range gasCounts {
@@ -225,7 +226,7 @@ func TestStateGenerator_NonConflictingGasAreAccepted(t *testing.T) {
 // Gas Refund Counter
 
 func TestStateGenerator_SetGasRefundIsEnforced(t *testing.T) {
-	gasRefundCounts := []uint64{0, 42, math.MaxUint64}
+	gasRefundCounts := []vm.Gas{0, 42, math.MaxInt64}
 
 	rnd := rand.New(0)
 	for _, gasRefund := range gasRefundCounts {

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -4,8 +4,8 @@ import (
 	"math"
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
-	"github.com/Fantom-foundation/Tosca/go/ct/gen"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 )
 
 // Domain represents the domain of values for a given type.
@@ -298,18 +298,18 @@ func (addressDomain) SamplesForAll(as []Address) []Address {
 
 type gasDomain struct{}
 
-func (gasDomain) Equal(a uint64, b uint64) bool     { return a == b }
-func (gasDomain) Less(a uint64, b uint64) bool      { return a < b }
-func (gasDomain) Predecessor(a uint64) uint64       { return a - 1 }
-func (gasDomain) Successor(a uint64) uint64         { return a + 1 }
-func (gasDomain) SomethingNotEqual(a uint64) uint64 { return a + 1 }
+func (gasDomain) Equal(a vm.Gas, b vm.Gas) bool     { return a == b }
+func (gasDomain) Less(a vm.Gas, b vm.Gas) bool      { return a < b }
+func (gasDomain) Predecessor(a vm.Gas) vm.Gas       { return a - 1 }
+func (gasDomain) Successor(a vm.Gas) vm.Gas         { return a + 1 }
+func (gasDomain) SomethingNotEqual(a vm.Gas) vm.Gas { return a + 1 }
 
-func (d gasDomain) Samples(a uint64) []uint64 {
-	return d.SamplesForAll([]uint64{a})
+func (d gasDomain) Samples(a vm.Gas) []vm.Gas {
+	return d.SamplesForAll([]vm.Gas{a})
 }
 
-func (gasDomain) SamplesForAll(as []uint64) []uint64 {
-	res := []uint64{0, gen.GasUpperbound}
+func (gasDomain) SamplesForAll(as []vm.Gas) []vm.Gas {
+	res := []vm.Gas{0, st.MaxGas}
 
 	// Test every element off by one.
 	for _, a := range as {
@@ -319,7 +319,7 @@ func (gasDomain) SamplesForAll(as []uint64) []uint64 {
 	}
 
 	// Add all powers of 2 until upper bound.
-	for value := uint64(1); value < gen.GasUpperbound; value <<= 1 {
+	for value := vm.Gas(1); value < st.MaxGas; value <<= 1 {
 		res = append(res, value)
 	}
 

--- a/go/ct/rlz/expressions.go
+++ b/go/ct/rlz/expressions.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/gen"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 )
 
 type RestrictionKind int
@@ -112,17 +113,17 @@ func (e pc) BindTo(generator *gen.StateGenerator) {
 
 type gas struct{}
 
-func Gas() Expression[uint64] {
+func Gas() Expression[vm.Gas] {
 	return gas{}
 }
 
-func (gas) Domain() Domain[uint64] { return gasDomain{} }
+func (gas) Domain() Domain[vm.Gas] { return gasDomain{} }
 
-func (gas) Eval(s *st.State) (uint64, error) {
+func (gas) Eval(s *st.State) (vm.Gas, error) {
 	return s.Gas, nil
 }
 
-func (gas) Restrict(kind RestrictionKind, amount uint64, generator *gen.StateGenerator) {
+func (gas) Restrict(kind RestrictionKind, amount vm.Gas, generator *gen.StateGenerator) {
 	switch kind {
 	case RestrictLess:
 		generator.SetGas(amount - 1)
@@ -142,17 +143,17 @@ func (gas) String() string {
 
 type gasRefund struct{}
 
-func GasRefund() Expression[uint64] {
+func GasRefund() Expression[vm.Gas] {
 	return gasRefund{}
 }
 
-func (gasRefund) Domain() Domain[uint64] { return uint64Domain{} }
+func (gasRefund) Domain() Domain[vm.Gas] { return gasDomain{} }
 
-func (gasRefund) Eval(s *st.State) (uint64, error) {
+func (gasRefund) Eval(s *st.State) (vm.Gas, error) {
 	return s.GasRefund, nil
 }
 
-func (gasRefund) Restrict(kind RestrictionKind, amount uint64, generator *gen.StateGenerator) {
+func (gasRefund) Restrict(kind RestrictionKind, amount vm.Gas, generator *gen.StateGenerator) {
 	if kind != RestrictEqual {
 		panic("GasRefund only supports equality constraints")
 	}

--- a/go/ct/st/memory.go
+++ b/go/ct/st/memory.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -74,9 +75,9 @@ func (m *Memory) Grow(offset, size uint64) {
 
 // ExpansionCosts calculates the expansion costs for the given offset and size.
 // It does not grow memory. It also returns offset and size converted to uint64.
-func (m *Memory) ExpansionCosts(offset_u256, size_u256 U256) (memCost, offset, size uint64) {
+func (m *Memory) ExpansionCosts(offset_u256, size_u256 U256) (memCost vm.Gas, offset, size uint64) {
 	if !size_u256.IsUint64() || (!offset_u256.IsUint64() && !size_u256.IsZero()) {
-		return math.MaxUint64, 0, 0
+		return math.MaxInt64, 0, 0
 	}
 	offset = offset_u256.Uint64()
 	size = size_u256.Uint64()
@@ -89,9 +90,9 @@ func (m *Memory) ExpansionCosts(offset_u256, size_u256 U256) (memCost, offset, s
 		memCost = 0
 		return
 	}
-	calcMemoryCost := func(size uint64) uint64 {
+	calcMemoryCost := func(size uint64) vm.Gas {
 		memorySizeWord := (size + 31) / 32
-		return (memorySizeWord*memorySizeWord)/512 + (3 * memorySizeWord)
+		return vm.Gas((memorySizeWord*memorySizeWord)/512 + (3 * memorySizeWord))
 	}
 	memCost = calcMemoryCost(newSize) - calcMemoryCost(uint64(m.Size()))
 	return

--- a/go/ct/st/memory_test.go
+++ b/go/ct/st/memory_test.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 )
 
 func TestMemory_NewMemory(t *testing.T) {
@@ -123,7 +124,7 @@ func TestMemory_ExpansionCosts(t *testing.T) {
 	mem := NewMemory()
 
 	cost, offset, size := mem.ExpansionCosts(NewU256(128), NewU256(32))
-	if want, got := uint64(15), cost; want != got {
+	if want, got := vm.Gas(15), cost; want != got {
 		t.Errorf("Expansion cost calculation wrong, want %v got %v", want, got)
 	}
 
@@ -139,7 +140,7 @@ func TestMemory_ExpansionCostsSizeTooBig(t *testing.T) {
 	mem := NewMemory()
 
 	cost, offset, size := mem.ExpansionCosts(NewU256(128), NewU256(1, 0))
-	if want, got := uint64(math.MaxUint64), cost; want != got {
+	if want, got := vm.Gas(math.MaxInt64), cost; want != got {
 		t.Errorf("Expansion cost calculation wrong, want %v got %v", want, got)
 	}
 
@@ -155,7 +156,7 @@ func TestMemory_ExpansionCostsOffsetTooBig(t *testing.T) {
 	mem := NewMemory()
 
 	cost, offset, size := mem.ExpansionCosts(NewU256(1, 0), NewU256(32))
-	if want, got := uint64(math.MaxUint64), cost; want != got {
+	if want, got := vm.Gas(math.MaxInt64), cost; want != got {
 		t.Errorf("Expansion cost calculation wrong, want %v got %v", want, got)
 	}
 

--- a/go/ct/st/serialization.go
+++ b/go/ct/st/serialization.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 	"golang.org/x/exp/maps"
 )
 
@@ -49,8 +50,8 @@ type stateSerializable struct {
 	Revision           Revision
 	ReadOnly           bool
 	Pc                 uint16
-	Gas                uint64
-	GasRefund          uint64
+	Gas                vm.Gas
+	GasRefund          vm.Gas
 	Code               []byte
 	Stack              []U256
 	Memory             []byte

--- a/go/ct/st/state.go
+++ b/go/ct/st/state.go
@@ -7,7 +7,13 @@ import (
 	"strings"
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 )
+
+// Upper bound for gas, this limit is required since evmc defines a signed type for gas.
+// Limiting gas also solves issue 293 regarding out of memory failures,
+// discussed here: https://github.com/Fantom-foundation/Tosca/issues/293
+const MaxGas = vm.Gas(1 << 60)
 
 // MaxDataSize is the maximum length of the call data vector generated for a test state. While
 // the maximum size is not limited in a real-world setup, larger inputs are not expected to trigger
@@ -51,8 +57,8 @@ type State struct {
 	Revision           Revision
 	ReadOnly           bool
 	Pc                 uint16
-	Gas                uint64
-	GasRefund          uint64
+	Gas                vm.Gas
+	GasRefund          vm.Gas
 	Code               *Code
 	Stack              *Stack
 	Memory             *Memory

--- a/go/vm/evmc/evmc_steppable_interpreter.go
+++ b/go/vm/evmc/evmc_steppable_interpreter.go
@@ -82,8 +82,8 @@ func (e *SteppableEvmcInterpreter) StepN(
 		return nil, err
 	}
 	state.Pc = uint16(result.Pc)
-	state.Gas = uint64(result.GasLeft)
-	state.GasRefund = uint64(result.GasRefund)
+	state.Gas = vm.Gas(result.GasLeft)
+	state.GasRefund = vm.Gas(result.GasRefund)
 	state.Memory = convertEvmcMemoryToCtMemory(result.Memory)
 	state.Stack, err = convertEvmcStackToCtStack(result.Stack)
 	if err != nil {

--- a/go/vm/lfvm/ct.go
+++ b/go/vm/lfvm/ct.go
@@ -96,8 +96,8 @@ func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 			return nil, fmt.Errorf("failed to convert program counter %d", ctxt.pc)
 		}
 	}
-	state.Gas = uint64(ctxt.gas)
-	state.GasRefund = uint64(ctxt.refund)
+	state.Gas = ctxt.gas
+	state.GasRefund = ctxt.refund
 	state.Stack = convertLfvmStackToCtStack(ctxt.stack)
 	state.Memory = convertLfvmMemoryToCtMemory(ctxt.memory)
 


### PR DESCRIPTION
This PR adds an enforcement of the gas boundaries to the range `[0, MaxGas]` to the state generator. 

Furthermore, it updates the state representation to use the `vm.Gas` type and adds additional unit tests for gas constraints.
