### PR TITLE
Do not apply zero-padding when copying call result data to memory

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -1617,7 +1617,8 @@ struct CallImpl {
     ctx.return_data.assign(result.output_data, result.output_data + result.output_size);
 
     if (ctx.return_data.size() > 0) {
-      ctx.memory.ReadFromWithSize(ctx.return_data, output_offset, output_size);
+      auto size = std::min(output_size, ctx.return_data.size());
+      ctx.memory.ReadFromWithSize(ctx.return_data, output_offset, size);
     }
 
     if (gas -= msg.gas - result.gas_left; gas < 0) [[unlikely]]


### PR DESCRIPTION
This PR removes the automatic zero-padding of call data results if the result is smaller than the range specified in the call parameters. This should correspond to the geth implementation [here](https://github.com/ethereum/go-ethereum/blob/767b00b0b514771a663f3362dd0310fc28d40c25/core/vm/instructions.go#L682).

This issue was discovered by Tosca CT. A regression test is added once #345 is merged.