### PR TITLE
ct: Fix memory expansion cost calculation overflowing

### DIFF
--- a/go/ct/st/memory.go
+++ b/go/ct/st/memory.go
@@ -85,13 +85,20 @@ func (m *Memory) ExpansionCosts(offset_u256, size_u256 U256) (memCost vm.Gas, of
 		memCost = 0
 		return
 	}
+	if offset > math.MaxUint64-size || size > math.MaxUint64-offset {
+		memCost = math.MaxInt64
+		return
+	}
 	newSize := offset + size
 	if newSize <= uint64(m.Size()) {
 		memCost = 0
 		return
 	}
 	calcMemoryCost := func(size uint64) vm.Gas {
-		memorySizeWord := (size + 31) / 32
+		memorySizeWord := size / 32
+		if size%32 != 0 {
+			memorySizeWord++
+		}
 		return vm.Gas((memorySizeWord*memorySizeWord)/512 + (3 * memorySizeWord))
 	}
 	memCost = calcMemoryCost(newSize) - calcMemoryCost(uint64(m.Size()))


### PR DESCRIPTION
This PR fixes an overflow bug in the computation of the memory expansion cost within the CT framework. This bug was fixed in evmzero with #267, but still remained broken in the CT framework.

Due to the lack of sparse memory in the CT framework this bug was never triggered. But it will be subject of a regression test with #329.