### PR TITLE
Grow memory for output data in calls even if call is skipped

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -1575,6 +1575,11 @@ struct CallImpl {
 
     ctx.return_data.clear();
 
+    // Grow the memory for the output for which gas has been charged above.
+    // This has to happen before reading the input as a span to avoid invalidating
+    // the input_data span with the capacity grow.
+    ctx.memory.Grow(output_offset, output_size);
+
     auto input_data = ctx.memory.GetSpan(input_offset, input_size);
 
     int64_t call_gas = kMaxGas;
@@ -1611,7 +1616,6 @@ struct CallImpl {
     const evmc::Result result = ctx.host->call(msg);
     ctx.return_data.assign(result.output_data, result.output_data + result.output_size);
 
-    ctx.memory.Grow(output_offset, output_size);
     if (ctx.return_data.size() > 0) {
       ctx.memory.ReadFromWithSize(ctx.return_data, output_offset, output_size);
     }


### PR DESCRIPTION
This issue was discovered by the Tosca CT for cases where there is not enough balance in the sender account to cover the value transfer of a call. In such a case, no call is conducted, and no result processed. However, the memory expansion was already charged for, but not conducted.

With this change, the memory expansion is carried out in any case that has sufficient funds and does not result in a failed status.

A regression test case will be added for this PR once #345 is merged.