### PR TITLE
Re-enable geth VM implementation in integration tests

### DIFF
--- a/go/vm/geth/geth.go
+++ b/go/vm/geth/geth.go
@@ -123,8 +123,8 @@ func (m *gethVm) Run(parameters vm.Parameters) (vm.Result, error) {
 // Now is doing nothing as this is not changing gas computation
 func transferFunc(stateDB geth.StateDB, callerAddress common.Address, to common.Address, value *big.Int) {
 	// Can be something like this:
-	// stateDB.SubBalance(callerAddress, value)
-	// stateDB.AddBalance(to, value)
+	stateDB.SubBalance(callerAddress, value)
+	stateDB.AddBalance(to, value)
 }
 
 // canTransferFunc is the signature of a transfer function
@@ -132,21 +132,24 @@ func canTransferFunc(stateDB geth.StateDB, callerAddress common.Address, value *
 	return stateDB.GetBalance(callerAddress).Cmp(value) >= 0
 }
 
+// stateDbAdapter adapts the vm.RunContext interface for its usage as a geth.StateDB in test
+// environment setups. The main purpose is to facilitate unit, integration, and conformance
+// testing for the geth interpreter.
 type stateDbAdapter struct {
 	context vm.RunContext
 	refund  uint64
 }
 
 func (s *stateDbAdapter) CreateAccount(common.Address) {
-	panic("should not be needed for a single contract execution")
+	// ignored: effect not needed in test environments
 }
 
 func (s *stateDbAdapter) SubBalance(common.Address, *big.Int) {
-	panic("should not be needed for a single contract execution")
+	// ignored: effect not needed in test environments
 }
 
 func (s *stateDbAdapter) AddBalance(common.Address, *big.Int) {
-	panic("should not be needed for a single contract execution")
+	// ignored: effect not needed in test environments
 }
 
 func (s *stateDbAdapter) GetBalance(addr common.Address) *big.Int {
@@ -155,11 +158,12 @@ func (s *stateDbAdapter) GetBalance(addr common.Address) *big.Int {
 }
 
 func (s *stateDbAdapter) GetNonce(common.Address) uint64 {
-	panic("should not be needed for a single contract execution")
+	// ignored: effect not needed in test environments
+	return 0
 }
 
 func (s *stateDbAdapter) SetNonce(common.Address, uint64) {
-	panic("should not be needed for a single contract execution")
+	// ignored: effect not needed in test environments
 }
 
 func (s *stateDbAdapter) GetCodeHash(addr common.Address) common.Hash {
@@ -171,7 +175,7 @@ func (s *stateDbAdapter) GetCode(addr common.Address) []byte {
 }
 
 func (s *stateDbAdapter) SetCode(common.Address, []byte) {
-	panic("should not be needed for a single contract execution")
+	// ignored: effect not needed in test environments
 }
 
 func (s *stateDbAdapter) GetCodeSize(addr common.Address) int {
@@ -203,7 +207,8 @@ func (s *stateDbAdapter) SetState(addr common.Address, key common.Hash, value co
 }
 
 func (s *stateDbAdapter) Suicide(addr common.Address) bool {
-	panic("not implemented")
+	// ignored: effect not needed in test environments
+	return false
 }
 
 func (s *stateDbAdapter) HasSuicided(addr common.Address) bool {
@@ -215,11 +220,11 @@ func (s *stateDbAdapter) Exist(addr common.Address) bool {
 }
 
 func (s *stateDbAdapter) Empty(addr common.Address) bool {
-	return s.context.AccountExists(vm.Address(addr))
+	return !s.context.AccountExists(vm.Address(addr))
 }
 
 func (s *stateDbAdapter) PrepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
-	panic("should not be needed for a single contract execution")
+	// ignored: effect not needed in test environments
 }
 
 func (s *stateDbAdapter) AddressInAccessList(addr common.Address) bool {
@@ -239,11 +244,11 @@ func (s *stateDbAdapter) AddSlotToAccessList(addr common.Address, slot common.Ha
 }
 
 func (s *stateDbAdapter) RevertToSnapshot(int) {
-	panic("should not be needed for a single contract execution")
+	// ignored: effect not needed in test environments
 }
 
 func (s *stateDbAdapter) Snapshot() int {
-	panic("should not be needed for a single contract execution")
+	return 0 // not relevant in test setups
 }
 
 func (s *stateDbAdapter) AddLog(log *types.Log) {
@@ -255,9 +260,9 @@ func (s *stateDbAdapter) AddLog(log *types.Log) {
 }
 
 func (s *stateDbAdapter) AddPreimage(common.Hash, []byte) {
-	panic("should not be needed for a single contract execution")
+	panic("should not be needed in test environments")
 }
 
 func (s *stateDbAdapter) ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error {
-	panic("should not be needed for a single contract execution")
+	panic("should not be needed in test environments")
 }

--- a/go/vm/test/dynamic_gas.go
+++ b/go/vm/test/dynamic_gas.go
@@ -726,7 +726,10 @@ func gasDynCreate(revision Revision, isCreate2 bool) []*DynGasTest {
 		// code_deposit_cost
 		expectedGas += vm.Gas(200 * returnSize)
 
-		mockCalls := func(mock *MockStateDB) {}
+		mockCalls := func(mock *MockStateDB) {
+			mock.EXPECT().AccessAccount(gomock.Any()).AnyTimes()
+			mock.EXPECT().GetCodeHash(gomock.Any()).AnyTimes()
+		}
 		// Append test
 		testCases = append(testCases, &DynGasTest{testName, stackValues, expectedGas, 0, mockCalls, memValues})
 	}

--- a/go/vm/test/integration_test.go
+++ b/go/vm/test/integration_test.go
@@ -1073,7 +1073,7 @@ func getRadomByte32() []byte {
 func setDefaultCallStateDBMock(mockStateDB *MockStateDB, account vm.Address, code []byte) {
 	// mock state calls for call instruction
 	mockStateDB.EXPECT().GetBalance(gomock.Any()).AnyTimes().Return(vm.Value{1})
-	mockStateDB.EXPECT().GetCodeHash(account).AnyTimes().Return(vm.Hash{})
+	mockStateDB.EXPECT().GetCodeHash(gomock.Any()).AnyTimes().Return(vm.Hash{})
 	mockStateDB.EXPECT().GetCode(account).AnyTimes().Return(code)
 	mockStateDB.EXPECT().IsAddressInAccessList(account).AnyTimes().Return(true)
 	mockStateDB.EXPECT().EmitLog(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()

--- a/go/vm/test/test_config.go
+++ b/go/vm/test/test_config.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	Variants = []string{
-		//"geth", // TODO: reenable once the geth EVM dependency is resolved
+		"geth",
 		"lfvm",
 		"lfvm-si",
 		"lfvm-no-sha-cache",

--- a/go/vm/test/verify_gas_test.go
+++ b/go/vm/test/verify_gas_test.go
@@ -300,7 +300,9 @@ func getCallInstructionGas(t *testing.T, revision Revision, callCode []byte) vm.
 	}
 	mockCtrl := gomock.NewController(t)
 	mockStateDB := NewMockStateDB(mockCtrl)
+	mockStateDB.EXPECT().AccountExists(account).AnyTimes().Return(true)
 	mockStateDB.EXPECT().GetCode(account).AnyTimes().Return(callCode)
+	mockStateDB.EXPECT().GetCodeHash(account).AnyTimes()
 	mockStateDB.EXPECT().IsAddressInAccessList(account).AnyTimes().Return(true)
 
 	// Minimum stack values to execute CALL instruction


### PR DESCRIPTION
This PR re-enables test coverage for `geth`s interpreter implementation in the integration tests.

Support was disabled by #311 as it was unclear which version of `geth` should be supported in the near future. Right now, it seems like we will stick with the current version for some time, so test coverage is to be reenabled.