### PR TITLE
Add support for CALL operation to the CT framework

### DIFF
--- a/go/ct/common/address.go
+++ b/go/ct/common/address.go
@@ -17,11 +17,13 @@ func AddressToU256(a vm.Address) U256 {
 	return NewU256FromBytes(a[:]...)
 }
 
+// Deprecated: use RandomAddress instead
 func RandAddress(rnd *rand.Rand) (vm.Address, error) {
+	return RandomAddress(rnd), nil
+}
+
+func RandomAddress(rnd *rand.Rand) vm.Address {
 	address := vm.Address{}
-	_, err := rnd.Read(address[:])
-	if err != nil {
-		return vm.Address{}, err
-	}
-	return address, nil
+	rnd.Read(address[:]) // never returns an error
+	return address
 }

--- a/go/ct/common/bytes.go
+++ b/go/ct/common/bytes.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"pgregory.net/rand"
+)
+
+// Bytes is an immutable slice of bytes that can be trivially cloned.
+type Bytes struct {
+	data string
+}
+
+func NewBytes(data []byte) Bytes {
+	return Bytes{data: string(data)}
+}
+
+func RandomBytes(rnd *rand.Rand) Bytes {
+	const (
+		expectedSize = 200
+		maxSize      = 2000
+	)
+	rand := rnd.ExpFloat64()
+	size := int(rand * expectedSize)
+	if size > maxSize {
+		size = maxSize
+	}
+	return RandomBytesOfSize(rnd, size)
+}
+
+func RandomBytesOfSize(rnd *rand.Rand, size int) Bytes {
+	data := make([]byte, size)
+	rnd.Read(data)
+	return NewBytes(data)
+}
+
+func (b Bytes) ToBytes() []byte {
+	return []byte(b.data)
+}
+
+func (b Bytes) String() string {
+	return fmt.Sprintf("0x%x", b.data)
+}
+
+func (b Bytes) MarshalJSON() ([]byte, error) {
+	return json.Marshal(fmt.Sprintf("%x", b.ToBytes()))
+}
+
+func (b *Bytes) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	data, err := hex.DecodeString(s)
+	if err != nil {
+		return err
+	}
+	b.data = string(data)
+	return nil
+}

--- a/go/ct/common/bytes_test.go
+++ b/go/ct/common/bytes_test.go
@@ -1,0 +1,91 @@
+package common
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBytes_EqualWhenContainingSameContent(t *testing.T) {
+	b1 := NewBytes([]byte{1, 2, 3})
+	b2 := NewBytes([]byte{1, 2, 3})
+	b3 := NewBytes([]byte{3, 2, 1})
+
+	if &b1 == &b2 {
+		t.Fatalf("instances are not distinct, got %v and %v", &b1, &b2)
+	}
+
+	if b1 != b2 {
+		t.Errorf("instances are not equal, got %v and %v", b1, b2)
+	}
+
+	if b1 == b3 {
+		t.Errorf("instances are equal, got %v and %v", b1, b3)
+	}
+}
+
+func TestBytes_AssignmentProducesEqualValue(t *testing.T) {
+	b1 := NewBytes([]byte{1, 2, 3})
+	b2 := b1
+
+	if b1 != b2 {
+		t.Errorf("assigned value is not equal: %v vs %v", b1, b2)
+	}
+}
+
+func TestBytes_CanBeJsonEncoded(t *testing.T) {
+	tests := map[string]struct {
+		bytes   Bytes
+		encoded string
+	}{
+		"empty": {
+			NewBytes(nil), "\"\"",
+		},
+		"single": {
+			NewBytes([]byte{1}), "\"01\"",
+		},
+		"triple": {
+			NewBytes([]byte{1, 2, 3}), "\"010203\"",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			encoded, err := json.Marshal(test.bytes)
+			if err != nil {
+				t.Fatalf("failed to encode into JSON: %v", err)
+			}
+
+			if want, got := test.encoded, string(encoded); want != got {
+				t.Errorf("unexpected JSON encoding, wanted %v, got %v", want, got)
+			}
+
+			var restored Bytes
+			if err := json.Unmarshal(encoded, &restored); err != nil {
+				t.Fatalf("failed to restore bytes: %v", err)
+			}
+			if test.bytes != restored {
+				t.Errorf("unexpected restored value, wanted %v, got %v", test.bytes, restored)
+			}
+		})
+	}
+}
+
+func TestBytes_InvalidJsonFails(t *testing.T) {
+	tests := map[string]string{
+		"empty":               "",
+		"missing start quote": "12\"",
+		"missing end quote":   "\"12",
+		"uneven length":       "\"123\"",
+		"not hex":             "\"xy\"",
+	}
+
+	for name, encoded := range tests {
+		t.Run(name, func(t *testing.T) {
+			var restored Bytes
+			err := json.Unmarshal([]byte(encoded), &restored)
+			if err == nil {
+				t.Errorf("decoding should have failed, but got %v", restored)
+			}
+		})
+	}
+}

--- a/go/ct/common/opcodes.go
+++ b/go/ct/common/opcodes.go
@@ -140,6 +140,7 @@ const (
 	LOG2           OpCode = 0xA2
 	LOG3           OpCode = 0xA3
 	LOG4           OpCode = 0xA4
+	CALL           OpCode = 0xF1
 	RETURN         OpCode = 0xF3
 	REVERT         OpCode = 0xFD
 	INVALID        OpCode = 0xFE
@@ -445,6 +446,8 @@ func (op OpCode) String() string {
 		return "LOG3"
 	case LOG4:
 		return "LOG4"
+	case CALL:
+		return "CALL"
 	case RETURN:
 		return "RETURN"
 	case REVERT:

--- a/go/ct/gen/call_journal.go
+++ b/go/ct/gen/call_journal.go
@@ -1,0 +1,40 @@
+package gen
+
+import (
+	"github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+	"github.com/Fantom-foundation/Tosca/go/vm"
+	"pgregory.net/rand"
+)
+
+type CallJournalGenerator struct {
+}
+
+func NewCallJournalGenerator() *CallJournalGenerator {
+	return &CallJournalGenerator{}
+}
+
+func (*CallJournalGenerator) Generate(rnd *rand.Rand) (*st.CallJournal, error) {
+	journal := st.NewCallJournal()
+
+	// One future call is enough for any single instruction.
+	journal.Future = append(journal.Future, st.FutureCall{
+		Success:   rnd.Int31n(2) == 1,
+		Output:    common.RandomBytes(rnd),
+		GasCosts:  vm.Gas(rnd.Int63()),
+		GasRefund: vm.Gas(rnd.Int63()),
+	})
+
+	return journal, nil
+}
+
+func (*CallJournalGenerator) Clone() *CallJournalGenerator {
+	return &CallJournalGenerator{}
+}
+
+func (*CallJournalGenerator) Restore(*CallJournalGenerator) {
+}
+
+func (*CallJournalGenerator) String() string {
+	return "{}"
+}

--- a/go/ct/gen/call_journal_test.go
+++ b/go/ct/gen/call_journal_test.go
@@ -1,0 +1,22 @@
+package gen
+
+import (
+	"testing"
+
+	"pgregory.net/rand"
+)
+
+func TestCallJournalGenerator_CanProduceNonEmptyJournal(t *testing.T) {
+	rnd := rand.New(0)
+	generator := NewCallJournalGenerator()
+	journal, err := generator.Generate(rnd)
+	if err != nil {
+		t.Fatalf("failed to generate journal, err: %v", err)
+	}
+	if len(journal.Past) != 0 {
+		t.Errorf("the generator should not produce past calls")
+	}
+	if len(journal.Future) != 1 {
+		t.Errorf("expected exactly one future call")
+	}
+}

--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -47,6 +47,7 @@ type StateGenerator struct {
 	storageGen      *StorageGenerator
 	accountsGen     *AccountsGenerator
 	callContextGen  *CallContextGenerator
+	callJournalGen  *CallJournalGenerator
 	BlockContextGen *BlockContextGenerator
 }
 
@@ -59,6 +60,7 @@ func NewStateGenerator() *StateGenerator {
 		storageGen:      NewStorageGenerator(),
 		accountsGen:     NewAccountGenerator(),
 		callContextGen:  NewCallContextGenerator(),
+		callJournalGen:  NewCallJournalGenerator(),
 		BlockContextGen: NewBlockContextGenerator(),
 	}
 }
@@ -367,6 +369,11 @@ func (g *StateGenerator) Generate(rnd *rand.Rand) (*st.State, error) {
 		return nil, err
 	}
 
+	resultCallJournal, err := g.callJournalGen.Generate(rnd)
+	if err != nil {
+		return nil, err
+	}
+
 	// Invoke BlockContextGenerator
 	resultBlockContext, err := g.BlockContextGen.Generate(rnd, resultRevision)
 	if err != nil {
@@ -434,6 +441,7 @@ func (g *StateGenerator) Generate(rnd *rand.Rand) (*st.State, error) {
 	result.Storage = resultStorage
 	result.Accounts = resultAccounts
 	result.CallContext = resultCallContext
+	result.CallJournal = resultCallJournal
 	result.BlockContext = resultBlockContext
 	result.CallData = resultCallData
 	result.LastCallReturnData = resultLastCallReturnData
@@ -460,6 +468,7 @@ func (g *StateGenerator) Clone() *StateGenerator {
 		storageGen:            g.storageGen.Clone(),
 		accountsGen:           g.accountsGen.Clone(),
 		callContextGen:        g.callContextGen.Clone(),
+		callJournalGen:        g.callJournalGen.Clone(),
 		BlockContextGen:       g.BlockContextGen.Clone(),
 	}
 }
@@ -481,6 +490,7 @@ func (g *StateGenerator) Restore(other *StateGenerator) {
 		g.storageGen.Restore(other.storageGen)
 		g.accountsGen.Restore(other.accountsGen)
 		g.callContextGen.Restore(other.callContextGen)
+		g.callJournalGen.Restore(other.callJournalGen)
 		g.BlockContextGen.Restore(other.BlockContextGen)
 	}
 }
@@ -532,8 +542,9 @@ func (g *StateGenerator) String() string {
 	parts = append(parts, fmt.Sprintf("memory=%v", g.memoryGen))
 	parts = append(parts, fmt.Sprintf("storage=%v", g.storageGen))
 	parts = append(parts, fmt.Sprintf("accounts=%v", g.accountsGen))
-	parts = append(parts, fmt.Sprintf("callcontext=%v", g.callContextGen))
-	parts = append(parts, fmt.Sprintf("blockcontext=%v", g.BlockContextGen))
+	parts = append(parts, fmt.Sprintf("callContext=%v", g.callContextGen))
+	parts = append(parts, fmt.Sprintf("callJournal=%v", g.callJournalGen))
+	parts = append(parts, fmt.Sprintf("blockContext=%v", g.BlockContextGen))
 
 	return "{" + strings.Join(parts, ",") + "}"
 }

--- a/go/ct/gen/state_test.go
+++ b/go/ct/gen/state_test.go
@@ -331,8 +331,9 @@ func TestStateGenerator_ClonesAreIndependent(t *testing.T) {
 		"memory={}",
 		"storage={}",
 		"accounts={}",
-		"callcontext={}",
-		"blockcontext={}",
+		"callContext={}",
+		"callJournal={}",
+		"blockContext={}",
 	})
 
 	checkPrint(clone2, []string{
@@ -347,8 +348,9 @@ func TestStateGenerator_ClonesAreIndependent(t *testing.T) {
 		"memory={}",
 		"storage={}",
 		"accounts={}",
-		"callcontext={}",
-		"blockcontext={}",
+		"callContext={}",
+		"callJournal={}",
+		"blockContext={}",
 	})
 }
 
@@ -360,16 +362,14 @@ func TestStateGenerator_CloneCanBeUsedToResetBuilder(t *testing.T) {
 
 	gen.SetGas(42)
 	gen.SetGasRefund(17)
-	want := "{pc=4,gas=42,gasRefund=17,code={},stack={},memory={},storage={},accounts={},callcontext={},blockcontext={}}"
-	if got := gen.String(); want != got {
-		t.Errorf("invalid clone, wanted %s, got %s", want, got)
+	if base, modified := backup.String(), gen.String(); base == modified {
+		t.Errorf("clones are not independent")
 	}
 
 	gen.Restore(backup)
 
-	want = "{pc=4,code={},stack={},memory={},storage={},accounts={},callcontext={},blockcontext={}}"
-	if got := gen.String(); want != got {
-		t.Errorf("invalid clone, wanted %s, got %s", want, got)
+	if want, got := backup.String(), gen.String(); want != got {
+		t.Errorf("restore did not work, wanted %s, got %s", want, got)
 	}
 }
 

--- a/go/ct/rlz/parameters.go
+++ b/go/ct/rlz/parameters.go
@@ -77,3 +77,26 @@ func (AddressParameter) Samples() []U256 {
 
 type DataOffsetParameter = MemoryOffsetParameter
 type DataSizeParameter = MemorySizeParameter
+
+type GasParameter struct{}
+
+func (GasParameter) Samples() []U256 {
+	return []U256{
+		NewU256(0),
+		NewU256(1),
+		NewU256(1 << 10),
+		NewU256(1 << 20),
+		NewU256(1 << 62),
+		MaxU256(),
+	}
+}
+
+type ValueParameter struct{}
+
+func (ValueParameter) Samples() []U256 {
+	return []U256{
+		NewU256(0),
+		NewU256(1),
+		MaxU256(),
+	}
+}

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -1347,6 +1347,139 @@ var Spec = func() Specification {
 		},
 	})...)
 
+	// --- CALL ---
+
+	// NOTE: this rule only covers the non-static Istanbul case in a coarse-grained
+	// way. Follow-work is required to cover other revisions and situations, as well
+	// as special cases currently covered in the effect function.
+	rules = append(rules, rulesFor(instruction{
+		op:        CALL,
+		name:      "_non_static_istanbul",
+		staticGas: 700,
+		pops:      7,
+		pushes:    1,
+		conditions: []Condition{
+			Eq(ReadOnly(), false),
+			IsRevision(R07_Istanbul),
+		},
+		parameters: []Parameter{
+			GasParameter{},
+			AddressParameter{},
+			ValueParameter{},
+			MemoryOffsetParameter{},
+			MemorySizeParameter{},
+			MemoryOffsetParameter{},
+			MemorySizeParameter{},
+		},
+		effect: func(s *st.State) {
+			gas := s.Stack.Pop()
+			target := s.Stack.Pop()
+			value := s.Stack.Pop()
+			argsOffset := s.Stack.Pop()
+			argsSize := s.Stack.Pop()
+			retOffset := s.Stack.Pop()
+			retSize := s.Stack.Pop()
+
+			// --- check preconditions ---
+
+			// No value transfer in a read-only context.
+			if s.ReadOnly && !value.IsZero() {
+				s.Status = st.Failed
+				return
+			}
+
+			// --- dynamic costs ---
+
+			// Compute the memory expansion costs of this call.
+			inputMemoryExpansionCost, argsOffset64, argsSize64 := s.Memory.ExpansionCosts(argsOffset, argsSize)
+			outputMemoryExpansionCost, retOffset64, retSize64 := s.Memory.ExpansionCosts(retOffset, retSize)
+			memoryExpansionCost := inputMemoryExpansionCost
+			if memoryExpansionCost < outputMemoryExpansionCost {
+				memoryExpansionCost = outputMemoryExpansionCost
+			}
+
+			// Compute the value transfer costs.
+			positiveValueCost := vm.Gas(0)
+			if !value.IsZero() {
+				positiveValueCost = 9000
+			}
+
+			// If an account is implicitly created, this costs extra.
+			valueToEmptyAccountCost := vm.Gas(0)
+			if !value.IsZero() && s.Accounts.IsEmpty(target.Bytes20be()) {
+				valueToEmptyAccountCost = 25000
+			}
+
+			// Deduct the gas costs for this call, except the costs for the recursive call.
+			dynamicGas, overflow := sumWithOverflow(memoryExpansionCost, positiveValueCost, valueToEmptyAccountCost)
+			if s.Gas < dynamicGas || overflow {
+				s.Status = st.Failed
+				return
+			}
+			s.Gas -= dynamicGas
+
+			// Grow the memory for which gas has just been deducted.
+			s.Memory.Grow(argsOffset64, argsSize64)
+			s.Memory.Grow(retOffset64, retSize64)
+
+			// Compute the gas provided to the nested call.
+			limit := s.Gas - s.Gas/64
+			endowment := limit
+			if gas.IsUint64() && gas.Uint64() < uint64(endowment) {
+				endowment = vm.Gas(gas.Uint64())
+			}
+
+			// If value is transferred, a stipend is granted.
+			stipend := vm.Gas(0)
+			if !value.IsZero() {
+				stipend = 2300
+			}
+			s.Gas += stipend
+
+			// Read the input from the call from memory.
+			input := s.Memory.Read(argsOffset64, argsSize64)
+
+			// --- call execution ---
+
+			// Check that the caller has enough balance to transfer the requested value.
+			if !value.IsZero() {
+				balance := s.Accounts.Balance[s.CallContext.AccountAddress]
+				if balance.Lt(value) {
+					s.Stack.Push(NewU256(0))
+					s.LastCallReturnData = nil
+					return
+				}
+			}
+
+			// Execute the call.
+			res := s.CallJournal.Call(vm.Call, vm.CallParameter{
+				Sender:    s.CallContext.AccountAddress,
+				Recipient: target.Bytes20be(),
+				Value:     value.Bytes32be(),
+				Gas:       endowment + stipend,
+				Input:     input,
+			})
+
+			// Process the result.
+			if retSize64 > 0 {
+				output := res.Output
+				if len(output) > int(retSize64) {
+					output = output[0:retSize64]
+				}
+				s.Memory.Write(output, retOffset64)
+			}
+
+			s.Gas -= endowment + stipend - res.GasLeft // < the costs for the code execution
+			s.GasRefund += res.GasRefund
+			s.LastCallReturnData = res.Output
+			if res.Success {
+				s.Stack.Push(NewU256(1))
+			} else {
+				s.Stack.Push(NewU256(0))
+			}
+		},
+	})...)
+
 	// --- End ---
 
 	return NewSpecification(rules...)
@@ -1788,4 +1921,16 @@ func rulesFor(i instruction) []Rule {
 		},
 	}...)
 	return res
+}
+
+func sumWithOverflow(values ...vm.Gas) (vm.Gas, bool) {
+	res := vm.Gas(0)
+	for _, cur := range values {
+		next := res + cur
+		if next < res {
+			return 0, true
+		}
+		res = next
+	}
+	return res, false
 }

--- a/go/ct/st/accounts.go
+++ b/go/ct/st/accounts.go
@@ -32,6 +32,13 @@ func (a *Accounts) GetCodeHash(address vm.Address) (hash [32]byte) {
 	return
 }
 
+func (a *Accounts) IsEmpty(address vm.Address) bool {
+	// By definition, an account is empty if it has an empty balance,
+	// a nonce that is 0, and an empty code. However, we do not model
+	// nonces in this state, so we only check the balance and code.
+	return a.Balance[address] == U256{} && len(a.Code[address]) == 0
+}
+
 func (a *Accounts) Clone() *Accounts {
 	return &Accounts{
 		Balance: maps.Clone(a.Balance),

--- a/go/ct/st/call_journal.go
+++ b/go/ct/st/call_journal.go
@@ -1,0 +1,171 @@
+package st
+
+import (
+	"fmt"
+	"slices"
+
+	. "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/vm"
+)
+
+// CallJournal is a part of the state modeling the effect of recursive
+// contract calls. It covers past calls to verify the proper execution
+// of calls as well as the effect of future calls to be triggered
+// by CREATE and CALL expressions.
+type CallJournal struct {
+	Past   []PastCall
+	Future []FutureCall
+}
+
+func NewCallJournal() *CallJournal {
+	return &CallJournal{}
+}
+
+func (j *CallJournal) Call(kind vm.CallKind, parameter vm.CallParameter) vm.Result {
+	// log the call as a past call.
+	j.Past = append(j.Past, PastCall{
+		Kind:      kind,
+		Recipient: parameter.Recipient,
+		Sender:    parameter.Sender,
+		Input:     NewBytes(parameter.Input),
+		Value:     parameter.Value,
+		Gas:       parameter.Gas,
+	})
+
+	// consume the next future result
+	var result FutureCall
+	if len(j.Future) > 0 {
+		result = j.Future[0]
+		j.Future = j.Future[1:]
+	}
+
+	gasLeft := parameter.Gas
+	if gasLeft < result.GasCosts {
+		gasLeft = 0
+	} else {
+		gasLeft -= result.GasCosts
+	}
+
+	return vm.Result{
+		Success:   result.Success,
+		Output:    result.Output.ToBytes(),
+		GasLeft:   gasLeft,
+		GasRefund: result.GasRefund,
+	}
+}
+
+func (j *CallJournal) Equal(other *CallJournal) bool {
+	if j == other {
+		return true
+	}
+	equalPast := slices.EqualFunc(j.Past, other.Past, func(a, b PastCall) bool {
+		return a.Equal(&b)
+	})
+	if !equalPast {
+		return false
+	}
+	return slices.EqualFunc(j.Future, other.Future, func(a, b FutureCall) bool {
+		return a.Equal(&b)
+	})
+}
+
+func (j *CallJournal) Diff(other *CallJournal) []string {
+	res := []string{}
+
+	if have, got := len(j.Past), len(other.Past); have != got {
+		res = append(res, fmt.Sprintf("different length of past calls, %d vs %d", have, got))
+	} else {
+		for i, call := range j.Past {
+			for _, diff := range call.Diff(&other.Past[i]) {
+				res = append(res, fmt.Sprintf("Past Call %d: %s", i, diff))
+			}
+		}
+	}
+
+	if have, got := len(j.Future), len(other.Future); have != got {
+		res = append(res, fmt.Sprintf("different length of future calls, %d vs %d", have, got))
+	} else {
+		for i, call := range j.Future {
+			for _, diff := range call.Diff(&other.Future[i]) {
+				res = append(res, fmt.Sprintf("Future Call %d: %s", i, diff))
+			}
+		}
+	}
+
+	return res
+}
+
+func (j *CallJournal) Clone() *CallJournal {
+	// PastCall and FutureCall objects can be shallow-cloned
+	// since their reference based fields are immutable.
+	return &CallJournal{
+		Past:   slices.Clone(j.Past),
+		Future: slices.Clone(j.Future),
+	}
+}
+
+// PastCall represents an already processed call. It is part of the state
+// model for two reasons to enable the verification of call parameters.
+type PastCall struct {
+	Kind      vm.CallKind
+	Recipient vm.Address
+	Sender    vm.Address
+	Input     Bytes
+	Value     vm.Value
+	Gas       vm.Gas
+}
+
+func (c *PastCall) Equal(other *PastCall) bool {
+	return c == other || *c == *other
+}
+
+func (c *PastCall) Diff(other *PastCall) []string {
+	var res []string
+	if have, got := c.Kind, other.Kind; have != got {
+		res = append(res, fmt.Sprintf("different call kind: %v vs %v", have, got))
+	}
+	if have, got := c.Recipient, other.Recipient; have != got {
+		res = append(res, fmt.Sprintf("different recipient: %v vs %v", have, got))
+	}
+	if have, got := c.Sender, other.Sender; have != got {
+		res = append(res, fmt.Sprintf("different sender: %v vs %v", have, got))
+	}
+	if have, got := c.Input, other.Input; have != got {
+		res = append(res, fmt.Sprintf("different input: %v vs %v", have, got))
+	}
+	if have, got := c.Value, other.Value; have != got {
+		res = append(res, fmt.Sprintf("different value: %v vs %v", have, got))
+	}
+	if have, got := c.Gas, other.Gas; have != got {
+		res = append(res, fmt.Sprintf("different gas: %v vs %v (diff: %d)", have, got, got-have))
+	}
+	return res
+}
+
+type FutureCall struct {
+	Success   bool
+	Output    Bytes
+	GasCosts  vm.Gas
+	GasRefund vm.Gas
+}
+
+func (c *FutureCall) Equal(other *FutureCall) bool {
+	return c == other || *c == *other
+}
+
+func (c *FutureCall) Diff(other *FutureCall) []string {
+	var res []string
+	if have, got := c.Success, other.Success; have != got {
+		res = append(res, fmt.Sprintf("different success: %t vs %t", have, got))
+	}
+	if have, got := c.Output, other.Output; have != got {
+		res = append(res, fmt.Sprintf("different output: %v vs %v", have, got))
+	}
+	if have, got := c.GasCosts, other.GasCosts; have != got {
+		res = append(res, fmt.Sprintf("different gas costs: %v vs %v", have, got))
+	}
+	if have, got := c.GasRefund, other.GasRefund; have != got {
+		res = append(res, fmt.Sprintf("different refund: %v vs %v", have, got))
+	}
+	return res
+}

--- a/go/ct/st/call_journal_test.go
+++ b/go/ct/st/call_journal_test.go
@@ -1,0 +1,246 @@
+package st
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/vm"
+)
+
+func TestCallJournal_CallMovesFutureToPastCall(t *testing.T) {
+	journal := NewCallJournal()
+
+	journal.Future = []FutureCall{{
+		Success:   true,
+		Output:    common.NewBytes([]byte{1, 2, 3}),
+		GasCosts:  5,
+		GasRefund: 2,
+	}}
+
+	res := journal.Call(vm.StaticCall, vm.CallParameter{
+		Sender:      vm.Address{1},
+		Recipient:   vm.Address{2},
+		Value:       vm.Value{3},
+		Input:       []byte{4, 5},
+		Gas:         6,
+		Salt:        vm.Hash{7},
+		CodeAddress: vm.Address{8},
+	})
+
+	if want, got := true, res.Success; want != got {
+		t.Errorf("unexpected success result, wanted %t, got %t", want, got)
+	}
+
+	if want, got := []byte{1, 2, 3}, res.Output; !bytes.Equal(want, got) {
+		t.Errorf("unexpected output, wanted %v, got %v", want, got)
+	}
+
+	if want, got := vm.Gas(1), res.GasLeft; want != got {
+		t.Errorf("unexpected remaining gas, wanted %d, got %d", want, got)
+	}
+
+	if want, got := vm.Gas(2), res.GasRefund; want != got {
+		t.Errorf("unexpected refund gas, wanted %d, got %d", want, got)
+	}
+
+	if len(journal.Past) != 1 {
+		t.Fatalf("no past call was recorded")
+	}
+	want := PastCall{
+		Kind:      vm.StaticCall,
+		Recipient: vm.Address{2},
+		Sender:    vm.Address{1},
+		Input:     common.NewBytes([]byte{4, 5}),
+		Value:     vm.Value{3},
+		Gas:       vm.Gas(6),
+	}
+
+	if got := journal.Past[0]; !want.Equal(&got) {
+		t.Errorf(
+			"failed to record past call, wanted %v, got %v, diff %v",
+			want, got, want.Diff(&got),
+		)
+	}
+}
+
+func TestCallJournal_EqualDetectsDifferences(t *testing.T) {
+	tests := map[string]struct {
+		modify func(c *CallJournal)
+	}{
+		"added_past":      {func(c *CallJournal) { c.Past = append(c.Past, PastCall{}) }},
+		"removed_past":    {func(c *CallJournal) { c.Past = c.Past[0 : len(c.Past)-1] }},
+		"modified_past":   {func(c *CallJournal) { c.Past[0].Gas++ }},
+		"added_future":    {func(c *CallJournal) { c.Future = append(c.Future, FutureCall{}) }},
+		"removed_future":  {func(c *CallJournal) { c.Future = c.Future[0 : len(c.Future)-1] }},
+		"modified_future": {func(c *CallJournal) { c.Future[0].GasCosts++ }},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			j1 := NewCallJournal()
+			j1.Past = []PastCall{{}}
+			j1.Future = []FutureCall{{}}
+			j2 := j1.Clone()
+			test.modify(j2)
+			if j1.Equal(j2) {
+				t.Errorf("failed to detect difference between %v and %v", j1, j2)
+			}
+		})
+	}
+}
+
+func TestCallJournal_DiffDetectsDifferences(t *testing.T) {
+	tests := map[string]struct {
+		modify func(c *CallJournal)
+		issue  string
+	}{
+		"added_past": {
+			func(c *CallJournal) { c.Past = append(c.Past, PastCall{}) },
+			"different length of past calls",
+		},
+		"removed_past": {
+			func(c *CallJournal) { c.Past = c.Past[0 : len(c.Past)-1] },
+			"different length of past calls",
+		},
+		"modified_past": {
+			func(c *CallJournal) { c.Past[0].Gas++ },
+			"Past Call 0: different gas",
+		},
+		"added_future": {
+			func(c *CallJournal) { c.Future = append(c.Future, FutureCall{}) },
+			"different length of future calls",
+		},
+		"removed_future": {
+			func(c *CallJournal) { c.Future = c.Future[0 : len(c.Future)-1] },
+			"different length of future calls",
+		},
+		"modified_future": {
+			func(c *CallJournal) { c.Future[0].GasCosts++ },
+			"Future Call 0: different gas costs",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			j1 := NewCallJournal()
+			j1.Past = []PastCall{{}}
+			j1.Future = []FutureCall{{}}
+			j2 := j1.Clone()
+			test.modify(j2)
+
+			diffs := j1.Diff(j2)
+			if len(diffs) != 1 {
+				t.Errorf("failed to detect difference, got %v", diffs)
+			}
+
+			diff := diffs[0]
+			if !strings.Contains(diff, test.issue) {
+				t.Errorf("invalid diff reported, expected a string with %s, got %s", test.issue, diff)
+			}
+		})
+	}
+}
+
+func TestPastCall_EqualDetectsDifferences(t *testing.T) {
+	tests := map[string]struct {
+		modify func(c *PastCall)
+	}{
+		"kind":      {func(c *PastCall) { c.Kind = vm.DelegateCall }},
+		"recipient": {func(c *PastCall) { c.Recipient[0]++ }},
+		"sender":    {func(c *PastCall) { c.Sender[0]++ }},
+		"input":     {func(c *PastCall) { c.Input = common.NewBytes([]byte{1, 2, 3}) }},
+		"value":     {func(c *PastCall) { c.Value[0]++ }},
+		"gas":       {func(c *PastCall) { c.Gas++ }},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			c1 := PastCall{}
+			c2 := c1
+			test.modify(&c2)
+			if c1.Equal(&c2) {
+				t.Errorf("failed to detect difference between %v and %v", c1, c2)
+			}
+		})
+	}
+}
+
+func TestPastCall_DiffDetectsDifferences(t *testing.T) {
+	tests := map[string]struct {
+		modify func(c *PastCall)
+	}{
+		"kind":      {func(c *PastCall) { c.Kind = vm.DelegateCall }},
+		"recipient": {func(c *PastCall) { c.Recipient[0]++ }},
+		"sender":    {func(c *PastCall) { c.Sender[0]++ }},
+		"input":     {func(c *PastCall) { c.Input = common.NewBytes([]byte{1, 2, 3}) }},
+		"value":     {func(c *PastCall) { c.Value[0]++ }},
+		"gas":       {func(c *PastCall) { c.Gas++ }},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			c1 := PastCall{}
+			c2 := c1
+			test.modify(&c2)
+			diffs := c1.Diff(&c2)
+			if want, got := 1, len(diffs); want != got {
+				t.Fatalf("unexpected number of differences, wanted %d, got %d", want, got)
+			}
+			diff := diffs[0]
+			if !strings.Contains(diff, name) {
+				t.Errorf("unexpected diff, wanted string containing %s, got %s", name, diff)
+			}
+		})
+	}
+}
+
+func TestFutureCall_EqualDetectsDifferences(t *testing.T) {
+	tests := map[string]struct {
+		modify func(c *FutureCall)
+	}{
+		"success":   {func(c *FutureCall) { c.Success = true }},
+		"gas costs": {func(c *FutureCall) { c.GasCosts++ }},
+		"refund":    {func(c *FutureCall) { c.GasRefund++ }},
+		"output":    {func(c *FutureCall) { c.Output = common.NewBytes([]byte{1, 2, 3}) }},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			c1 := FutureCall{}
+			c2 := c1
+			test.modify(&c2)
+			if c1.Equal(&c2) {
+				t.Errorf("failed to detect difference between %v and %v", c1, c2)
+			}
+		})
+	}
+}
+
+func TestFutureCall_DiffDetectsDifferences(t *testing.T) {
+	tests := map[string]struct {
+		modify func(c *FutureCall)
+	}{
+		"success":   {func(c *FutureCall) { c.Success = true }},
+		"gas costs": {func(c *FutureCall) { c.GasCosts++ }},
+		"refund":    {func(c *FutureCall) { c.GasRefund++ }},
+		"output":    {func(c *FutureCall) { c.Output = common.NewBytes([]byte{1, 2, 3}) }},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			c1 := FutureCall{}
+			c2 := c1
+			test.modify(&c2)
+			diffs := c1.Diff(&c2)
+			if want, got := 1, len(diffs); want != got {
+				t.Fatalf("unexpected number of differences, wanted %d, got %d", want, got)
+			}
+			diff := diffs[0]
+			if !strings.Contains(diff, name) {
+				t.Errorf("unexpected diff, wanted string containing %s, got %s", name, diff)
+			}
+		})
+	}
+}

--- a/go/ct/st/serialization.go
+++ b/go/ct/st/serialization.go
@@ -65,6 +65,7 @@ type stateSerializable struct {
 	CallData           byteSliceSerializable
 	LastCallReturnData byteSliceSerializable
 	ReturnData         byteSliceSerializable
+	CallJournal        *CallJournal
 }
 
 // byteSliceSerializable is a wrapper to achieve hex code output
@@ -130,6 +131,7 @@ func newStateSerializableFromState(state *State) *stateSerializable {
 		CallData:           bytes.Clone(state.CallData),
 		LastCallReturnData: bytes.Clone(state.LastCallReturnData),
 		ReturnData:         bytes.Clone(state.ReturnData),
+		CallJournal:        state.CallJournal,
 	}
 }
 
@@ -189,6 +191,9 @@ func (s *stateSerializable) deserialize() *State {
 	state.CallData = bytes.Clone(s.CallData)
 	state.LastCallReturnData = bytes.Clone(s.LastCallReturnData)
 	state.ReturnData = bytes.Clone(s.ReturnData)
+	if s.CallJournal != nil {
+		state.CallJournal = s.CallJournal.Clone()
+	}
 	return state
 }
 

--- a/go/ct/st/state_test.go
+++ b/go/ct/st/state_test.go
@@ -721,6 +721,10 @@ func TestState_EqualityConsidersRelevantFieldsDependingOnStatus(t *testing.T) {
 			modify:      func(s *State) { s.CallData = []byte{1, 2, 3} },
 			relevantFor: allButFailed,
 		},
+		"call_journal": {
+			modify:      func(s *State) { s.CallJournal.Future = []FutureCall{{Success: false}} },
+			relevantFor: allButFailed,
+		},
 		"last_call_return_data": {
 			modify:      func(s *State) { s.LastCallReturnData = []byte{1, 2, 3} },
 			relevantFor: onlyRunning,

--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -124,7 +124,13 @@ func (c *ctRunContext) EmitLog(addr vm.Address, topics []vm.Hash, data []byte) {
 }
 
 func (c *ctRunContext) Call(kind vm.CallKind, parameter vm.CallParameter) (vm.CallResult, error) {
-	panic("not implemented")
+	res := c.state.CallJournal.Call(kind, parameter)
+	return vm.CallResult{
+		Success:   res.Success,
+		Output:    res.Output,
+		GasLeft:   res.GasLeft,
+		GasRefund: res.GasRefund,
+	}, nil
 }
 
 func (c *ctRunContext) SelfDestruct(addr vm.Address, beneficiary vm.Address) bool {

--- a/go/vm/lfvm/ct.go
+++ b/go/vm/lfvm/ct.go
@@ -107,6 +107,8 @@ func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 	state.Stack = convertLfvmStackToCtStack(ctxt.stack)
 	state.Memory = convertLfvmMemoryToCtMemory(ctxt.memory)
 	state.ReturnData = result
+	state.LastCallReturnData = ctxt.return_data
+
 	return state, nil
 }
 


### PR DESCRIPTION
Adds a first, rough, specification rule for a CALL instruction to Tosca's Conformance Tests.

The majority of the PR is about the addition of a `CallJournal` to the CT `State` enabling the tracking of recursive calls. The one rule defined based on it, for CALL instructions for the revision `Berlin` in a non-static setup, managed to reveal 2 issues in the LFVM implementation (see #352 and #353) as well as two issues in the evmzero code (see #354 and #355). These fixes should be merged before this PR to avoid the CT testing to fail during nightly tests.