### PR TITLE
Fix evmzero logging

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -4,7 +4,6 @@
 #include <cstdio>
 #include <intx/intx.hpp>
 #include <iostream>
-#include <type_traits>
 
 #include "common/assert.h"
 #include "common/macros.h"
@@ -1898,11 +1897,11 @@ void RunInterpreter(Context& ctx, Observer& observer, int steps) {
     gas = res.gas_left;                                                         \
     top -= op::Impl<op::opcode>::kInfo.GetStackDelta();                         \
     size += op::Impl<op::opcode>::kInfo.GetStackDelta();                        \
-    observer.PostInstruction(op::opcode, ctx);                                  \
-    if constexpr (std::is_same<Observer, Logger>::value) {                      \
+    if (Observer::uses_context) {                                               \
       ctx.gas = gas;                                                            \
       ctx.stack.SetTop(top);                                                    \
     }                                                                           \
+    observer.PostInstruction(op::opcode, ctx);                                  \
   }                                                                             \
   DISPATCH();
 

--- a/cpp/vm/evmzero/logger.h
+++ b/cpp/vm/evmzero/logger.h
@@ -7,6 +7,8 @@ namespace tosca::evmzero {
 
 class Logger {
  public:
+  static constexpr bool uses_context = true;
+
   inline void PreRun(const InterpreterArgs&) {}
 
   inline void PreInstruction(op::OpCode opcode, const internal::Context& ctx) {

--- a/cpp/vm/evmzero/observer.h
+++ b/cpp/vm/evmzero/observer.h
@@ -23,6 +23,7 @@ struct Context;
 // The PreInstruction/PostInstruction get called before/after interpreting each instruction, respectively.
 template <typename O>
 concept Observer = requires(O o, const InterpreterArgs &args, op::OpCode opcode, const internal::Context &ctx) {
+  { o.uses_context } -> std::same_as<const bool &>;
   { o.PreRun(args) } -> std::same_as<void>;
   { o.PreInstruction(opcode, ctx) } -> std::same_as<void>;
   { o.PostInstruction(opcode, ctx) } -> std::same_as<void>;
@@ -31,6 +32,7 @@ concept Observer = requires(O o, const InterpreterArgs &args, op::OpCode opcode,
 
 // This type serves as a no-op implementation of the observer concept that is used when no observer is to be used.
 struct NoObserver {
+  static constexpr bool uses_context = false;
   inline void PreRun(const InterpreterArgs &) {}
   inline void PreInstruction(op::OpCode, const internal::Context &) {}
   inline void PostInstruction(op::OpCode, const internal::Context &) {}

--- a/cpp/vm/evmzero/profiler.h
+++ b/cpp/vm/evmzero/profiler.h
@@ -212,6 +212,8 @@ class Profiler {
   Profiler& operator=(const Profiler&) = delete;
   Profiler& operator=(Profiler&&) = delete;
 
+  static constexpr bool uses_context = false;
+
   // Construct the profiler from an already existing profile.
   explicit Profiler(const Profile<Mode>& profile) noexcept : profile_(profile) {}
 


### PR DESCRIPTION
This PR adds gas and stack to the logger context, fixing #319.

Simply copying the values added  an overhead to the benchmarks:
```
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Tosca/go/vm/test
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
                            │ original.log │           changed_directly.log           │
                            │    sec/op    │    sec/op      vs base                   │
Inc/1/evmzero-8               2.301µ ± 30%    2.519µ ± 11%        ~ (p=0.650 n=10+20)
Inc/10/evmzero-8              2.189µ ±  7%    2.378µ ± 19%   +8.66% (p=0.003 n=10+20)
Fib/1/evmzero-8               2.594µ ± 10%    2.730µ ± 10%        ~ (p=0.226 n=10+20)
Fib/5/evmzero-8               8.174µ ± 36%    9.809µ ± 12%  +20.00% (p=0.019 n=10+20)
Fib/10/evmzero-8              60.84µ ±  8%    75.92µ ±  7%  +24.79% (p=0.000 n=10+20)
Fib/15/evmzero-8              707.6µ ± 15%    872.3µ ± 14%  +23.29% (p=0.002 n=10+20)
Fib/20/evmzero-8              8.509m ± 83%    8.873m ± 11%        ~ (p=0.248 n=10+20)
Sha3/1/evmzero-8              1.895µ ± 17%    1.965µ ±  4%        ~ (p=0.650 n=10+20)
Sha3/10/evmzero-8             3.288µ ± 10%    3.518µ ±  3%   +7.01% (p=0.014 n=10+20)
Sha3/100/evmzero-8            17.48µ ± 15%    19.66µ ±  7%  +12.49% (p=0.015 n=10+20)
Sha3/1000/evmzero-8           182.3µ ± 21%    188.5µ ±  7%        ~ (p=0.183 n=10+20)
Arith/1/evmzero-8             2.395µ ±  3%    2.933µ ± 10%  +22.48% (p=0.000 n=10+20)
Arith/10/evmzero-8            6.153µ ± 17%    5.819µ ± 14%        ~ (p=0.183 n=10+20)
Arith/100/evmzero-8           36.17µ ± 20%    47.68µ ± 16%  +31.83% (p=0.000 n=10+20)
Arith/280/evmzero-8           94.10µ ±  9%   125.77µ ± 11%  +33.65% (p=0.000 n=10+20)
Memory/1/evmzero-8            3.704µ ± 32%    4.217µ ± 21%        ~ (p=0.122 n=10+20)
Memory/10/evmzero-8           7.858µ ± 19%    8.979µ ±  9%        ~ (p=0.067 n=10+20)
Memory/100/evmzero-8          43.66µ ± 14%    49.10µ ± 16%  +12.45% (p=0.001 n=10+20)
Memory/1000/evmzero-8         521.8µ ± 12%    626.8µ ± 12%  +20.11% (p=0.005 n=10+20)
Memory/10000/evmzero-8        4.370m ± 16%    4.149m ± 13%        ~ (p=0.350 n=10+20)
Analysis/jumpdest/evmzero-8   1.532µ ± 15%    1.596µ ± 18%        ~ (p=0.588 n=10+20)
Analysis/stop/evmzero-8       1.591µ ± 16%    1.602µ ±  8%        ~ (p=0.553 n=10+20)
Analysis/push1/evmzero-8      1.331µ ±  4%    1.421µ ± 10%        ~ (p=0.334 n=10+20)
Analysis/push32/evmzero-8     1.663µ ±  6%    1.326µ ± 20%  -20.29% (p=0.017 n=10+20)
geomean                       17.42µ          19.13µ         +9.81%
```

With the current implementation they are only copied when the logger is active, which should not have an impact on the other versions. 