### PR TITLE
CT: reduce make+copy pattern

### DIFF
--- a/go/ct/common/slices.go
+++ b/go/ct/common/slices.go
@@ -1,0 +1,17 @@
+package common
+
+func RightPadSlice[T any](source []T, size int) []T {
+	res := make([]T, size)
+	copy(res, source)
+	return res
+}
+
+func LeftPadSlice[T any](source []T, size int) []T {
+	res := make([]T, size)
+	if size < len(source) {
+		copy(res, source)
+	} else {
+		copy(res[size-len(source):], source)
+	}
+	return res
+}

--- a/go/ct/common/slices.go
+++ b/go/ct/common/slices.go
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the GNU Lesser General Public Licence v3
+//
+
 package common
 
 func RightPadSlice[T any](source []T, size int) []T {

--- a/go/ct/common/slices_test.go
+++ b/go/ct/common/slices_test.go
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the GNU Lesser General Public Licence v3
+//
+
 package common
 
 import (

--- a/go/ct/common/slices_test.go
+++ b/go/ct/common/slices_test.go
@@ -1,0 +1,42 @@
+package common
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestSlices_RightPadSlice(t *testing.T) {
+	base := []int{1, 2, 3}
+	tests := map[string]struct {
+		length int
+		want   []int
+	}{
+		"longer":  {length: 5, want: []int{1, 2, 3, 0, 0}},
+		"shorter": {length: 1, want: base[:1]},
+		"equal":   {length: len(base), want: base},
+	}
+
+	for name, test := range tests {
+		if got := RightPadSlice(base, test.length); !slices.Equal(test.want, got) {
+			t.Errorf("Right padding for %v failed, wanted %v, but got %v", name, test.want, got)
+		}
+	}
+}
+
+func TestSlices_LeftPadSlice(t *testing.T) {
+	base := []int{1, 2, 3}
+	tests := map[string]struct {
+		length int
+		want   []int
+	}{
+		"longer":  {length: 5, want: []int{0, 0, 1, 2, 3}},
+		"shorter": {length: 1, want: base[:1]},
+		"equal":   {length: len(base), want: base},
+	}
+
+	for name, test := range tests {
+		if got := LeftPadSlice(base, test.length); !slices.Equal(test.want, got) {
+			t.Errorf("Right padding for %v failed, wanted %v, but got %v", name, test.want, got)
+		}
+	}
+}

--- a/go/ct/gen/stack.go
+++ b/go/ct/gen/stack.go
@@ -22,7 +22,6 @@ import (
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
-	"github.com/Fantom-foundation/Tosca/go/ct/utils"
 )
 
 type StackGenerator struct {
@@ -95,7 +94,9 @@ func (g *StackGenerator) BindValue(pos int, variable Variable) {
 }
 
 func (g *StackGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Stack, error) {
-	constraints := utils.RightPadSliceWithCap(g.constValues, int64(len(g.constValues)), int64(len(g.constValues)+len(g.varValues)))
+	// convert variable constraints to constant constraints
+	constraints := make([]constValueConstraint, len(g.constValues), len(g.constValues)+len(g.varValues))
+	copy(constraints, g.constValues)
 
 	for _, cur := range g.varValues {
 		value, found := assignment[cur.variable]

--- a/go/ct/gen/stack.go
+++ b/go/ct/gen/stack.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
+	"github.com/Fantom-foundation/Tosca/go/ct/utils"
 )
 
 type StackGenerator struct {
@@ -94,9 +95,8 @@ func (g *StackGenerator) BindValue(pos int, variable Variable) {
 }
 
 func (g *StackGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Stack, error) {
-	// convert variable constraints to constant constraints
-	constraints := make([]constValueConstraint, len(g.constValues), len(g.constValues)+len(g.varValues))
-	copy(constraints, g.constValues)
+	constraints := utils.RightPadSliceWithCap(g.constValues, int64(len(g.constValues)), int64(len(g.constValues)+len(g.varValues)))
+
 	for _, cur := range g.varValues {
 		value, found := assignment[cur.variable]
 		if !found {

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/ct/gen"
 	. "github.com/Fantom-foundation/Tosca/go/ct/rlz"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
+	"github.com/Fantom-foundation/Tosca/go/ct/utils"
 	"github.com/Fantom-foundation/Tosca/go/vm"
 )
 
@@ -1177,8 +1178,7 @@ func getAllRules() []Rule {
 					start = uint64(len)
 				}
 				end := min(start+32, uint64(len))
-				data := make([]byte, 32)
-				copy(data, s.CallData.Get(start, end))
+				data := utils.RightPadSlice(s.CallData.Get(start, end), 32)
 				pushData = NewU256FromBytes(data...)
 			}
 
@@ -1212,14 +1212,13 @@ func getAllRules() []Rule {
 			}
 			s.Gas -= expansionCost
 
-			dataBuffer := make([]byte, size)
 			start := offsetU256.Uint64()
 			len := s.CallData.Length()
 			if offsetU256.Gt(NewU256(uint64(len))) {
 				start = uint64(len)
 			}
 			end := min(start+size, uint64(len))
-			copy(dataBuffer, s.CallData.Get(start, end))
+			dataBuffer := utils.RightPadSlice(s.CallData.Get(start, end), int64(size))
 			s.Memory.Write(dataBuffer, destOffset)
 		},
 	})...)
@@ -1643,8 +1642,7 @@ func extCodeCopyEffect(s *st.State, markWarm bool) {
 	}
 	end := min(start+size, codeSize)
 
-	codeCopy := make([]byte, size)
-	copy(codeCopy, s.Accounts.GetCode(address).ToBytes()[start:end])
+	codeCopy := utils.RightPadSlice(s.Accounts.GetCode(address).ToBytes()[start:end], int64(size))
 
 	s.Memory.Write(codeCopy, destOffset)
 	if markWarm {

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -18,11 +18,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Fantom-foundation/Tosca/go/ct/common"
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/gen"
 	. "github.com/Fantom-foundation/Tosca/go/ct/rlz"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
-	"github.com/Fantom-foundation/Tosca/go/ct/utils"
 	"github.com/Fantom-foundation/Tosca/go/vm"
 )
 
@@ -1178,7 +1178,7 @@ func getAllRules() []Rule {
 					start = uint64(len)
 				}
 				end := min(start+32, uint64(len))
-				data := utils.RightPadSlice(s.CallData.Get(start, end), 32)
+				data := common.RightPadSlice(s.CallData.Get(start, end), 32)
 				pushData = NewU256FromBytes(data...)
 			}
 
@@ -1218,7 +1218,7 @@ func getAllRules() []Rule {
 				start = uint64(len)
 			}
 			end := min(start+size, uint64(len))
-			dataBuffer := utils.RightPadSlice(s.CallData.Get(start, end), int64(size))
+			dataBuffer := common.RightPadSlice(s.CallData.Get(start, end), int(size))
 			s.Memory.Write(dataBuffer, destOffset)
 		},
 	})...)
@@ -1642,7 +1642,7 @@ func extCodeCopyEffect(s *st.State, markWarm bool) {
 	}
 	end := min(start+size, codeSize)
 
-	codeCopy := utils.RightPadSlice(s.Accounts.GetCode(address).ToBytes()[start:end], int64(size))
+	codeCopy := common.RightPadSlice(s.Accounts.GetCode(address).ToBytes()[start:end], int(size))
 
 	s.Memory.Write(codeCopy, destOffset)
 	if markWarm {

--- a/go/ct/st/code.go
+++ b/go/ct/st/code.go
@@ -137,8 +137,8 @@ func (a *Code) Diff(b *Code) (res []string) {
 	return
 }
 
-func (c *Code) CopyTo(dst []byte) int {
-	return copy(dst, c.code)
+func (c *Code) Copy() []byte {
+	return bytes.Clone(c.code)
 }
 
 func (c *Code) String() string {

--- a/go/ct/st/code_test.go
+++ b/go/ct/st/code_test.go
@@ -105,7 +105,7 @@ func TestCode_GetData(t *testing.T) {
 	}
 }
 
-func TestCode_CopyTo(t *testing.T) {
+func TestCode_Copy(t *testing.T) {
 	src := []byte{byte(ADD), byte(PUSH1), 5, byte(PUSH2)}
 	code := NewCode(src)
 
@@ -114,9 +114,8 @@ func TestCode_CopyTo(t *testing.T) {
 	}
 
 	for i := 0; i < len(src); i++ {
-		dst := make([]byte, i)
-		if got := code.CopyCodeSlice(0, i, dst); got != i || !bytes.Equal(src[0:i], dst) {
-			t.Errorf("failed to copy data, expected %x, got %x, return %d", src[0:i], dst, i)
+		if got := code.Copy(); !bytes.Equal(src, got) {
+			t.Errorf("failed to copy data, expected %x, got %x", src, got)
 		}
 	}
 }

--- a/go/ct/st/code_test.go
+++ b/go/ct/st/code_test.go
@@ -13,7 +13,6 @@
 package st
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"slices"
@@ -101,22 +100,6 @@ func TestCode_GetData(t *testing.T) {
 	for _, i := range []int{0, 1, 3} {
 		if _, err := code.GetData(i); !errors.Is(err, ErrInvalidPosition) {
 			t.Errorf("unexpected error: %v", err)
-		}
-	}
-}
-
-func TestCode_CopyTo(t *testing.T) {
-	src := []byte{byte(ADD), byte(PUSH1), 5, byte(PUSH2)}
-	code := NewCode(src)
-
-	if got, want := code.Length(), len(src); got != want {
-		t.Errorf("unexpected code length, wanted %d, got %d", want, got)
-	}
-
-	for i := 0; i < len(src); i++ {
-		dst := make([]byte, i)
-		if got := code.CopyTo(dst); got != i || !bytes.Equal(src[0:i], dst) {
-			t.Errorf("failed to copy data, expected %x, got %x, return %d", src[0:i], dst, i)
 		}
 	}
 }

--- a/go/ct/st/code_test.go
+++ b/go/ct/st/code_test.go
@@ -13,6 +13,7 @@
 package st
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"slices"
@@ -100,6 +101,22 @@ func TestCode_GetData(t *testing.T) {
 	for _, i := range []int{0, 1, 3} {
 		if _, err := code.GetData(i); !errors.Is(err, ErrInvalidPosition) {
 			t.Errorf("unexpected error: %v", err)
+		}
+	}
+}
+
+func TestCode_CopyTo(t *testing.T) {
+	src := []byte{byte(ADD), byte(PUSH1), 5, byte(PUSH2)}
+	code := NewCode(src)
+
+	if got, want := code.Length(), len(src); got != want {
+		t.Errorf("unexpected code length, wanted %d, got %d", want, got)
+	}
+
+	for i := 0; i < len(src); i++ {
+		dst := make([]byte, i)
+		if got := code.CopyCodeSlice(0, i, dst); got != i || !bytes.Equal(src[0:i], dst) {
+			t.Errorf("failed to copy data, expected %x, got %x, return %d", src[0:i], dst, i)
 		}
 	}
 }

--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -189,3 +189,21 @@ func (c *ctRunContext) IsSlotInAccessList(addr vm.Address, key vm.Key) (addressP
 func (c *ctRunContext) HasSelfDestructed(addr vm.Address) bool {
 	panic("not implemented")
 }
+
+func RightPadSlice[T any](source []T, size int64) []T {
+	res := make([]T, size)
+	copy(res, source)
+	return res
+}
+
+func RightPadSliceWithCap[T any](source []T, len, cap int64) []T {
+	res := make([]T, len, cap)
+	copy(res, source)
+	return res
+}
+
+func LeftPadSlice[T any](source []T, size int64) []T {
+	res := make([]T, size)
+	copy(res[size-int64(len(source)):], source)
+	return res
+}

--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -31,8 +31,7 @@ func ToVmParameters(state *st.State) vm.Parameters {
 
 	var code []byte
 	if state.Code != nil {
-		code = make([]byte, state.Code.Length())
-		state.Code.CopyTo(code)
+		code = state.Code.Copy()
 	}
 
 	var revision vm.Revision

--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -189,21 +189,3 @@ func (c *ctRunContext) IsSlotInAccessList(addr vm.Address, key vm.Key) (addressP
 func (c *ctRunContext) HasSelfDestructed(addr vm.Address) bool {
 	panic("not implemented")
 }
-
-func RightPadSlice[T any](source []T, size int64) []T {
-	res := make([]T, size)
-	copy(res, source)
-	return res
-}
-
-func RightPadSliceWithCap[T any](source []T, len, cap int64) []T {
-	res := make([]T, len, cap)
-	copy(res, source)
-	return res
-}
-
-func LeftPadSlice[T any](source []T, size int64) []T {
-	res := make([]T, size)
-	copy(res[size-int64(len(source)):], source)
-	return res
-}

--- a/go/ct/utils/adapter_test.go
+++ b/go/ct/utils/adapter_test.go
@@ -321,7 +321,5 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 				t.Errorf("failed to verify property, wanted %v, got %v of type %v and %v", want, got, reflect.TypeOf(want), reflect.TypeOf(got))
 			}
 		})
-
 	}
-
 }

--- a/go/vm/lfvm/converter.go
+++ b/go/vm/lfvm/converter.go
@@ -22,8 +22,10 @@ import (
 
 	"github.com/Fantom-foundation/Tosca/go/vm"
 
+	"github.com/Fantom-foundation/Tosca/go/ct/utils"
 	// This is only imported to get the EVM opcode definitions.
 	// TODO: write up our own op-code definition and remove this dependency.
+
 	evm "github.com/ethereum/go-ethereum/core/vm"
 )
 
@@ -365,12 +367,10 @@ func appendInstructions(res *codeBuilder, pos int, code []byte, with_super_instr
 				ext++
 			}
 			if ext > 0 {
-				ins := make([]Instruction, len(res.code)+ext)
-				copy(ins, res.code[:])
+				ins := utils.RightPadSlice(res.code[:], int64(len(res.code)+ext))
 				res.code = ins
 			}
-			data = make([]byte, n+1)
-			copy(data, code[pos+1:])
+			data = utils.RightPadSlice(code[pos+1:], int64(n+1))
 		} else {
 			data = code[pos+1 : pos+1+n]
 		}

--- a/go/vm/lfvm/converter.go
+++ b/go/vm/lfvm/converter.go
@@ -20,9 +20,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/vm"
 
-	"github.com/Fantom-foundation/Tosca/go/ct/utils"
 	// This is only imported to get the EVM opcode definitions.
 	// TODO: write up our own op-code definition and remove this dependency.
 
@@ -367,10 +367,10 @@ func appendInstructions(res *codeBuilder, pos int, code []byte, with_super_instr
 				ext++
 			}
 			if ext > 0 {
-				ins := utils.RightPadSlice(res.code[:], int64(len(res.code)+ext))
+				ins := common.RightPadSlice(res.code[:], len(res.code)+ext)
 				res.code = ins
 			}
-			data = utils.RightPadSlice(code[pos+1:], int64(n+1))
+			data = common.RightPadSlice(code[pos+1:], n+1)
 		} else {
 			data = code[pos+1 : pos+1+n]
 		}

--- a/go/vm/lfvm/ct.go
+++ b/go/vm/lfvm/ct.go
@@ -144,8 +144,7 @@ func getPcMap(code *st.Code) (*PcMap, error) {
 	pcMap, ok := pcMapCache.data[code.Hash()]
 
 	if !ok {
-		byteCode := make([]byte, code.Length())
-		code.CopyTo(byteCode)
+		byteCode := code.Copy()
 		pcMap, err := GenPcMapWithoutSuperInstructions(byteCode)
 		if err != nil {
 			return nil, err

--- a/go/vm/test/integration_test.go
+++ b/go/vm/test/integration_test.go
@@ -21,6 +21,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/Fantom-foundation/Tosca/go/ct/utils"
 	"github.com/Fantom-foundation/Tosca/go/vm"
 	"github.com/holiman/uint256"
 	"go.uber.org/mock/gomock"
@@ -709,7 +710,7 @@ func TestNoReturnDataForCreate(t *testing.T) {
 						byte(geth.PUSH1), byte(0),
 						byte(test.returnInstruction)}
 
-					createInputBytes := rightPadBytes(createInputCode, 32)
+					createInputBytes := utils.RightPadSlice(createInputCode, 32)
 					createInputValue := []*big.Int{big.NewInt(0).SetBytes(createInputBytes)}
 
 					code, _ := addValuesToStack(createInputValue, 0)
@@ -971,13 +972,13 @@ func TestCallDataLoadInstructionInputOverflow(t *testing.T) {
 	sizeUint64, sizeOverUint64, sizeUint256 := getCornerSizeValues()
 
 	b := []byte{1}
-	input := leftPadBytes(b[:], 32)
+	input := utils.LeftPadSlice(b[:], 32)
 
 	tests := []overflowTestCase{
 		{"all zero", []*big.Int{big.NewInt(0), big.NewInt(0)}, zeroInput, big.NewInt(0), nil},
 		{"data input one", []*big.Int{big.NewInt(0), big.NewInt(0)}, input, big.NewInt(1), nil},
 		{"data input one, offset one", []*big.Int{big.NewInt(0), big.NewInt(1)}, input, big.NewInt(256), nil},
-		{"data input one, offset 31", []*big.Int{big.NewInt(0), big.NewInt(31)}, input, big.NewInt(0).SetBytes(rightPadBytes(b[:], 32)), nil},
+		{"data input one, offset 31", []*big.Int{big.NewInt(0), big.NewInt(31)}, input, big.NewInt(0).SetBytes(utils.RightPadSlice(b[:], 32)), nil},
 		{"data input one, offset 300", []*big.Int{big.NewInt(0), big.NewInt(300)}, input, big.NewInt(0), nil},
 		{"data input one, offset uint64", []*big.Int{big.NewInt(0), sizeUint64}, input, big.NewInt(0), nil},
 		{"data input one, offset over64", []*big.Int{big.NewInt(0), sizeOverUint64}, input, big.NewInt(0), nil},
@@ -991,7 +992,7 @@ func TestCallDataCopyInstructionInputOverflow(t *testing.T) {
 	_, sizeOverUint64, sizeUint256 := getCornerSizeValues()
 
 	b := []byte{1}
-	input := leftPadBytes(b[:], 32)
+	input := utils.LeftPadSlice(b[:], 32)
 
 	tests := []overflowTestCase{
 		{"all zero", []*big.Int{big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0)}, zeroInput, big.NewInt(0), nil},
@@ -1096,16 +1097,4 @@ func setDefaultCallStateDBMock(mockStateDB *MockStateDB, account vm.Address, cod
 	mockStateDB.EXPECT().IsSlotInAccessList(gomock.Any(), gomock.Any()).AnyTimes().Return(true, true)
 	mockStateDB.EXPECT().AccessAccount(gomock.Any()).AnyTimes().Return(vm.WarmAccess)
 	mockStateDB.EXPECT().AccessStorage(gomock.Any(), gomock.Any()).AnyTimes().Return(vm.WarmAccess)
-}
-
-func rightPadBytes(data []byte, size int) []byte {
-	res := make([]byte, size)
-	copy(res, data)
-	return res
-}
-
-func leftPadBytes(data []byte, size int) []byte {
-	res := make([]byte, size)
-	copy(res[size-len(data):], data)
-	return res
 }

--- a/go/vm/test/integration_test.go
+++ b/go/vm/test/integration_test.go
@@ -21,7 +21,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/Fantom-foundation/Tosca/go/ct/utils"
+	"github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/vm"
 	"github.com/holiman/uint256"
 	"go.uber.org/mock/gomock"
@@ -710,7 +710,7 @@ func TestNoReturnDataForCreate(t *testing.T) {
 						byte(geth.PUSH1), byte(0),
 						byte(test.returnInstruction)}
 
-					createInputBytes := utils.RightPadSlice(createInputCode, 32)
+					createInputBytes := common.RightPadSlice(createInputCode, 32)
 					createInputValue := []*big.Int{big.NewInt(0).SetBytes(createInputBytes)}
 
 					code, _ := addValuesToStack(createInputValue, 0)
@@ -972,13 +972,13 @@ func TestCallDataLoadInstructionInputOverflow(t *testing.T) {
 	sizeUint64, sizeOverUint64, sizeUint256 := getCornerSizeValues()
 
 	b := []byte{1}
-	input := utils.LeftPadSlice(b[:], 32)
+	input := common.LeftPadSlice(b[:], 32)
 
 	tests := []overflowTestCase{
 		{"all zero", []*big.Int{big.NewInt(0), big.NewInt(0)}, zeroInput, big.NewInt(0), nil},
 		{"data input one", []*big.Int{big.NewInt(0), big.NewInt(0)}, input, big.NewInt(1), nil},
 		{"data input one, offset one", []*big.Int{big.NewInt(0), big.NewInt(1)}, input, big.NewInt(256), nil},
-		{"data input one, offset 31", []*big.Int{big.NewInt(0), big.NewInt(31)}, input, big.NewInt(0).SetBytes(utils.RightPadSlice(b[:], 32)), nil},
+		{"data input one, offset 31", []*big.Int{big.NewInt(0), big.NewInt(31)}, input, big.NewInt(0).SetBytes(common.RightPadSlice(b[:], 32)), nil},
 		{"data input one, offset 300", []*big.Int{big.NewInt(0), big.NewInt(300)}, input, big.NewInt(0), nil},
 		{"data input one, offset uint64", []*big.Int{big.NewInt(0), sizeUint64}, input, big.NewInt(0), nil},
 		{"data input one, offset over64", []*big.Int{big.NewInt(0), sizeOverUint64}, input, big.NewInt(0), nil},
@@ -992,7 +992,7 @@ func TestCallDataCopyInstructionInputOverflow(t *testing.T) {
 	_, sizeOverUint64, sizeUint256 := getCornerSizeValues()
 
 	b := []byte{1}
-	input := utils.LeftPadSlice(b[:], 32)
+	input := common.LeftPadSlice(b[:], 32)
 
 	tests := []overflowTestCase{
 		{"all zero", []*big.Int{big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0)}, zeroInput, big.NewInt(0), nil},


### PR DESCRIPTION
This PR attempts to reduce the amount of times the pattern `make`+`copy` is called. replacing it by either `clone` or `PadSlice`.

This PR Fixes  #359 