### PR TITLE
Fix underflow in callGas computation

### DIFF
--- a/go/vm/lfvm/gas.go
+++ b/go/vm/lfvm/gas.go
@@ -246,8 +246,11 @@ func getStaticGasPriceInternal(op OpCode) vm.Gas {
 // As part of EIP 150 (TangerineWhistle), the returned gas is gas - base * 63 / 64.
 func callGas(availableGas, base vm.Gas, callCost *uint256.Int) vm.Gas {
 	availableGas = availableGas - base
+	if availableGas < 0 {
+		return base
+	}
 	gas := availableGas - availableGas/64
-	if !callCost.IsUint64() || (gas >= 0 && gas < vm.Gas(callCost.Uint64())) {
+	if !callCost.IsUint64() || (gas < vm.Gas(callCost.Uint64())) {
 		return gas
 	}
 	return vm.Gas(callCost.Uint64())

--- a/go/vm/lfvm/gas_test.go
+++ b/go/vm/lfvm/gas_test.go
@@ -1,0 +1,51 @@
+package lfvm
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/vm"
+	"github.com/holiman/uint256"
+)
+
+func TestGas_CallGasCalculation(t *testing.T) {
+	tests := map[string]struct {
+		available vm.Gas       // < the gas available in the current context
+		baseCosts vm.Gas       // < the costs for setting up the call
+		provided  *uint256.Int // < the gas to be provided to the nested call
+		want      vm.Gas       // < the gas costs for the call
+	}{
+		"available_is_more_than_provided": {
+			available: vm.Gas(200),
+			baseCosts: vm.Gas(20),
+			provided:  uint256.NewInt(30),
+			want:      30, // < limited by gas to be provided to nested call
+		},
+		"available_is_less_than_provided": {
+			available: vm.Gas(200),
+			baseCosts: vm.Gas(20),
+			provided:  uint256.NewInt(300),
+			want:      (200 - 20) - (200-20)/64, //  < limited by 63/64 of the available gas after the base costs
+		},
+		"available_is_less_than_provided_exceeding_maxUint64": {
+			available: vm.Gas(200),
+			baseCosts: vm.Gas(20),
+			provided:  new(uint256.Int).Lsh(uint256.NewInt(1), 64),
+			want:      (200 - 20) - (200-20)/64, //  < limited by 63/64 of the available gas after the base costs
+		},
+		"base_costs_higher_than_available": {
+			available: vm.Gas(20),
+			baseCosts: vm.Gas(200),
+			provided:  uint256.NewInt(300),
+			want:      200, //  < the base costs
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := callGas(test.available, test.baseCosts, test.provided)
+			if want := test.want; want != got {
+				t.Errorf("unexpected result, wanted %d, got %d", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Before this fix, if `availableGas` was less than `base` a negative result would be returned. But costs must not be negative.

This issue was discovered through Tosca CT.