### PR TITLE
lfvm: remove error field

### DIFF
--- a/go/vm/lfvm/converter.go
+++ b/go/vm/lfvm/converter.go
@@ -29,12 +29,6 @@ func clearConversionCache() {
 	cache = map[vm.Hash]cache_val{}
 }
 
-func getConversionCacheLength() int {
-	mu.Lock()
-	defer mu.Unlock()
-	return len(cache)
-}
-
 func Convert(code []byte, with_super_instructions bool, create bool, noCodeCache bool, codeHash vm.Hash) (Code, error) {
 	// TODO: clean up this code; it does some checks that seems to be once used
 	// for debugging an issue that do not make sense any more.
@@ -52,7 +46,7 @@ func Convert(code []byte, with_super_instructions bool, create bool, noCodeCache
 		if noCodeCache {
 
 			if !bytes.Equal(res.oldCode, code) {
-				log.Println(fmt.Sprintf("Different code for hash %v", codeHash))
+				log.Printf("Different code for hash %v", codeHash)
 				isEqual = false
 			}
 		}

--- a/go/vm/lfvm/ct_test.go
+++ b/go/vm/lfvm/ct_test.go
@@ -46,16 +46,6 @@ func TestCtAdapter_Interface(t *testing.T) {
 ////////////////////////////////////////////////////////////
 // ct -> lfvm
 
-func getEmptyState() *st.State {
-	return st.NewState(st.NewCode([]byte{}))
-}
-
-func getByteCodeFromState(state *st.State) []byte {
-	code := make([]byte, state.Code.Length())
-	state.Code.CopyTo(code)
-	return code
-}
-
 func TestConvertToLfvm_StatusCode(t *testing.T) {
 
 	expected := map[Status]st.StatusCode{

--- a/go/vm/lfvm/instructions.go
+++ b/go/vm/lfvm/instructions.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"math"
-	"math/big"
 	"math/bits"
 
 	"github.com/ethereum/go-ethereum/params"
@@ -12,10 +11,6 @@ import (
 	"golang.org/x/crypto/sha3"
 
 	"github.com/Fantom-foundation/Tosca/go/vm"
-)
-
-var (
-	big0 = big.NewInt(0)
 )
 
 func opStop(c *context) {

--- a/go/vm/lfvm/interpreter_test.go
+++ b/go/vm/lfvm/interpreter_test.go
@@ -201,7 +201,7 @@ func TestStackMinBoundry(t *testing.T) {
 
 		// Check the result.
 		if ctxt.status != test.endStatus {
-			t.Errorf("execution failed %v: status is %v, wanted %v, error %v", test.name, ctxt.status, test.endStatus, ctxt.err)
+			t.Errorf("execution failed %v: status is %v, wanted %v", test.name, ctxt.status, test.endStatus)
 		} else {
 			t.Log("Success", test.name)
 		}
@@ -223,7 +223,7 @@ func TestStackMaxBoundry(t *testing.T) {
 
 		// Check the result.
 		if ctxt.status != test.endStatus {
-			t.Errorf("execution failed %v: status is %v, wanted %v, error %v", test.name, ctxt.status, test.endStatus, ctxt.err)
+			t.Errorf("execution failed %v: status is %v, wanted %v", test.name, ctxt.status, test.endStatus)
 		} else {
 			t.Log("Success", test.name)
 		}
@@ -412,7 +412,7 @@ func TestOKInstructionPath(t *testing.T) {
 
 			// Check the result.
 			if ctxt.status != test.endStatus {
-				t.Errorf("execution failed: status is %v, wanted %v, error %v", ctxt.status, test.endStatus, ctxt.err)
+				t.Errorf("execution failed: status is %v, wanted %v", ctxt.status, test.endStatus)
 			}
 
 			// Check gas consumption
@@ -501,7 +501,7 @@ func benchmarkFib(b *testing.B, arg int, with_super_instructions bool) {
 
 		// Check the result.
 		if ctxt.status != RETURNED {
-			b.Fatalf("execution failed: status is %v, error %v", ctxt.status, ctxt.err)
+			b.Fatalf("execution failed: status is %v", ctxt.status)
 		}
 
 		size := ctxt.result_size


### PR DESCRIPTION
This PR removes the error field from lfvm since it is not used by any EVM implementation. These changes fix #315.
