### PR TITLE
CT: returnData type to Bytes

### DIFF
--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -387,12 +387,9 @@ func (g *StateGenerator) Generate(rnd *rand.Rand) (*st.State, error) {
 	resultLastCallReturnData := RandomBytes(rnd, st.MaxDataSize)
 
 	// Generate return data for terminal states.
-	var resultReturnData []byte
+	var resultReturnData Bytes
 	if resultStatus == st.Stopped || resultStatus == st.Reverted {
-		resultReturnData, err = getRandomData(rnd)
-		if err != nil {
-			return nil, err
-		}
+		resultReturnData = RandomBytes(rnd, st.MaxDataSize)
 	}
 
 	// Sub-generators can modify the assignment when unassigned variables are

--- a/go/ct/gen/state_test.go
+++ b/go/ct/gen/state_test.go
@@ -415,7 +415,7 @@ func TestStateGenerator_DataGeneration(t *testing.T) {
 
 func TestStateGenerator_ReturnDataShouldBeEmpty(t *testing.T) {
 	state := genRandomState(t)
-	if want, got := 0, len(state.ReturnData); want != got {
+	if want, got := 0, state.ReturnData.Length(); want != got {
 		t.Errorf("unexpected length of generated return data, wanted %d, got %d", want, got)
 	}
 }

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -1,7 +1,6 @@
 package spc
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 
@@ -96,7 +95,7 @@ func getAllRules() []Rule {
 		),
 		Effect: Change(func(s *st.State) {
 			s.Status = st.Stopped
-			s.ReturnData = nil // nothing is returned by stop
+			s.ReturnData = Bytes{}
 			s.Pc++
 		}),
 	})
@@ -1299,7 +1298,7 @@ func getAllRules() []Rule {
 			}
 			s.Gas -= expansionCost
 
-			s.ReturnData = bytes.Clone(s.Memory.Read(offset, size))
+			s.ReturnData = NewBytes(s.Memory.Read(offset, size))
 			s.Status = st.Stopped
 		},
 	})...)
@@ -1326,7 +1325,7 @@ func getAllRules() []Rule {
 			}
 			s.Gas -= expansionCost
 
-			s.ReturnData = bytes.Clone(s.Memory.Read(offset, size))
+			s.ReturnData = NewBytes(s.Memory.Read(offset, size))
 			s.Status = st.Reverted
 		},
 	})...)

--- a/go/ct/st/serialization.go
+++ b/go/ct/st/serialization.go
@@ -130,7 +130,7 @@ func newStateSerializableFromState(state *State) *stateSerializable {
 		BlockContext:       state.BlockContext,
 		CallData:           state.CallData.ToBytes(),
 		LastCallReturnData: state.LastCallReturnData.ToBytes(),
-		ReturnData:         bytes.Clone(state.ReturnData),
+		ReturnData:         state.ReturnData.ToBytes(),
 		CallJournal:        state.CallJournal,
 	}
 }
@@ -206,7 +206,7 @@ func (s *stateSerializable) deserialize() *State {
 	state.BlockContext = s.BlockContext
 	state.CallData = NewBytes(s.CallData)
 	state.LastCallReturnData = NewBytes(s.LastCallReturnData)
-	state.ReturnData = bytes.Clone(s.ReturnData)
+	state.ReturnData = NewBytes(s.ReturnData)
 	if s.CallJournal != nil {
 		state.CallJournal = s.CallJournal.Clone()
 	}

--- a/go/ct/st/state_test.go
+++ b/go/ct/st/state_test.go
@@ -617,8 +617,8 @@ func TestState_StatusCodeUnmarshalError(t *testing.T) {
 }
 
 func TestState_EqualConsidersReturnDataOnlyWhenStoppedOrReverted(t *testing.T) {
-	dataValue := make([]byte, 1)
-	dataValue[0]++
+	dataValue1 := []byte{1}
+	dataValue2 := []byte{2}
 	tests := map[string]struct {
 		status StatusCode
 		wanted bool
@@ -633,9 +633,9 @@ func TestState_EqualConsidersReturnDataOnlyWhenStoppedOrReverted(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			s1 := getNewFilledState()
 			s1.Status = test.status
-			s1.ReturnData = dataValue
+			s1.ReturnData = NewBytes(dataValue1)
 			s2 := s1.Clone()
-			s2.ReturnData[0]++
+			s2.ReturnData = NewBytes(dataValue2)
 			if want, got := test.wanted, s1.Eq(s2); want != got {
 				t.Errorf("unexpected equality result, wanted %t, got %t", want, got)
 			}
@@ -730,7 +730,7 @@ func TestState_EqualityConsidersRelevantFieldsDependingOnStatus(t *testing.T) {
 			relevantFor: onlyRunning,
 		},
 		"return_data": {
-			modify:      func(s *State) { s.ReturnData = []byte{1, 2, 3} },
+			modify:      func(s *State) { s.ReturnData = NewBytes([]byte{1, 2, 3}) },
 			relevantFor: []StatusCode{Stopped, Reverted},
 		},
 	}

--- a/go/vm/evmc/evmc_steppable_interpreter.go
+++ b/go/vm/evmc/evmc_steppable_interpreter.go
@@ -84,7 +84,7 @@ func (e *SteppableEvmcInterpreter) StepN(
 	}
 
 	if result.StepStatusCode == evmc.Returned || result.StepStatusCode == evmc.Reverted {
-		state.ReturnData = result.Output
+		state.ReturnData = common.NewBytes(result.Output)
 	}
 	state.Pc = uint16(result.Pc)
 	state.Gas = vm.Gas(result.GasLeft)

--- a/go/vm/geth/ct.go
+++ b/go/vm/geth/ct.go
@@ -89,7 +89,7 @@ func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 		// local check is performed to determine whether the result should be
 		// copied or not.
 		if !isStopInstruction {
-			state.ReturnData = interpreterState.Result
+			state.ReturnData = common.NewBytes(interpreterState.Result)
 		}
 	}
 	return state, nil

--- a/go/vm/lfvm/ct.go
+++ b/go/vm/lfvm/ct.go
@@ -106,7 +106,7 @@ func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 	state.GasRefund = ctxt.refund
 	state.Stack = convertLfvmStackToCtStack(ctxt.stack)
 	state.Memory = convertLfvmMemoryToCtMemory(ctxt.memory)
-	state.ReturnData = result
+	state.ReturnData = common.NewBytes(result)
 	state.LastCallReturnData = common.NewBytes(ctxt.return_data)
 
 	return state, nil


### PR DESCRIPTION
This PR changes the type of the ct state's `returnData` to the immutable `Bytes`

This PR is part of #365 and depends on #400