### PR TITLE
Decrease ct test time

### DIFF
--- a/go/ct/driver/run.go
+++ b/go/ct/driver/run.go
@@ -53,7 +53,7 @@ var RunCmd = cli.Command{
 			Name:  "cpuprofile",
 			Usage: "store CPU profile in the provided filename",
 		},
-		&cli.BoolFlag{
+		&cli.BoolFlag{ // < TODO: make every run a full mode once tests pass
 			Name:  "full-mode",
 			Usage: "if enabled, test cases targeting rules other than the one generating the case will be executed",
 		},
@@ -70,10 +70,10 @@ func doRun(context *cli.Context) error {
 	if cpuprofileFilename := context.String("cpuprofile"); cpuprofileFilename != "" {
 		f, err := os.Create(cpuprofileFilename)
 		if err != nil {
-			return fmt.Errorf("could not create CPU profile: %s", err)
+			return fmt.Errorf("could not create CPU profile: %w", err)
 		}
 		if err := pprof.StartCPUProfile(f); err != nil {
-			return fmt.Errorf("could not start CPU profile: %s", err)
+			return fmt.Errorf("could not start CPU profile: %w", err)
 		}
 		defer pprof.StopCPUProfile()
 	}
@@ -139,7 +139,7 @@ func doRun(context *cli.Context) error {
 
 	err = forEachState(opRun, printIssueCounts, jobCount, seed, fullMode, filter)
 	if err != nil {
-		return fmt.Errorf("error generating States: %v", err)
+		return fmt.Errorf("error generating States: %w", err)
 	}
 	issues := issuesCollector.issues
 
@@ -243,7 +243,9 @@ func forEachState(
 			for state := range stateChannel {
 				testCounter.Add(1)
 				consumeStatus := opFunction(state)
-				abortTests.Store(consumeStatus == rlz.ConsumeAbort)
+				if consumeStatus == rlz.ConsumeAbort {
+					abortTests.Store(false)
+				}
 			}
 		}()
 	}

--- a/go/ct/driver/test.go
+++ b/go/ct/driver/test.go
@@ -50,10 +50,10 @@ func doTest(context *cli.Context) error {
 	if cpuprofileFilename := context.String("cpuprofile"); cpuprofileFilename != "" {
 		f, err := os.Create(cpuprofileFilename)
 		if err != nil {
-			return fmt.Errorf("could not create CPU profile: %s", err)
+			return fmt.Errorf("could not create CPU profile: %w", err)
 		}
 		if err := pprof.StartCPUProfile(f); err != nil {
-			return fmt.Errorf("could not start CPU profile: %s", err)
+			return fmt.Errorf("could not start CPU profile: %w", err)
 		}
 		defer pprof.StopCPUProfile()
 	}
@@ -86,7 +86,7 @@ func doTest(context *cli.Context) error {
 				s := state.Clone()
 				rules[i].Effect.Apply(s)
 				if !s.Eq(s0) {
-					issuesCollector.AddIssue(nil, fmt.Errorf("multiple conflicting rules for state %v: %v", state, rules))
+					issuesCollector.AddIssue(state, fmt.Errorf("multiple conflicting rules for state: %v", rules))
 					return rlz.ConsumeContinue
 				}
 			}
@@ -98,7 +98,7 @@ func doTest(context *cli.Context) error {
 
 	err = forEachState(opTest, printIssueCounts, jobCount, seed, fullMode, filter)
 	if err != nil {
-		return fmt.Errorf("error generating States: %v", err)
+		return fmt.Errorf("error generating States: %w", err)
 	}
 
 	// Summarize the result.


### PR DESCRIPTION
This PR reuses the ct run code for the ct test. Parallelization over states rather than rules allows to make use of parallel hardware also when filtering for a single rule. 