### PR TITLE
Make LFVM call check for sufficient balance before a call

### DIFF
--- a/go/vm/lfvm/instructions.go
+++ b/go/vm/lfvm/instructions.go
@@ -986,6 +986,20 @@ func opCall(c *context) {
 
 	// Get the arguments from the memory.
 	args := c.memory.GetSlice(inOffset.Uint64(), inSize.Uint64())
+
+	// Check that the caller has enough balance to transfer the requested value.
+	if !value.IsZero() {
+		balance := c.context.GetBalance(c.params.Recipient)
+		balanceU256 := new(uint256.Int).SetBytes32(balance[:])
+		if balanceU256.Lt(value) {
+			c.stack.pushEmpty().Clear()
+			c.return_data = nil
+			c.gas += cost // the gas send to the nested contract is returned
+			return
+		}
+	}
+
+	// Perform the call.
 	ret, err := c.context.Call(kind, vm.CallParameter{
 		Sender:    c.params.Recipient,
 		Recipient: toAddr,


### PR DESCRIPTION
This PR adds a check for sufficient balance to the implementation of the CALL instruction of LFVM.

When using the LFVM interpreter with the geth EVM implementation this test is not strictly necessary since it is also conducted by the geth EVM itself before running the call. However, interpreter implementations like evmzero are covering this check in their implementations for the sake of completeness. Thus, it was decided to make this check mandatory.