### PR TITLE
Switch CI to github hosted resources

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,11 +16,26 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+
+    - uses: egor-tensin/setup-clang@v1
+      with:
+        version: 14
+
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v1.13
+      with:
+        cmake-version: '3.27.x'
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.21
+        cache: false
 
     - name: Check Go sources formatting
       working-directory: ./


### PR DESCRIPTION
This PR switches the CI testing for Go changes back to github hosted resources.