### PR TITLE
CT: Add account and account generator benchmarks

### DIFF
--- a/go/ct/gen/accounts_test.go
+++ b/go/ct/gen/accounts_test.go
@@ -99,7 +99,7 @@ func BenchmarkAccountGenWithConstraint(b *testing.B) {
 	generator.BindWarm(v1)
 	generator.BindCold(v2)
 	for i := 0; i < b.N; i++ {
-		_, _ = generator.Generate(assignment, rnd, NewAddressFromInt(8))
+		generator.Generate(assignment, rnd, NewAddressFromInt(8))
 	}
 }
 
@@ -109,6 +109,6 @@ func BenchmarkAccountGenWithOutConstraint(b *testing.B) {
 	generator := NewAccountGenerator()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = generator.Generate(assignment, rnd, NewAddressFromInt(8))
+		generator.Generate(assignment, rnd, NewAddressFromInt(8))
 	}
 }

--- a/go/ct/st/accounts_test.go
+++ b/go/ct/st/accounts_test.go
@@ -183,7 +183,7 @@ func BenchmarkAccountClone(b *testing.B) {
 	a := NewAddressFromInt(42)
 	b1 := accountInit(a)
 	for i := 0; i < b.N; i++ {
-		_ = b1.Clone()
+		b1.Clone()
 	}
 }
 


### PR DESCRIPTION
This PR adds 5 benchmarks:
- 4 in `go/ct/st/account_test.go` where it checks for:
 . clone
 . clone + balance modification
 . clone + code modification
 . clone + warm modification
- 1 in `go/ct/gen/account_test.go` where it checks for `AccountGenerator.Generate`
