### PR TITLE
CT: byteSliceSereializable to Bytes

### DIFF
--- a/go/ct/st/serialization_integration_test.go
+++ b/go/ct/st/serialization_integration_test.go
@@ -39,3 +39,26 @@ func TestSerialization_EndToEndTest(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkSerliazation_EndToEnd(b *testing.B) {
+	rnd := rand.New(0)
+	gen := gen.NewStateGenerator()
+
+	for i := 0; i < b.N; i++ {
+		state, err := gen.Generate(rnd)
+		if err != nil {
+			b.Fatalf("failed to generate random state: %v", err)
+		}
+
+		path := filepath.Join(b.TempDir(), "state.json")
+		if err := st.ExportStateJSON(state, path); err != nil {
+			b.Fatalf("failed to write state to file: %v", err)
+		}
+
+		_, err = st.ImportStateJSON(path)
+		if err != nil {
+			b.Fatalf("failed to read state from file: %v", err)
+		}
+	}
+
+}


### PR DESCRIPTION
This PR changes the type of byteeSliceSerializable to Bytes.
it also adds a benchmark for end to end serialization, which shows the following results before and after the change of type:

```
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
                         │ serialization.oldd │       serialization.new        │
                         │       sec/op       │    sec/op     vs base          │
Serliazation_EndToEnd-16         15.83m ± 26%   13.39m ± 28%  ~ (p=0.529 n=10)

                         │ serialization.oldd │          serialization.new          │
                         │        B/op        │     B/op      vs base               │
Serliazation_EndToEnd-16         16.13Mi ± 0%   16.14Mi ± 0%  +0.03% (p=0.000 n=10)

                         │ serialization.oldd │         serialization.new          │
                         │     allocs/op      │  allocs/op   vs base               │
Serliazation_EndToEnd-16          133.3k ± 0%   133.3k ± 0%  +0.01% (p=0.000 n=10)
```

contributes to #365 