### PR TITLE
Make basic VM types serializable

### DIFF
--- a/go/ct/common/address.go
+++ b/go/ct/common/address.go
@@ -1,71 +1,27 @@
 package common
 
 import (
-	"fmt"
-	"regexp"
-	"strconv"
-
+	"github.com/Fantom-foundation/Tosca/go/vm"
 	"pgregory.net/rand"
 )
 
-type Address [20]byte
-
-// Diff returns a list of differences between the two addresses.
-func (a *Address) Diff(b Address) (res []string) {
-	if *a != b {
-		res = append(res, fmt.Sprintf("Different address, want %v, got %v", a, b))
-	}
-	return
-}
-
-func NewAddress(in U256) Address {
+func NewAddress(in U256) vm.Address {
 	return in.internal.Bytes20()
 }
 
-func NewAddressFromInt(in uint64) Address {
+func NewAddressFromInt(in uint64) vm.Address {
 	return NewAddress(NewU256(in))
 }
 
-func (a *Address) ToU256() U256 {
+func AddressToU256(a vm.Address) U256 {
 	return NewU256FromBytes(a[:]...)
 }
 
-func RandAddress(rnd *rand.Rand) (Address, error) {
-	address := Address{}
+func RandAddress(rnd *rand.Rand) (vm.Address, error) {
+	address := vm.Address{}
 	_, err := rnd.Read(address[:])
 	if err != nil {
-		return Address{}, err
+		return vm.Address{}, err
 	}
 	return address, nil
-}
-
-func (a *Address) Clone() Address {
-	return *a
-}
-
-func (a Address) String() string {
-	return fmt.Sprintf("0x%x", ([20]byte)(a))
-}
-
-func (a Address) MarshalText() ([]byte, error) {
-	return []byte(a.String()), nil
-}
-
-func (a *Address) UnmarshalText(text []byte) error {
-	r := regexp.MustCompile("^0x([[:xdigit:]]{40})$")
-	match := r.FindSubmatch(text)
-
-	if len(match) != 2 {
-		return fmt.Errorf("invalid address: %s", text)
-	}
-
-	for i := 0; i < 20; i++ {
-		b := match[1][i*2 : i*2+2]
-		parsed, err := strconv.ParseUint(string(b), 16, 8)
-		if err != nil {
-			return err
-		}
-		a[i] = byte(parsed)
-	}
-	return nil
 }

--- a/go/ct/common/address_test.go
+++ b/go/ct/common/address_test.go
@@ -1,20 +1,11 @@
 package common
 
 import (
-	"bytes"
-	"strings"
 	"testing"
 
+	"github.com/Fantom-foundation/Tosca/go/vm"
 	"pgregory.net/rand"
 )
-
-func TestAddress_NewAddress(t *testing.T) {
-	address := Address{}
-
-	if address != [20]byte{} {
-		t.Errorf("New address must be default value.")
-	}
-}
 
 func TestAddress_NewAddressFrom(t *testing.T) {
 	addressU256 := NewAddress(NewU256(42))
@@ -37,40 +28,13 @@ func TestAddress_ToU256(t *testing.T) {
 	want := NewU256(42)
 	address := NewAddress(want)
 
-	if got := address.ToU256(); want != got {
+	if got := AddressToU256(address); want != got {
 		t.Errorf("Conversion from U256 is broken: got %v, want %v", got, want)
 	}
 }
 
-func TestAddress_Eq(t *testing.T) {
-	address1 := Address{}
-	address2 := Address{0xff}
-
-	if address1 != address1 {
-		t.Error("Self-comparison is broken")
-	}
-
-	if address1 == address2 {
-		t.Errorf("Different addresses are not recognized as such")
-	}
-}
-
-func TestAddress_Diff(t *testing.T) {
-	address1 := Address{}
-	address2 := Address{0xff}
-	str := address1.Diff(address2)
-
-	if len(str) != 1 {
-		t.Errorf("Wrong amount of differences found.")
-	}
-
-	if !strings.Contains(str[0], "Different address") {
-		t.Errorf("Difference reported at wrong position.")
-	}
-}
-
 func TestAddress_RandAddress(t *testing.T) {
-	address1 := Address{}
+	address1 := vm.Address{}
 	rnd := rand.New(0)
 	address2, err := RandAddress(rnd)
 
@@ -80,127 +44,5 @@ func TestAddress_RandAddress(t *testing.T) {
 
 	if address1 == address2 {
 		t.Errorf("Random Address is same as default value")
-	}
-}
-
-func TestAddress_Clone(t *testing.T) {
-	address1 := Address{}
-	address2 := address1.Clone()
-
-	if address1 != address2 {
-		t.Error("Clones are not equal")
-	}
-
-	address2[0] = 0xff
-	if address1 == address2 {
-		t.Errorf("Clones are not independent")
-	}
-}
-
-func TestAddress_String(t *testing.T) {
-	address1 := Address{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13}
-	str := address1.String()
-	if str != "0x000102030405060708090a0b0c0d0e0f10111213" {
-		t.Errorf("Invalid address string.")
-	}
-
-}
-
-func TestAddress_Marshalling(t *testing.T) {
-	tests := []struct {
-		address    Address
-		marshalled []byte
-	}{
-		{Address{}, []byte("0x0000000000000000000000000000000000000000")},
-		{Address{0x00}, []byte("0x0000000000000000000000000000000000000000")},
-		{Address{0x01}, []byte("0x0100000000000000000000000000000000000000")},
-		{Address{0x02}, []byte("0x0200000000000000000000000000000000000000")},
-		{Address{0x01, 0x02}, []byte("0x0102000000000000000000000000000000000000")},
-		{Address{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13}, []byte("0x000102030405060708090a0b0c0d0e0f10111213")},
-	}
-
-	for _, test := range tests {
-		marshalled, err := test.address.MarshalText()
-		if err != nil {
-			t.Fatalf("Unexpected error when marshalling address: %v", err)
-		}
-		if !bytes.Equal(marshalled, test.marshalled) {
-			t.Errorf("Unexpected marshalled value: want %v, got %v", test.marshalled, marshalled)
-		}
-	}
-}
-
-func TestAddress_Unmarshalling(t *testing.T) {
-	tests := []struct {
-		marshalled []byte
-		want       Address
-	}{
-		{[]byte("0x0000000000000000000000000000000000000000"), Address{}},
-		{[]byte("0x0000000000000000000000000000000000000000"), Address{0x00}},
-		{[]byte("0x0100000000000000000000000000000000000000"), Address{0x01}},
-		{[]byte("0x0200000000000000000000000000000000000000"), Address{0x02}},
-		{[]byte("0x0102000000000000000000000000000000000000"), Address{0x01, 0x02}},
-		{[]byte("0x000102030405060708090a0b0c0d0e0f10111213"), Address{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13}},
-	}
-
-	for _, test := range tests {
-		var a Address
-		err := a.UnmarshalText(test.marshalled)
-		if err != nil {
-			t.Fatalf("Unexpected error when unmarshalling address: %v", err)
-		}
-		if a != test.want {
-			t.Errorf("Unexpected unmarshalled value: want %v, got %v", test.want, a)
-		}
-	}
-}
-
-func TestAddress_UnmarshallingError(t *testing.T) {
-	testCases := map[string][]byte{
-		"empty":                 []byte(""),
-		"empty with hex prefix": []byte("0x"),
-		"no hex prefix":         []byte("0000000000000000000000000000000000000000"),
-		"too short":             []byte("0x00000000000000000000000000000000000000"),
-		"too long":              []byte("0x000000000000000000000000000000000000000000"),
-		"invalid hex":           []byte("0x0g00000000000000000000000000000000000000"),
-	}
-
-	for name, input := range testCases {
-		t.Run(name, func(t *testing.T) {
-			var a Address
-			err := a.UnmarshalText(input)
-			if err == nil {
-				t.Fatalf("Expected error when unmarshalling input with: %s", name)
-			}
-		})
-	}
-}
-
-func TestAddress_MarshallingRoundTrip(t *testing.T) {
-	tests := []struct {
-		address Address
-	}{
-		{Address{}},
-		{Address{0x00}},
-		{Address{0x01}},
-		{Address{0x02}},
-		{Address{0x01, 0x02}},
-		{Address{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13}},
-	}
-
-	for _, test := range tests {
-		marshalled, err := test.address.MarshalText()
-		if err != nil {
-			t.Fatalf("Unexpected error when marshalling address: %v", err)
-		}
-
-		var a Address
-		err = a.UnmarshalText(marshalled)
-		if err != nil {
-			t.Fatalf("Unexpected error when unmarshalling address: %v", err)
-		}
-		if a != test.address {
-			t.Errorf("Unexpected unmarshalled value: want %v, got %v", test.address, a)
-		}
 	}
 }

--- a/go/ct/gen/accounts.go
+++ b/go/ct/gen/accounts.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 	"pgregory.net/rand"
 )
 
@@ -71,7 +72,7 @@ func randCode(rnd *rand.Rand) []byte {
 	return code
 }
 
-func (g *AccountsGenerator) Generate(assignment Assignment, rnd *rand.Rand, accountAddress Address) (*st.Accounts, error) {
+func (g *AccountsGenerator) Generate(assignment Assignment, rnd *rand.Rand, accountAddress vm.Address) (*st.Accounts, error) {
 	// Check for conflicts among warm/cold constraints.
 	sort.Slice(g.warmCold, func(i, j int) bool { return g.warmCold[i].Less(&g.warmCold[j]) })
 	for i := 0; i < len(g.warmCold)-1; i++ {
@@ -83,14 +84,14 @@ func (g *AccountsGenerator) Generate(assignment Assignment, rnd *rand.Rand, acco
 
 	// When handling unbound variables, we need to generate an unused address for
 	// them. We therefore track which addresses have already been used.
-	addressesInUse := map[Address]bool{}
+	addressesInUse := map[vm.Address]bool{}
 	addressesInUse[accountAddress] = true
 	for _, con := range g.warmCold {
 		if pos, isBound := assignment[con.key]; isBound {
 			addressesInUse[NewAddress(pos)] = true
 		}
 	}
-	getUnusedAddress := func() Address {
+	getUnusedAddress := func() vm.Address {
 		for {
 			address, _ := RandAddress(rnd)
 
@@ -101,12 +102,12 @@ func (g *AccountsGenerator) Generate(assignment Assignment, rnd *rand.Rand, acco
 		}
 	}
 
-	getAddress := func(v Variable) Address {
+	getAddress := func(v Variable) vm.Address {
 		key, isBound := assignment[v]
 		address := NewAddress(key)
 		if !isBound {
 			address = getUnusedAddress()
-			assignment[v] = address.ToU256()
+			assignment[v] = AddressToU256(address)
 		}
 
 		return address

--- a/go/ct/gen/block_context_test.go
+++ b/go/ct/gen/block_context_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 	"pgregory.net/rand"
 )
 
@@ -24,7 +25,7 @@ func TestBlockContextGen_Generate(t *testing.T) {
 	if blockCtx.ChainID == (common.NewU256()) {
 		t.Errorf("Generated chainid has default value.")
 	}
-	if blockCtx.CoinBase == (common.Address{}) {
+	if blockCtx.CoinBase == (vm.Address{}) {
 		t.Errorf("Generated coinbase has default value.")
 	}
 	if blockCtx.GasLimit == (uint64(0)) {

--- a/go/ct/gen/call_context.go
+++ b/go/ct/gen/call_context.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 )
 
 type CallContextGenerator struct {
@@ -14,7 +15,7 @@ func NewCallContextGenerator() *CallContextGenerator {
 	return &CallContextGenerator{}
 }
 
-func (*CallContextGenerator) Generate(rnd *rand.Rand, accountAddress common.Address) (st.CallContext, error) {
+func (*CallContextGenerator) Generate(rnd *rand.Rand, accountAddress vm.Address) (st.CallContext, error) {
 	originAddress, err := common.RandAddress(rnd)
 	if err != nil {
 		return st.CallContext{}, err

--- a/go/ct/gen/call_context_test.go
+++ b/go/ct/gen/call_context_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 	"pgregory.net/rand"
 )
 
@@ -19,13 +20,13 @@ func TestCallContextGen_Generate(t *testing.T) {
 		t.Errorf("Error generating call context: %v", err)
 	}
 
-	if callCtx.AccountAddress == (common.Address{}) {
+	if callCtx.AccountAddress == (vm.Address{}) {
 		t.Errorf("Generated account address has default value.")
 	}
-	if callCtx.OriginAddress == (common.Address{}) {
+	if callCtx.OriginAddress == (vm.Address{}) {
 		t.Errorf("Generated origin address has default value.")
 	}
-	if callCtx.CallerAddress == (common.Address{}) {
+	if callCtx.CallerAddress == (vm.Address{}) {
 		t.Errorf("Generated caller address has default value.")
 	}
 	if callCtx.Value.Eq(common.NewU256(0)) {

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -264,28 +264,28 @@ func (stackSizeDomain) SamplesForAll(as []int) []int {
 
 type addressDomain struct{}
 
-func (addressDomain) Equal(a, b Address) bool {
+func (addressDomain) Equal(a, b vm.Address) bool {
 	return a == b
 }
 
-func (addressDomain) Less(Address, Address) bool  { panic("not implemented") }
-func (addressDomain) Predecessor(Address) Address { panic("not implemented") }
-func (addressDomain) Successor(Address) Address   { panic("not implemented") }
+func (addressDomain) Less(vm.Address, vm.Address) bool  { panic("not implemented") }
+func (addressDomain) Predecessor(vm.Address) vm.Address { panic("not implemented") }
+func (addressDomain) Successor(vm.Address) vm.Address   { panic("not implemented") }
 
-func (addressDomain) SomethingNotEqual(a Address) Address {
-	return Address{a[0] + 1}
+func (addressDomain) SomethingNotEqual(a vm.Address) vm.Address {
+	return vm.Address{a[0] + 1}
 }
 
-func (ad addressDomain) Samples(a Address) []Address {
-	return ad.SamplesForAll([]Address{a})
+func (ad addressDomain) Samples(a vm.Address) []vm.Address {
+	return ad.SamplesForAll([]vm.Address{a})
 }
 
-func (addressDomain) SamplesForAll(as []Address) []Address {
-	ret := []Address{}
+func (addressDomain) SamplesForAll(as []vm.Address) []vm.Address {
+	ret := []vm.Address{}
 	ret = append(ret, as...)
 
-	zero := Address{}
-	ffs := Address{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	zero := vm.Address{}
+	ffs := vm.Address{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 
 	ret = append(ret, zero)
 	ret = append(ret, ffs)

--- a/go/ct/st/accounts.go
+++ b/go/ct/st/accounts.go
@@ -6,25 +6,26 @@ import (
 	"reflect"
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 	"golang.org/x/crypto/sha3"
 	"golang.org/x/exp/maps"
 )
 
 type Accounts struct {
-	Balance map[Address]U256
-	Code    map[Address][]byte
-	warm    map[Address]struct{}
+	Balance map[vm.Address]U256
+	Code    map[vm.Address][]byte
+	warm    map[vm.Address]struct{}
 }
 
 func NewAccounts() *Accounts {
 	return &Accounts{
-		Balance: make(map[Address]U256),
-		Code:    make(map[Address][]byte),
-		warm:    make(map[Address]struct{}),
+		Balance: make(map[vm.Address]U256),
+		Code:    make(map[vm.Address][]byte),
+		warm:    make(map[vm.Address]struct{}),
 	}
 }
 
-func (a *Accounts) GetCodeHash(address Address) (hash [32]byte) {
+func (a *Accounts) GetCodeHash(address vm.Address) (hash [32]byte) {
 	hasher := sha3.NewLegacyKeccak256()
 	hasher.Write(a.Code[address])
 	hasher.Sum(hash[:])
@@ -88,25 +89,25 @@ func (a *Accounts) Diff(b *Accounts) (res []string) {
 	return
 }
 
-func (a *Accounts) IsWarm(key Address) bool {
+func (a *Accounts) IsWarm(key vm.Address) bool {
 	_, contains := a.warm[key]
 	return contains
 }
 
-func (a *Accounts) IsCold(key Address) bool {
+func (a *Accounts) IsCold(key vm.Address) bool {
 	_, contains := a.warm[key]
 	return !contains
 }
 
-func (a *Accounts) MarkWarm(key Address) {
+func (a *Accounts) MarkWarm(key vm.Address) {
 	a.warm[key] = struct{}{}
 }
 
-func (a *Accounts) MarkCold(key Address) {
+func (a *Accounts) MarkCold(key vm.Address) {
 	delete(a.warm, key)
 }
 
-func (a *Accounts) SetWarm(key Address, warm bool) {
+func (a *Accounts) SetWarm(key vm.Address, warm bool) {
 	if warm {
 		a.MarkWarm(key)
 	} else {

--- a/go/ct/st/accounts_test.go
+++ b/go/ct/st/accounts_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 )
 
 func TestAccounts_MarkWarmMarksAddressesAsWarm(t *testing.T) {
@@ -71,7 +72,7 @@ func TestAccounts_Clone(t *testing.T) {
 
 func TestAccounts_AccountsWithZeroBalanceAreTreatedTheSameByEqAndDiff(t *testing.T) {
 	a1 := NewAccounts()
-	a1.Balance[Address{1}] = NewU256(0)
+	a1.Balance[vm.Address{1}] = NewU256(0)
 	a2 := NewAccounts()
 
 	equal := a1.Eq(a2)

--- a/go/ct/st/block_context.go
+++ b/go/ct/st/block_context.go
@@ -4,18 +4,19 @@ import (
 	"fmt"
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 )
 
 // BlockContext holds the block environment information
 type BlockContext struct {
-	BaseFee     U256    // Base fee in wei
-	BlockNumber uint64  // Block's number
-	ChainID     U256    // Chain id of the network
-	CoinBase    Address // Address of the block's beneficiary
-	GasLimit    uint64  // Block's gas limit
-	GasPrice    U256    // Price of gas in current environment
-	Difficulty  U256    // Current block's difficulty
-	TimeStamp   uint64  // Block's timestamp in unix time in seconds
+	BaseFee     U256       // Base fee in wei
+	BlockNumber uint64     // Block's number
+	ChainID     U256       // Chain id of the network
+	CoinBase    vm.Address // Address of the block's beneficiary
+	GasLimit    uint64     // Block's gas limit
+	GasPrice    U256       // Price of gas in current environment
+	Difficulty  U256       // Current block's difficulty
+	TimeStamp   uint64     // Block's timestamp in unix time in seconds
 }
 
 // Diff returns a list of differences between the two contexts

--- a/go/ct/st/call_context.go
+++ b/go/ct/st/call_context.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 )
 
 // CallContext holds all data needed for the call-group of instructions
 type CallContext struct {
-	AccountAddress Address // Address of currently executing account
-	OriginAddress  Address // Address of execution origination
-	CallerAddress  Address // Address of the caller
-	Value          U256    // Deposited value by the instruction/transaction responsible for this execution
+	AccountAddress vm.Address // Address of currently executing account
+	OriginAddress  vm.Address // Address of execution origination
+	CallerAddress  vm.Address // Address of the caller
+	Value          U256       // Deposited value by the instruction/transaction responsible for this execution
 }
 
 // Diff returns a list of differences between the two call contexts.

--- a/go/ct/st/serialization.go
+++ b/go/ct/st/serialization.go
@@ -5,12 +5,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"slices"
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/vm"
-	"golang.org/x/exp/maps"
 )
 
 ////////////////////////////////////////////////////////////
@@ -79,9 +79,9 @@ type storageSerializable struct {
 
 // accountsSerializable is a serializable representation of the Accounts struct.
 type accountsSerializable struct {
-	Balance map[Address]U256
-	Code    map[Address]byteSliceSerializable
-	Warm    map[Address]bool
+	Balance map[vm.Address]U256
+	Code    map[vm.Address]byteSliceSerializable
+	Warm    map[vm.Address]bool
 }
 
 // logsSerializable is a serializable representation of the Log.
@@ -169,7 +169,7 @@ func (s *stateSerializable) deserialize() *State {
 	if s.Accounts != nil {
 		state.Accounts.Balance = maps.Clone(s.Accounts.Balance)
 
-		state.Accounts.Code = make(map[Address][]byte)
+		state.Accounts.Code = make(map[vm.Address][]byte)
 		for address, code := range s.Accounts.Code {
 			state.Accounts.Code[address] = code
 		}
@@ -203,12 +203,12 @@ func newStorageSerializable(storage *Storage) *storageSerializable {
 
 // newAccountsSerializable creates a new balanceSerializable instance from the given Balance instance.
 func newAccountsSerializable(accounts *Accounts) *accountsSerializable {
-	warm := make(map[Address]bool)
+	warm := make(map[vm.Address]bool)
 	for key := range accounts.warm {
 		warm[key] = true
 	}
 
-	codes := make(map[Address]byteSliceSerializable)
+	codes := make(map[vm.Address]byteSliceSerializable)
 	for address, code := range accounts.Code {
 		codes[address] = code
 	}

--- a/go/ct/st/serialization_test.go
+++ b/go/ct/st/serialization_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 )
 
 ////////////////////////////////////////////////////////////
@@ -26,11 +27,11 @@ func getNewFilledState() *State {
 	s.Storage.Original[NewU256(77)] = NewU256(4)
 	s.Storage.MarkWarm(NewU256(9))
 	s.Accounts = NewAccounts()
-	s.Accounts.Balance[Address{0x01}] = NewU256(42)
-	s.Accounts.Code[Address{0x01}] = []byte{byte(PUSH1), byte(6)}
-	s.Accounts.MarkWarm(Address{0x02})
+	s.Accounts.Balance[vm.Address{0x01}] = NewU256(42)
+	s.Accounts.Code[vm.Address{0x01}] = []byte{byte(PUSH1), byte(6)}
+	s.Accounts.MarkWarm(vm.Address{0x02})
 	s.Logs.AddLog([]byte{4, 5, 6}, NewU256(21), NewU256(22))
-	s.CallContext = CallContext{AccountAddress: Address{0x01}}
+	s.CallContext = CallContext{AccountAddress: vm.Address{0x01}}
 	s.BlockContext = BlockContext{BlockNumber: 1}
 	s.CallData = []byte{1}
 	s.LastCallReturnData = []byte{1}
@@ -171,12 +172,12 @@ func TestSerialization_NewStateSerializableIsIndependent(t *testing.T) {
 	serializableState.Storage.Current[NewU256(42)] = NewU256(4)
 	serializableState.Storage.Original[NewU256(77)] = NewU256(7)
 	serializableState.Storage.Warm[NewU256(9)] = false
-	serializableState.Accounts.Balance[Address{0x01}] = NewU256(77)
-	serializableState.Accounts.Code[Address{0x01}] = []byte{byte(INVALID)}
-	delete(serializableState.Accounts.Warm, Address{0x02})
+	serializableState.Accounts.Balance[vm.Address{0x01}] = NewU256(77)
+	serializableState.Accounts.Code[vm.Address{0x01}] = []byte{byte(INVALID)}
+	delete(serializableState.Accounts.Warm, vm.Address{0x02})
 	serializableState.Logs.Entries[0].Data[0] = 99
 	serializableState.Logs.Entries[0].Topics[0] = NewU256(42)
-	serializableState.CallContext.AccountAddress = Address{0x02}
+	serializableState.CallContext.AccountAddress = vm.Address{0x02}
 	serializableState.BlockContext.BlockNumber = 42
 	serializableState.CallData = []byte{4}
 	serializableState.LastCallReturnData = []byte{6}
@@ -197,12 +198,12 @@ func TestSerialization_NewStateSerializableIsIndependent(t *testing.T) {
 		s.Storage.Current[NewU256(7)].IsZero() &&
 		s.Storage.Original[NewU256(77)].Eq(NewU256(4)) &&
 		s.Storage.IsWarm(NewU256(9)) &&
-		s.Accounts.Balance[Address{0x01}].Eq(NewU256(42)) &&
-		bytes.Equal(s.Accounts.Code[Address{0x01}], []byte{byte(PUSH1), byte(6)}) &&
-		s.Accounts.IsWarm(Address{0x02}) &&
+		s.Accounts.Balance[vm.Address{0x01}].Eq(NewU256(42)) &&
+		bytes.Equal(s.Accounts.Code[vm.Address{0x01}], []byte{byte(PUSH1), byte(6)}) &&
+		s.Accounts.IsWarm(vm.Address{0x02}) &&
 		s.Logs.Entries[0].Data[0] == 4 &&
 		s.Logs.Entries[0].Topics[0] == NewU256(21) &&
-		s.CallContext.AccountAddress == Address{0x01} &&
+		s.CallContext.AccountAddress == vm.Address{0x01} &&
 		s.BlockContext.BlockNumber == 1 &&
 		len(s.CallData) == 1 &&
 		s.CallData[0] == 1 &&
@@ -229,12 +230,12 @@ func TestSerialization_DeserializedStateIsIndependent(t *testing.T) {
 	deserializedState.Storage.Current[NewU256(42)] = NewU256(4)
 	deserializedState.Storage.Original[NewU256(77)] = NewU256(7)
 	deserializedState.Storage.warm[NewU256(9)] = false
-	deserializedState.Accounts.Balance[Address{0x01}] = NewU256(77)
-	deserializedState.Accounts.Code[Address{0x01}] = []byte{byte(INVALID)}
-	delete(deserializedState.Accounts.warm, Address{0x02})
+	deserializedState.Accounts.Balance[vm.Address{0x01}] = NewU256(77)
+	deserializedState.Accounts.Code[vm.Address{0x01}] = []byte{byte(INVALID)}
+	delete(deserializedState.Accounts.warm, vm.Address{0x02})
 	deserializedState.Logs.Entries[0].Data[0] = 99
 	deserializedState.Logs.Entries[0].Topics[0] = NewU256(42)
-	deserializedState.CallContext.AccountAddress = Address{0x02}
+	deserializedState.CallContext.AccountAddress = vm.Address{0x02}
 	deserializedState.BlockContext.BlockNumber = 42
 	deserializedState.CallData = []byte{4}
 	deserializedState.LastCallReturnData = []byte{6}
@@ -255,12 +256,12 @@ func TestSerialization_DeserializedStateIsIndependent(t *testing.T) {
 		s.Storage.Current[NewU256(7)].IsZero() &&
 		s.Storage.Original[NewU256(77)].Eq(NewU256(4)) &&
 		s.Storage.Warm[NewU256(9)] == true &&
-		s.Accounts.Balance[Address{0x01}].Eq(NewU256(42)) &&
-		bytes.Equal(s.Accounts.Code[Address{0x01}], []byte{byte(PUSH1), byte(6)}) &&
-		s.Accounts.Warm[Address{0x02}] == true &&
+		s.Accounts.Balance[vm.Address{0x01}].Eq(NewU256(42)) &&
+		bytes.Equal(s.Accounts.Code[vm.Address{0x01}], []byte{byte(PUSH1), byte(6)}) &&
+		s.Accounts.Warm[vm.Address{0x02}] == true &&
 		s.Logs.Entries[0].Data[0] == 4 &&
 		s.Logs.Entries[0].Topics[0] == NewU256(21) &&
-		s.CallContext.AccountAddress == Address{0x01} &&
+		s.CallContext.AccountAddress == vm.Address{0x01} &&
 		s.BlockContext.BlockNumber == 1 &&
 		len(s.CallData) == 1 &&
 		s.CallData[0] == 1 &&

--- a/go/ct/st/state_test.go
+++ b/go/ct/st/state_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 )
 
 func TestState_CloneCreatesEqualState(t *testing.T) {
@@ -22,9 +23,9 @@ func TestState_CloneCreatesEqualState(t *testing.T) {
 	state.Storage.Current[NewU256(4)] = NewU256(5)
 	state.Storage.Original[NewU256(6)] = NewU256(7)
 	state.Logs.AddLog([]byte{10, 11}, NewU256(21), NewU256(22))
-	state.CallContext.AccountAddress = Address{0xff}
-	state.CallContext.OriginAddress = Address{0xfe}
-	state.CallContext.CallerAddress = Address{0xfd}
+	state.CallContext.AccountAddress = vm.Address{0xff}
+	state.CallContext.OriginAddress = vm.Address{0xfe}
+	state.CallContext.CallerAddress = vm.Address{0xfd}
 	state.CallContext.Value = NewU256(252)
 	state.BlockContext.BlockNumber = 251
 	state.BlockContext.CoinBase[0] = 0xfa
@@ -53,9 +54,9 @@ func TestState_CloneIsIndependent(t *testing.T) {
 	state.Storage.Current[NewU256(4)] = NewU256(5)
 	state.Storage.Original[NewU256(6)] = NewU256(7)
 	state.Logs.AddLog([]byte{10, 11}, NewU256(21), NewU256(22))
-	state.CallContext.AccountAddress = Address{0xff}
-	state.CallContext.OriginAddress = Address{0xfe}
-	state.CallContext.CallerAddress = Address{0xfd}
+	state.CallContext.AccountAddress = vm.Address{0xff}
+	state.CallContext.OriginAddress = vm.Address{0xfe}
+	state.CallContext.CallerAddress = vm.Address{0xfd}
 	state.CallContext.Value = NewU256(252)
 	state.BlockContext.BlockNumber = 251
 	state.BlockContext.CoinBase[0] = 0xfa
@@ -79,9 +80,9 @@ func TestState_CloneIsIndependent(t *testing.T) {
 	clone.Storage.MarkWarm(NewU256(42))
 	clone.Logs.Entries[0].Data[0] = 31
 	clone.Logs.Entries[0].Topics[0] = NewU256(41)
-	clone.CallContext.AccountAddress = Address{0x01}
-	clone.CallContext.OriginAddress = Address{0x02}
-	clone.CallContext.CallerAddress = Address{0x03}
+	clone.CallContext.AccountAddress = vm.Address{0x01}
+	clone.CallContext.OriginAddress = vm.Address{0x02}
+	clone.CallContext.CallerAddress = vm.Address{0x03}
 	clone.CallContext.Value = NewU256(4)
 	clone.BlockContext.BlockNumber = 5
 	clone.BlockContext.CoinBase[0] = 0x06
@@ -106,9 +107,9 @@ func TestState_CloneIsIndependent(t *testing.T) {
 		!state.Storage.IsWarm(NewU256(42)) &&
 		state.Logs.Entries[0].Data[0] == 10 &&
 		state.Logs.Entries[0].Topics[0] == NewU256(21) &&
-		state.CallContext.AccountAddress == Address{0xff} &&
-		state.CallContext.OriginAddress == Address{0xfe} &&
-		state.CallContext.CallerAddress == Address{0xfd} &&
+		state.CallContext.AccountAddress == vm.Address{0xff} &&
+		state.CallContext.OriginAddress == vm.Address{0xfe} &&
+		state.CallContext.CallerAddress == vm.Address{0xfd} &&
 		state.CallContext.Value.Eq(NewU256(252)) &&
 		state.BlockContext.BlockNumber == 251 &&
 		state.BlockContext.CoinBase[0] == 0xfa &&
@@ -200,8 +201,8 @@ func TestState_Eq(t *testing.T) {
 	}
 	s2 = NewState(NewCode([]byte{byte(ADD), byte(STOP)}))
 
-	s1.CallContext = CallContext{AccountAddress: Address{0x00}}
-	s2.CallContext = CallContext{AccountAddress: Address{0xff}}
+	s1.CallContext = CallContext{AccountAddress: vm.Address{0x00}}
+	s2.CallContext = CallContext{AccountAddress: vm.Address{0xff}}
 	if s1.Eq(s2) {
 		t.Fail()
 	}
@@ -455,7 +456,7 @@ func TestState_DiffMatch(t *testing.T) {
 	s1.Memory.Write([]byte{1, 2, 3}, 31)
 	s1.Storage.MarkWarm(NewU256(42))
 	s1.Logs.AddLog([]byte{4, 5, 6}, NewU256(21), NewU256(22))
-	s1.CallContext = CallContext{AccountAddress: Address{0x01}}
+	s1.CallContext = CallContext{AccountAddress: vm.Address{0x01}}
 	s1.BlockContext = BlockContext{BlockNumber: 1}
 	s1.CallData = append(s1.CallData, 1)
 	s1.LastCallReturnData = append(s1.LastCallReturnData, 1)
@@ -470,7 +471,7 @@ func TestState_DiffMatch(t *testing.T) {
 	s2.Memory.Write([]byte{1, 2, 3}, 31)
 	s2.Storage.MarkWarm(NewU256(42))
 	s2.Logs.AddLog([]byte{4, 5, 6}, NewU256(21), NewU256(22))
-	s2.CallContext = CallContext{AccountAddress: Address{0x01}}
+	s2.CallContext = CallContext{AccountAddress: vm.Address{0x01}}
 	s2.BlockContext = BlockContext{BlockNumber: 1}
 	s2.CallData = append(s2.CallData, 1)
 	s2.LastCallReturnData = append(s2.LastCallReturnData, 1)
@@ -498,7 +499,7 @@ func TestState_DiffMismatch(t *testing.T) {
 	s1.Storage.MarkWarm(NewU256(42))
 	s1.Logs.AddLog([]byte{4, 5, 6}, NewU256(21), NewU256(22))
 	s1.Logs.AddLog([]byte{4, 5, 6}, NewU256(21), NewU256(22))
-	s1.CallContext = CallContext{AccountAddress: Address{0xff}}
+	s1.CallContext = CallContext{AccountAddress: vm.Address{0xff}}
 	s1.BlockContext = BlockContext{BlockNumber: 1}
 	s1.CallData = append(s1.CallData, 1)
 	s1.LastCallReturnData = append(s1.LastCallReturnData, 1)
@@ -513,7 +514,7 @@ func TestState_DiffMismatch(t *testing.T) {
 	s2.Memory.Write([]byte{1, 2, 4}, 31)
 	s2.Storage.MarkCold(NewU256(42))
 	s2.Logs.AddLog([]byte{4, 7, 6}, NewU256(24), NewU256(22))
-	s2.CallContext = CallContext{AccountAddress: Address{0xef}}
+	s2.CallContext = CallContext{AccountAddress: vm.Address{0xef}}
 	s2.BlockContext = BlockContext{BlockNumber: 251}
 	s2.CallData = append(s2.CallData, 250)
 	s2.LastCallReturnData = append(s2.LastCallReturnData, 249)

--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -59,9 +59,9 @@ type ctRunContext struct {
 }
 
 func (c *ctRunContext) AccountExists(addr vm.Address) bool {
-	_, existsCode := c.state.Accounts.Code[cc.Address(addr)]
-	_, existsBalance := c.state.Accounts.Balance[cc.Address(addr)]
-	existsWarm := c.state.Accounts.IsWarm(cc.Address(addr))
+	_, existsCode := c.state.Accounts.Code[addr]
+	_, existsBalance := c.state.Accounts.Balance[addr]
+	existsWarm := c.state.Accounts.IsWarm(addr)
 	return existsCode || existsBalance || existsWarm
 }
 
@@ -80,20 +80,20 @@ func (c *ctRunContext) SetStorage(addr vm.Address, key vm.Key, value vm.Word) vm
 }
 
 func (c *ctRunContext) GetBalance(addr vm.Address) vm.Value {
-	balance := c.state.Accounts.Balance[cc.Address(addr)]
+	balance := c.state.Accounts.Balance[addr]
 	return vm.Value(balance.Bytes32be())
 }
 
 func (c *ctRunContext) GetCodeSize(addr vm.Address) int {
-	return len(c.state.Accounts.Code[cc.Address(addr)])
+	return len(c.state.Accounts.Code[addr])
 }
 
 func (c *ctRunContext) GetCodeHash(addr vm.Address) vm.Hash {
-	return c.state.Accounts.GetCodeHash(cc.Address(addr))
+	return c.state.Accounts.GetCodeHash(addr)
 }
 
 func (c *ctRunContext) GetCode(addr vm.Address) []byte {
-	return c.state.Accounts.Code[cc.Address(addr)]
+	return c.state.Accounts.Code[addr]
 }
 
 func (c *ctRunContext) GetTransactionContext() vm.TransactionContext {
@@ -132,8 +132,8 @@ func (c *ctRunContext) SelfDestruct(addr vm.Address, beneficiary vm.Address) boo
 }
 
 func (c *ctRunContext) AccessAccount(addr vm.Address) vm.AccessStatus {
-	warm := c.state.Accounts.IsWarm(cc.Address(addr))
-	c.state.Accounts.MarkWarm(cc.Address(addr))
+	warm := c.state.Accounts.IsWarm(addr)
+	c.state.Accounts.MarkWarm(addr)
 	if warm {
 		return vm.WarmAccess
 	}
@@ -158,7 +158,7 @@ func (c *ctRunContext) GetCommittedStorage(addr vm.Address, key vm.Key) vm.Word 
 }
 
 func (c *ctRunContext) IsAddressInAccessList(addr vm.Address) bool {
-	return c.state.Accounts.IsWarm(cc.Address(addr))
+	return c.state.Accounts.IsWarm(addr)
 }
 
 func (c *ctRunContext) IsSlotInAccessList(addr vm.Address, key vm.Key) (addressPresent, slotPresent bool) {

--- a/go/ct/utils/adapter_test.go
+++ b/go/ct/utils/adapter_test.go
@@ -41,15 +41,15 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 			func(p vm.Parameters) (any, any) { return false, p.Static },
 		},
 		"recipient": {
-			func(s *st.State) { s.CallContext.AccountAddress = cc.Address{1, 2, 3} },
+			func(s *st.State) { s.CallContext.AccountAddress = vm.Address{1, 2, 3} },
 			func(p vm.Parameters) (any, any) { return vm.Address{1, 2, 3}, p.Recipient },
 		},
 		"sender": {
-			func(s *st.State) { s.CallContext.CallerAddress = cc.Address{1, 2, 3} },
+			func(s *st.State) { s.CallContext.CallerAddress = vm.Address{1, 2, 3} },
 			func(p vm.Parameters) (any, any) { return vm.Address{1, 2, 3}, p.Sender },
 		},
 		"origin": {
-			func(s *st.State) { s.CallContext.OriginAddress = cc.Address{1, 2, 3} },
+			func(s *st.State) { s.CallContext.OriginAddress = vm.Address{1, 2, 3} },
 			func(p vm.Parameters) (any, any) { return vm.Address{1, 2, 3}, p.Context.GetTransactionContext().Origin },
 		},
 		"value": {
@@ -63,7 +63,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 			},
 		},
 		"coinbase": {
-			func(s *st.State) { s.BlockContext.CoinBase = cc.Address{1, 2, 3} },
+			func(s *st.State) { s.BlockContext.CoinBase = vm.Address{1, 2, 3} },
 			func(p vm.Parameters) (any, any) {
 				return vm.Address{1, 2, 3}, p.Context.GetTransactionContext().Coinbase
 			},
@@ -180,7 +180,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 		"balance-unspecified": {
 			func(s *st.State) {
 				s.Accounts = &st.Accounts{}
-				s.Accounts.Balance = map[cc.Address]cc.U256{
+				s.Accounts.Balance = map[vm.Address]cc.U256{
 					{1}: cc.NewU256(2),
 				}
 			},
@@ -192,7 +192,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 		"balance-specified": {
 			func(s *st.State) {
 				s.Accounts = &st.Accounts{}
-				s.Accounts.Balance = map[cc.Address]cc.U256{
+				s.Accounts.Balance = map[vm.Address]cc.U256{
 					{1}: cc.NewU256(2),
 				}
 			},
@@ -204,7 +204,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 		"getCode": {
 			func(s *st.State) {
 				s.Accounts = &st.Accounts{}
-				s.Accounts.Code = map[cc.Address][]byte{
+				s.Accounts.Code = map[vm.Address][]byte{
 					{1}: {byte(cc.ADD), byte(cc.SUB)},
 				}
 			},
@@ -216,7 +216,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 		"getCodeHash-emptyHash": {
 			func(s *st.State) {
 				s.Accounts = &st.Accounts{}
-				s.Accounts.Code = map[cc.Address][]byte{}
+				s.Accounts.Code = map[vm.Address][]byte{}
 			},
 			func(p vm.Parameters) (any, any) {
 				ctxt := p.Context
@@ -232,7 +232,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 		"getCodeHash": {
 			func(s *st.State) {
 				s.Accounts = &st.Accounts{}
-				s.Accounts.Code = map[cc.Address][]byte{
+				s.Accounts.Code = map[vm.Address][]byte{
 					{1}: {byte(cc.ADD), byte(cc.SUB)},
 				}
 			},
@@ -250,7 +250,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 		"getCodeSize-empty": {
 			func(s *st.State) {
 				s.Accounts = &st.Accounts{}
-				s.Accounts.Code = map[cc.Address][]byte{}
+				s.Accounts.Code = map[vm.Address][]byte{}
 			},
 			func(p vm.Parameters) (any, any) {
 				ctxt := p.Context
@@ -260,7 +260,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 		"getCodeSize": {
 			func(s *st.State) {
 				s.Accounts = &st.Accounts{}
-				s.Accounts.Code = map[cc.Address][]byte{
+				s.Accounts.Code = map[vm.Address][]byte{
 					{1}: {byte(cc.ADD), byte(cc.SUB)},
 				}
 			},
@@ -281,7 +281,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 		"warm-account": {
 			func(s *st.State) {
 				s.Accounts = st.NewAccounts()
-				s.Accounts.MarkWarm(cc.Address{})
+				s.Accounts.MarkWarm(vm.Address{})
 			},
 			func(p vm.Parameters) (any, any) {
 				ctxt := p.Context
@@ -300,7 +300,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 		"warm-account-legacy": {
 			func(s *st.State) {
 				s.Accounts = st.NewAccounts()
-				s.Accounts.MarkWarm(cc.Address{})
+				s.Accounts.MarkWarm(vm.Address{})
 			},
 			func(p vm.Parameters) (any, any) {
 				ctxt := p.Context

--- a/go/vm/types.go
+++ b/go/vm/types.go
@@ -7,34 +7,40 @@ import (
 	"strings"
 )
 
-func (a Address) MarshalJSON() ([]byte, error) {
-	res := fmt.Sprintf("%x", a)
-	return json.Marshal(res)
+func (a Address) String() string {
+	return fmt.Sprintf("0x%x", a[:])
 }
 
-func (a *Address) UnmarshalJSON(data []byte) error {
-	return jsonToBytes(a[:], data)
+func (a Address) MarshalText() ([]byte, error) {
+	return bytesToText(a[:])
 }
 
-func (v Value) MarshalJSON() ([]byte, error) {
-	return bytesToJSON(v[:])
+func (a *Address) UnmarshalText(data []byte) error {
+	return textToBytes(a[:], data)
 }
 
-func (v *Value) UnmarshalJSON(data []byte) error {
-	return jsonToBytes(v[:], data)
+func (v Value) String() string {
+	return fmt.Sprintf("0x%x", v[:])
 }
 
-func bytesToJSON(data []byte) ([]byte, error) {
-	res := fmt.Sprintf("%x", data)
-	return json.Marshal(res)
+func (v Value) MarshalText() ([]byte, error) {
+	return bytesToText(v[:])
 }
 
-func jsonToBytes(trg []byte, data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
+func (v *Value) UnmarshalText(data []byte) error {
+	return textToBytes(v[:], data)
+}
+
+func bytesToText(data []byte) ([]byte, error) {
+	return []byte(fmt.Sprintf("0x%x", data)), nil
+}
+
+func textToBytes(trg []byte, data []byte) error {
+	s := string(data)
+	if !strings.HasPrefix(s, "0x") {
+		return fmt.Errorf("invalid format, does not start with 0x: %v", s)
 	}
-	data, err := hex.DecodeString(s)
+	data, err := hex.DecodeString(s[2:])
 	if err != nil {
 		return err
 	}
@@ -67,18 +73,8 @@ func (k CallKind) String() string {
 func (k CallKind) MarshalJSON() ([]byte, error) {
 	var res string
 	switch k {
-	case Call:
-		res = "call"
-	case StaticCall:
-		res = "static_call"
-	case DelegateCall:
-		res = "delegate_call"
-	case CallCode:
-		res = "call_code"
-	case Create:
-		res = "create"
-	case Create2:
-		res = "create2"
+	case Call, StaticCall, DelegateCall, CallCode, Create, Create2:
+		res = k.String()
 	default:
 		return nil, fmt.Errorf("invalid call kind: %v", k)
 	}

--- a/go/vm/types_test.go
+++ b/go/vm/types_test.go
@@ -5,17 +5,25 @@ import (
 	"testing"
 )
 
+func TestAddress_NewAddress(t *testing.T) {
+	address := Address{}
+
+	if address != [20]byte{} {
+		t.Errorf("New address must be default value.")
+	}
+}
+
 func TestAddress_JSON_Encoding(t *testing.T) {
 	tests := []struct {
 		address Address
 		json    string
 	}{
-		{Address{}, "\"0000000000000000000000000000000000000000\""},
-		{Address{1}, "\"0100000000000000000000000000000000000000\""},
-		{Address{0xAB}, "\"ab00000000000000000000000000000000000000\""},
+		{Address{}, "\"0x0000000000000000000000000000000000000000\""},
+		{Address{1}, "\"0x0100000000000000000000000000000000000000\""},
+		{Address{0xAB}, "\"0xab00000000000000000000000000000000000000\""},
 		{
 			Address{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
-			"\"000102030405060708090a0b0c0d0e0f10111213\"",
+			"\"0x000102030405060708090a0b0c0d0e0f10111213\"",
 		},
 	}
 
@@ -42,18 +50,23 @@ func TestAddress_JSON_Encoding(t *testing.T) {
 
 func TestAddress_JSON_InvalidValueDecodingFails(t *testing.T) {
 	tests := map[string]string{
-		"way to short":      "\"123\"",
-		"just to short":     "\"000102030405060708090a0b0c0d0e0f1011121\"",
-		"just to long":      "\"000102030405060708090a0b0c0d0e0f101112131\"",
-		"not hex":           "\"hello, this is a test with 20 characters\"",
-		"not a JSON string": "000102030405060708090a0b0c0d0e0f10111213",
+		"empty":                 "\"\"",
+		"empty with hex prefix": "\"0x\"",
+		"no hex prefix":         "\"0000000000000000000000000000000000000000\"",
+		"too short":             "\"0x00000000000000000000000000000000000000\"",
+		"just too short":        "\"0x000102030405060708090a0b0c0d0e0f1011121\"",
+		"just too long":         "\"0x000102030405060708090a0b0c0d0e0f101112131\"",
+		"too long":              "\"0x000000000000000000000000000000000000000000\"",
+		"invalid hex":           "\"0x0g00000000000000000000000000000000000000\"",
+		"not hex":               "\"hello, this is a test with 20 characters\"",
+		"not a JSON string":     "0x000102030405060708090a0b0c0d0e0f10111213",
 	}
 
 	for name, data := range tests {
 		t.Run(name, func(t *testing.T) {
 			var address Address
 			if json.Unmarshal([]byte(data), &address) == nil {
-				t.Errorf("expected decoding to fail, but instead it produced a result")
+				t.Errorf("expected decoding to fail, but instead it produced %v", address)
 			}
 		})
 	}
@@ -64,9 +77,9 @@ func TestValue_JSON_Encoding(t *testing.T) {
 		value Value
 		json  string
 	}{
-		{Value{}, "\"0000000000000000000000000000000000000000000000000000000000000000\""},
-		{Value{1}, "\"0100000000000000000000000000000000000000000000000000000000000000\""},
-		{Value{0xAB}, "\"ab00000000000000000000000000000000000000000000000000000000000000\""},
+		{Value{}, "\"0x0000000000000000000000000000000000000000000000000000000000000000\""},
+		{Value{1}, "\"0x0100000000000000000000000000000000000000000000000000000000000000\""},
+		{Value{0xAB}, "\"0xab00000000000000000000000000000000000000000000000000000000000000\""},
 		{
 			Value{
 				0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
@@ -74,7 +87,7 @@ func TestValue_JSON_Encoding(t *testing.T) {
 				20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
 				30, 31,
 			},
-			"\"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f\"",
+			"\"0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f\"",
 		},
 	}
 


### PR DESCRIPTION
This PR adds JSON marshaling and unmarshaling support to the basic VM types `Address`, `Value`, and `CallKind`. 

These types are used for modelling CT states and thus either require a serializable equivalent for the CT state import/export or need to be made serializable themselves. Since it does not hurt to have it defined on the types themselves, and this might come in handy in other situations, the latter option was chosen. 

As suggested by reviewers, this PR is now also replacing the CT's `common.Address` with `vm.Address`.