### PR TITLE
Fix handling of return data for stop instructions

### DIFF
--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -385,10 +385,13 @@ func (g *StateGenerator) Generate(rnd *rand.Rand) (*st.State, error) {
 		return nil, err
 	}
 
-	// Generate return data
-	resultReturnData, err := getRandomData(rnd)
-	if err != nil {
-		return nil, err
+	// Generate return data for terminal states.
+	var resultReturnData []byte
+	if resultStatus == st.Stopped || resultStatus == st.Reverted {
+		resultReturnData, err = getRandomData(rnd)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Sub-generators can modify the assignment when unassigned variables are

--- a/go/ct/gen/state_test.go
+++ b/go/ct/gen/state_test.go
@@ -407,11 +407,19 @@ func testData(data []byte, name string, t *testing.T) {
 // //////////////////////////////////////////////////////////
 // Call data
 // Last Call Return data
-// Return data
 
 func TestStateGenerator_DataGeneration(t *testing.T) {
 	state := genRandomState(t)
 	testData(state.CallData, "call data", t)
 	testData(state.LastCallReturnData, "last call return data", t)
-	testData(state.ReturnData, "return data", t)
+}
+
+// //////////////////////////////////////////////////////////
+// Return data should always be empty
+
+func TestStateGenerator_ReturnDataShouldBeEmpty(t *testing.T) {
+	state := genRandomState(t)
+	if want, got := 0, len(state.ReturnData); want != got {
+		t.Errorf("unexpected length of generated return data, wanted %d, got %d", want, got)
+	}
 }

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -114,6 +114,7 @@ var Spec = func() Specification {
 		),
 		Effect: Change(func(s *st.State) {
 			s.Status = st.Stopped
+			s.ReturnData = nil // nothing is returned by stop
 			s.Pc++
 		}),
 	})


### PR DESCRIPTION
This PR fixes the currently broken support for the stop instruction.

The following changes are applied:
- the function computing state equality has been refined to not cover internal state like stack or memory in terminal states
- generators are no longer producing return data since input states should never have such data; only terminal states may have non-empty return data