### PR TITLE
Add support for automatic export if issues to JSON files 

### DIFF
--- a/go/ct/driver/regressions.go
+++ b/go/ct/driver/regressions.go
@@ -113,11 +113,7 @@ func doRegressionTests(context *cli.Context) error {
 			}
 
 			if !result.Eq(expected) {
-				errMsg := fmt.Sprintln(result.Diff(expected))
-				errMsg += fmt.Sprintln("input state:", input)
-				errMsg += fmt.Sprintln("result state:", result)
-				errMsg += fmt.Sprintln("expected state:", expected)
-				fmt.Printf("Failed to evaluate rule %v: %v\n", rule, errMsg)
+				fmt.Printf("Failed to evaluate rule %v: %v\n", rule, formatDiffForUser(input, result, expected, rule.Name))
 				continue
 			}
 


### PR DESCRIPTION
This PR updates the CT driver to automatically export identified issues into JSON files suitable to be utilized by the regression tool. The path to each exported issue is printed together with the error information to the console.

The PR also unifies the error representation of the `run` and `regression` sub-command.