### PR TITLE
Add support for static-call semantic in CALL op specification

### DIFF
--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -1346,136 +1346,7 @@ func getAllRules() []Rule {
 
 	// --- CALL ---
 
-	// NOTE: this rule only covers the non-static Istanbul case in a coarse-grained
-	// way. Follow-work is required to cover other revisions and situations, as well
-	// as special cases currently covered in the effect function.
-	rules = append(rules, rulesFor(instruction{
-		op:        CALL,
-		name:      "_non_static_istanbul",
-		staticGas: 700,
-		pops:      7,
-		pushes:    1,
-		conditions: []Condition{
-			Eq(ReadOnly(), false),
-			IsRevision(R07_Istanbul),
-		},
-		parameters: []Parameter{
-			GasParameter{},
-			AddressParameter{},
-			ValueParameter{},
-			MemoryOffsetParameter{},
-			MemorySizeParameter{},
-			MemoryOffsetParameter{},
-			MemorySizeParameter{},
-		},
-		effect: func(s *st.State) {
-			gas := s.Stack.Pop()
-			target := s.Stack.Pop()
-			value := s.Stack.Pop()
-			argsOffset := s.Stack.Pop()
-			argsSize := s.Stack.Pop()
-			retOffset := s.Stack.Pop()
-			retSize := s.Stack.Pop()
-
-			// --- check preconditions ---
-
-			// No value transfer in a read-only context.
-			if s.ReadOnly && !value.IsZero() {
-				s.Status = st.Failed
-				return
-			}
-
-			// --- dynamic costs ---
-
-			// Compute the memory expansion costs of this call.
-			inputMemoryExpansionCost, argsOffset64, argsSize64 := s.Memory.ExpansionCosts(argsOffset, argsSize)
-			outputMemoryExpansionCost, retOffset64, retSize64 := s.Memory.ExpansionCosts(retOffset, retSize)
-			memoryExpansionCost := inputMemoryExpansionCost
-			if memoryExpansionCost < outputMemoryExpansionCost {
-				memoryExpansionCost = outputMemoryExpansionCost
-			}
-
-			// Compute the value transfer costs.
-			positiveValueCost := vm.Gas(0)
-			if !value.IsZero() {
-				positiveValueCost = 9000
-			}
-
-			// If an account is implicitly created, this costs extra.
-			valueToEmptyAccountCost := vm.Gas(0)
-			if !value.IsZero() && s.Accounts.IsEmpty(target.Bytes20be()) {
-				valueToEmptyAccountCost = 25000
-			}
-
-			// Deduct the gas costs for this call, except the costs for the recursive call.
-			dynamicGas, overflow := sumWithOverflow(memoryExpansionCost, positiveValueCost, valueToEmptyAccountCost)
-			if s.Gas < dynamicGas || overflow {
-				s.Status = st.Failed
-				return
-			}
-			s.Gas -= dynamicGas
-
-			// Grow the memory for which gas has just been deducted.
-			s.Memory.Grow(argsOffset64, argsSize64)
-			s.Memory.Grow(retOffset64, retSize64)
-
-			// Compute the gas provided to the nested call.
-			limit := s.Gas - s.Gas/64
-			endowment := limit
-			if gas.IsUint64() && gas.Uint64() < uint64(endowment) {
-				endowment = vm.Gas(gas.Uint64())
-			}
-
-			// If value is transferred, a stipend is granted.
-			stipend := vm.Gas(0)
-			if !value.IsZero() {
-				stipend = 2300
-			}
-			s.Gas += stipend
-
-			// Read the input from the call from memory.
-			input := s.Memory.Read(argsOffset64, argsSize64)
-
-			// --- call execution ---
-
-			// Check that the caller has enough balance to transfer the requested value.
-			if !value.IsZero() {
-				balance := s.Accounts.GetBalance(s.CallContext.AccountAddress)
-				if balance.Lt(value) {
-					s.Stack.Push(NewU256(0))
-					s.LastCallReturnData = Bytes{}
-					return
-				}
-			}
-
-			// Execute the call.
-			res := s.CallJournal.Call(vm.Call, vm.CallParameter{
-				Sender:    s.CallContext.AccountAddress,
-				Recipient: target.Bytes20be(),
-				Value:     value.Bytes32be(),
-				Gas:       endowment + stipend,
-				Input:     input,
-			})
-
-			// Process the result.
-			if retSize64 > 0 {
-				output := res.Output
-				if len(output) > int(retSize64) {
-					output = output[0:retSize64]
-				}
-				s.Memory.Write(output, retOffset64)
-			}
-
-			s.Gas -= endowment + stipend - res.GasLeft // < the costs for the code execution
-			s.GasRefund += res.GasRefund
-			s.LastCallReturnData = NewBytes(res.Output)
-			if res.Success {
-				s.Stack.Push(NewU256(1))
-			} else {
-				s.Stack.Push(NewU256(0))
-			}
-		},
-	})...)
+	rules = append(rules, callOp()...)
 
 	// --- End ---
 
@@ -1905,19 +1776,204 @@ func rulesFor(i instruction) []Rule {
 		Le(StackSize(), st.MaxStackSize-(max(i.pushes-i.pops, 0))),
 	)
 
-	res = append(res, []Rule{
-		{
-			Name:      fmt.Sprintf("%s_regular%v", strings.ToLower(i.op.String()), i.name),
-			Condition: And(localConditions...),
-			Parameter: i.parameters,
-			Effect: Change(func(s *st.State) {
-				s.Gas -= i.staticGas
-				s.Pc++
-				i.effect(s)
-			}),
-		},
-	}...)
+	res = append(res, Rule{
+		Name:      fmt.Sprintf("%s_regular%v", strings.ToLower(i.op.String()), i.name),
+		Condition: And(localConditions...),
+		Parameter: i.parameters,
+		Effect: Change(func(s *st.State) {
+			s.Gas -= i.staticGas
+			s.Pc++
+			i.effect(s)
+		}),
+	})
 	return res
+}
+
+func callOp() []Rule {
+	res := []Rule{}
+	// NOTE: this rule only covers Istanbul case in a coarse-grained way.
+	// Follow-work is required to cover other revisions and situations,
+	// as well as special cases currently covered in the effect function.
+	res = append(res, callOpIstanbul()...)
+	return res
+}
+
+func callOpIstanbul() []Rule {
+	instruction := instruction{
+		op:        CALL,
+		name:      "_istanbul",
+		staticGas: 700,
+		pops:      7,
+		pushes:    1,
+	}
+
+	isCallWithSufficientGasAndStack := And(
+		IsRevision(R07_Istanbul),
+		Eq(Status(), st.Running),
+		Eq(Op(Pc()), CALL),
+		Ge(Gas(), instruction.staticGas),
+		Ge(StackSize(), instruction.pops),
+		Le(StackSize(), st.MaxStackSize-(instruction.pushes-instruction.pops)),
+	)
+
+	parameters := []Parameter{
+		GasParameter{},
+		AddressParameter{},
+		ValueParameter{},
+		MemoryOffsetParameter{},
+		MemorySizeParameter{},
+		MemoryOffsetParameter{},
+		MemorySizeParameter{},
+	}
+
+	performsCall := Change(func(s *st.State) {
+		s.Gas -= instruction.staticGas
+		s.Pc++
+		callEffectIstanbul(s)
+	})
+
+	res := []Rule{}
+	res = append(res, tooLittleGas(instruction)...)
+	res = append(res, tooFewElements(instruction)...)
+
+	res = append(res, Rule{
+		Name: "call_istanbul_not_static",
+		Condition: And(
+			isCallWithSufficientGasAndStack,
+			Eq(ReadOnly(), false),
+		),
+		Parameter: parameters,
+		Effect:    performsCall,
+	})
+
+	res = append(res, Rule{
+		Name: "call_istanbul_static_no_value",
+		Condition: And(
+			isCallWithSufficientGasAndStack,
+			Eq(ReadOnly(), true),
+			Eq(Param(2), NewU256(0)),
+		),
+		Parameter: parameters,
+		Effect:    performsCall,
+	})
+
+	res = append(res, Rule{
+		Name: "call_istanbul_static_with_value",
+		Condition: And(
+			isCallWithSufficientGasAndStack,
+			Eq(ReadOnly(), true),
+			Ne(Param(2), NewU256(0)),
+		),
+		Effect: FailEffect(),
+	})
+
+	return res
+}
+
+func callEffectIstanbul(s *st.State) {
+	gas := s.Stack.Pop()
+	target := s.Stack.Pop()
+	value := s.Stack.Pop()
+	argsOffset := s.Stack.Pop()
+	argsSize := s.Stack.Pop()
+	retOffset := s.Stack.Pop()
+	retSize := s.Stack.Pop()
+
+	// --- dynamic costs ---
+
+	// Compute the memory expansion costs of this call.
+	inputMemoryExpansionCost, argsOffset64, argsSize64 := s.Memory.ExpansionCosts(argsOffset, argsSize)
+	outputMemoryExpansionCost, retOffset64, retSize64 := s.Memory.ExpansionCosts(retOffset, retSize)
+	memoryExpansionCost := inputMemoryExpansionCost
+	if memoryExpansionCost < outputMemoryExpansionCost {
+		memoryExpansionCost = outputMemoryExpansionCost
+	}
+
+	// Compute the value transfer costs.
+	positiveValueCost := vm.Gas(0)
+	if !value.IsZero() {
+		positiveValueCost = 9000
+	}
+
+	// If an account is implicitly created, this costs extra.
+	valueToEmptyAccountCost := vm.Gas(0)
+	if !value.IsZero() && s.Accounts.IsEmpty(target.Bytes20be()) {
+		valueToEmptyAccountCost = 25000
+	}
+
+	// Deduct the gas costs for this call, except the costs for the recursive call.
+	dynamicGas, overflow := sumWithOverflow(memoryExpansionCost, positiveValueCost, valueToEmptyAccountCost)
+	if s.Gas < dynamicGas || overflow {
+		s.Status = st.Failed
+		return
+	}
+	s.Gas -= dynamicGas
+
+	// Grow the memory for which gas has just been deducted.
+	s.Memory.Grow(argsOffset64, argsSize64)
+	s.Memory.Grow(retOffset64, retSize64)
+
+	// Compute the gas provided to the nested call.
+	limit := s.Gas - s.Gas/64
+	endowment := limit
+	if gas.IsUint64() && gas.Uint64() < uint64(endowment) {
+		endowment = vm.Gas(gas.Uint64())
+	}
+
+	// If value is transferred, a stipend is granted.
+	stipend := vm.Gas(0)
+	if !value.IsZero() {
+		stipend = 2300
+	}
+	s.Gas += stipend
+
+	// Read the input from the call from memory.
+	input := s.Memory.Read(argsOffset64, argsSize64)
+
+	// --- call execution ---
+
+	// Check that the caller has enough balance to transfer the requested value.
+	if !value.IsZero() {
+		balance := s.Accounts.GetBalance(s.CallContext.AccountAddress)
+		if balance.Lt(value) {
+			s.Stack.Push(NewU256(0))
+			s.LastCallReturnData = Bytes{}
+			return
+		}
+	}
+
+	// In a static context all calls are static calls.
+	kind := vm.Call
+	if s.ReadOnly {
+		kind = vm.StaticCall
+	}
+
+	// Execute the call.
+	res := s.CallJournal.Call(kind, vm.CallParameter{
+		Sender:    s.CallContext.AccountAddress,
+		Recipient: target.Bytes20be(),
+		Value:     value.Bytes32be(),
+		Gas:       endowment + stipend,
+		Input:     input,
+	})
+
+	// Process the result.
+	if retSize64 > 0 {
+		output := res.Output
+		if len(output) > int(retSize64) {
+			output = output[0:retSize64]
+		}
+		s.Memory.Write(output, retOffset64)
+	}
+
+	s.Gas -= endowment + stipend - res.GasLeft // < the costs for the code execution
+	s.GasRefund += res.GasRefund
+	s.LastCallReturnData = NewBytes(res.Output)
+	if res.Success {
+		s.Stack.Push(NewU256(1))
+	} else {
+		s.Stack.Push(NewU256(0))
+	}
 }
 
 func sumWithOverflow(values ...vm.Gas) (vm.Gas, bool) {


### PR DESCRIPTION
This PR adds support for static contexts to the CALL expression specification.

This contributes to #380 

Todo:
- [x] check on all EVM implementations
- [x] assess impact on execution time of tests