### PR TITLE
Add sub-command to list rule generation information

### DIFF
--- a/go/ct/driver/generator_info.go
+++ b/go/ct/driver/generator_info.go
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the GNU Lesser General Public Licence v3
+//
+
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/Fantom-foundation/Tosca/go/ct/rlz"
+	"github.com/Fantom-foundation/Tosca/go/ct/spc"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/exp/maps"
+)
+
+var GeneratorInfoCmd = cli.Command{
+	Action: doListGeneratorInfo,
+	Name:   "generator-info",
+	Usage:  "Lists details on the number of test cases produced per rule",
+}
+
+func doListGeneratorInfo(context *cli.Context) error {
+	rules := spc.Spec.GetRules()
+
+	infos := map[string]rlz.TestCaseEnumerationInfo{}
+	for _, rule := range rules {
+		infos[rule.Name] = rule.GetTestCaseEnumerationInfo()
+	}
+
+	names := maps.Keys(infos)
+	sort.Slice(names, func(i, j int) bool {
+		infoA := infos[names[i]]
+		infoB := infos[names[j]]
+		return infoA.TotalNumberOfCases() < infoB.TotalNumberOfCases()
+	})
+
+	total := 0
+	for _, info := range infos {
+		total += info.TotalNumberOfCases()
+	}
+
+	for _, name := range names {
+		info := infos[name]
+		fmt.Printf("----- Rule: %s -----\n%v", name, &info)
+		numCases := info.TotalNumberOfCases()
+		fmt.Printf("Share of total rules: %.1f%%\n\n", (float32(numCases)/float32(total))*100)
+	}
+	fmt.Printf("Total number of tests: %d\n", total)
+	return nil
+}

--- a/go/ct/driver/main.go
+++ b/go/ct/driver/main.go
@@ -26,6 +26,7 @@ func main() {
 		Copyright: "(c) 2023 Fantom Foundation",
 		Flags:     []cli.Flag{},
 		Commands: []*cli.Command{
+			&GeneratorInfoCmd,
 			&ListCmd,
 			&RegressionsCmd,
 			&RunCmd,


### PR DESCRIPTION
This PR adds a sub-command to the CT driver providing insights into the factors contributing to the number of test cases generated from each rule. An example is shown here:
```
----- Rule: extcodecopy_regular_cold -----
Conditions:
	Gas ≥ 2600: 8
	code[PC] = EXTCODECOPY: 2
	cold(param[0]): 2
	revision(Berlin-UnknownNextRevision): 4
	revision(Istanbul-London): 4
	stackSize ≤ 1024: 4
	stackSize ≥ 4: 5
	status = running: 4
Parameters:
	0: 2
	1: 5
	2: 5
	3: 5
Total number of cases: 10240000
Share of total rules: 1.0%
```
The intention of this utility is to aid the tuning of the test case generation process.