### PR TITLE
Fix std::min issue on Mac.

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -1617,7 +1617,7 @@ struct CallImpl {
     ctx.return_data.assign(result.output_data, result.output_data + result.output_size);
 
     if (ctx.return_data.size() > 0) {
-      auto size = std::min(output_size, ctx.return_data.size());
+      auto size = std::min<uint64_t>(output_size, ctx.return_data.size());
       ctx.memory.ReadFromWithSize(ctx.return_data, output_offset, size);
     }
 


### PR DESCRIPTION
This PR fixes issue with `Min` func on MacBook, which is not recognized without this fix.