### PR TITLE
Specification Map Datastructure

### DIFF
--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -22,6 +22,10 @@ type Specification interface {
 	GetRulesFor(*st.State) []Rule
 }
 
+var Spec = func() Specification {
+	return NewSpecificationMap(getAllRules()...)
+}()
+
 // instruction holds the basic information for the 4 basic rules
 // these are not enough gas, stack overflow, stack underflow, and a regular behavior case
 type instruction struct {

--- a/go/ct/spc/specification_map.go
+++ b/go/ct/spc/specification_map.go
@@ -13,11 +13,6 @@ type specificationMap struct {
 	rules map[string][]Rule
 }
 
-var Spec = func() Specification {
-	rules := getAllRules()
-	return NewSpecificationMap(rules...)
-}()
-
 func (s *specificationMap) GetRules() []Rule {
 	// allocating space for 5 rules per rule, checked with GetAllRules benchmark
 	allRules := make([]Rule, 0, len(s.rules)*5)

--- a/go/ct/spc/specification_test.go
+++ b/go/ct/spc/specification_test.go
@@ -145,6 +145,9 @@ func TestSpecification_OperationNotExecutedIfNotRunning(t *testing.T) {
 			statusString := strings.TrimPrefix(substring[0][0], "status = ")
 
 			if statusString != "running" && !slices.Contains(knownNoOps, rule.Name) {
+				if ruleToOpString(rule) != "noOp" {
+					t.Errorf("Rule has code operation constrain but no status")
+				}
 				t.Errorf("Rule is not an operation but not in list of known no operations")
 			}
 		} else {


### PR DESCRIPTION
This PR changes the specification data structure from a list to a map with operation names as keys. Rather then checking all rules if they fit a given input state, only the ones with the correct operation are checked. For terminal state and failure rules a `noOp` key is introduced.

These changes improved the `getRulesFor(state)` as follows:
```
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Tosca/go/ct/spc
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
                         │   old.txt   │               new.txt                │
                         │   sec/op    │    sec/op     vs base                │
Specification_GetState-8   42.95µ ± 5%   26.91µ ± 13%  -37.36% (p=0.000 n=10)

                         │   old.txt    │            new.txt             │
                         │     B/op     │     B/op      vs base          │
Specification_GetState-8   22.72Ki ± 0%   22.72Ki ± 0%  ~ (p=0.926 n=10)

                         │  old.txt   │              new.txt              │
                         │ allocs/op  │ allocs/op   vs base               │
Specification_GetState-8   44.00 ± 0%   45.00 ± 0%  +2.27% (p=0.000 n=10)
```