### PR TITLE
Make properties in test case enumeration explicit

### DIFF
--- a/go/ct/driver/run.go
+++ b/go/ct/driver/run.go
@@ -158,7 +158,7 @@ func doRun(context *cli.Context) error {
 
 	// Summarize the result.
 	if skippedCount.Load() > 0 {
-		fmt.Printf("Number of skipped tests: %d", skippedCount.Load())
+		fmt.Printf("Number of skipped tests: %d\n", skippedCount.Load())
 	}
 
 	if len(issues) == 0 {

--- a/go/ct/rlz/expressions.go
+++ b/go/ct/rlz/expressions.go
@@ -33,6 +33,7 @@ const (
 )
 
 type Expression[T any] interface {
+	Property() Property
 	Domain() Domain[T]
 
 	// Eval evaluates this expression on the given state.
@@ -66,6 +67,8 @@ func Status() Expression[st.StatusCode] {
 	return status{}
 }
 
+func (status) Property() Property { return Property("status") }
+
 func (status) Domain() Domain[st.StatusCode] { return statusCodeDomain{} }
 
 func (status) Eval(s *st.State) (st.StatusCode, error) {
@@ -91,6 +94,8 @@ type pc struct{}
 func Pc() BindableExpression[U256] {
 	return pc{}
 }
+
+func (pc) Property() Property { return Property("pc") }
 
 func (pc) Domain() Domain[U256] { return pcDomain{} }
 
@@ -129,6 +134,8 @@ func Gas() Expression[vm.Gas] {
 	return gas{}
 }
 
+func (gas) Property() Property { return Property("gas") }
+
 func (gas) Domain() Domain[vm.Gas] { return gasDomain{} }
 
 func (gas) Eval(s *st.State) (vm.Gas, error) {
@@ -159,6 +166,8 @@ func GasRefund() Expression[vm.Gas] {
 	return gasRefund{}
 }
 
+func (gasRefund) Property() Property { return Property("gasRefund") }
+
 func (gasRefund) Domain() Domain[vm.Gas] { return gasDomain{} }
 
 func (gasRefund) Eval(s *st.State) (vm.Gas, error) {
@@ -183,6 +192,8 @@ type readOnly struct{}
 func ReadOnly() Expression[bool] {
 	return readOnly{}
 }
+
+func (readOnly) Property() Property { return Property("readOnly") }
 
 func (readOnly) Domain() Domain[bool] { return boolDomain{} }
 
@@ -211,6 +222,8 @@ type op struct {
 func Op(position BindableExpression[U256]) Expression[OpCode] {
 	return op{position}
 }
+
+func (e op) Property() Property { return Property(e.String()) }
 
 func (op) Domain() Domain[OpCode] { return opCodeDomain{} }
 
@@ -253,6 +266,8 @@ func StackSize() Expression[int] {
 	return stackSize{}
 }
 
+func (stackSize) Property() Property { return Property("stackSize") }
+
 func (stackSize) Domain() Domain[int] { return stackSizeDomain{} }
 
 func (stackSize) Eval(s *st.State) (int, error) {
@@ -290,6 +305,8 @@ const ErrStackOutOfBoundsAccess = ConstErr("out-of-bounds stack access")
 func Param(pos int) BindableExpression[U256] {
 	return param{pos}
 }
+
+func (p param) Property() Property { return Property(p.String()) }
 
 func (param) Domain() Domain[U256] { return u256Domain{} }
 
@@ -333,6 +350,8 @@ type constant struct {
 func Constant(value U256) BindableExpression[U256] {
 	return constant{value}
 }
+
+func (constant) Property() Property { return Property("constant") }
 
 func (constant) Domain() Domain[U256] { return u256Domain{} }
 

--- a/go/ct/rlz/expressions_test.go
+++ b/go/ct/rlz/expressions_test.go
@@ -170,7 +170,7 @@ func TestExpression_GasConstraints(t *testing.T) {
 			random := rand.New()
 			hits := 0
 			misses := 0
-			test.condition.EnumerateTestCases(gen.NewStateGenerator(), func(g *gen.StateGenerator) ConsumerResult {
+			enumerateTestCases(test.condition, gen.NewStateGenerator(), func(g *gen.StateGenerator) ConsumerResult {
 				state, err := g.Generate(random)
 				if errors.Is(err, gen.ErrUnsatisfiable) {
 					return ConsumeContinue // ignored

--- a/go/ct/rlz/property.go
+++ b/go/ct/rlz/property.go
@@ -1,0 +1,6 @@
+package rlz
+
+// Property is a type to identify a value in a state targeted
+// by a condition. Examples are gas, stack sizes, or parameter
+// values.
+type Property string

--- a/go/ct/rlz/test_value.go
+++ b/go/ct/rlz/test_value.go
@@ -1,0 +1,166 @@
+//
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the GNU Lesser General Public Licence v3
+//
+
+package rlz
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+
+	"github.com/Fantom-foundation/Tosca/go/ct/gen"
+	"golang.org/x/exp/maps"
+)
+
+// TestValue is a single point in the parameter space of a state
+// property that should be tested. An example might be a gas value
+// of 67 units.
+type TestValue interface {
+	fmt.Stringer
+	Property() Property           // < the property the value is to assigned to (e.g. "gas")
+	Compare(TestValue) int        // < a total order on test values
+	Restrict(*gen.StateGenerator) // < restricts the given generator to produce states with the value to be tested
+	private()                     // < to make sure nobody outside this package can implement this interface
+}
+
+// getPropertyTestValues computes a list of test values to test the given
+// condition, grouped by the targeted property.
+func getPropertyTestValues(condition Condition) map[Property][]TestValue {
+	// Collect and index test cases derived from the condition.
+	dimensions := map[Property][]TestValue{}
+	for _, cur := range condition.GetTestValues() {
+		tests := dimensions[cur.Property()]
+		tests = append(tests, cur)
+		dimensions[cur.Property()] = tests
+	}
+
+	// Remove duplicates in individual dimensions.
+	for property, tests := range dimensions {
+		dimensions[property] = removeDuplicates(tests)
+	}
+	return dimensions
+}
+
+// enumerateTestCases sets constraints on a copy of the given generator and
+// invokes the given consumer function with it.
+func enumerateTestCases(
+	condition Condition,
+	generator *gen.StateGenerator,
+	consumer func(*gen.StateGenerator) ConsumerResult,
+) ConsumerResult {
+	dimensions := getPropertyTestValues(condition)
+
+	// Sort dimensions to have a deterministic execution order.
+	properties := maps.Keys(dimensions)
+	slices.Sort(properties)
+	cases := [][]TestValue{}
+	for _, property := range properties {
+		cases = append(cases, dimensions[property])
+	}
+
+	// Run the actual test-case generation.
+	return enumerateTestStates(cases, generator, consumer)
+}
+
+func enumerateTestStates(
+	values [][]TestValue,
+	generator *gen.StateGenerator,
+	consumer func(*gen.StateGenerator) ConsumerResult,
+) ConsumerResult {
+	if len(values) == 0 {
+		return consumer(generator)
+	}
+	head := values[0]
+	rest := values[1:]
+	for _, cur := range head {
+		copy := generator.Clone()
+		cur.Restrict(copy)
+		if res := enumerateTestStates(rest, copy, consumer); res == ConsumeAbort {
+			return res
+		}
+	}
+	return ConsumeContinue
+}
+
+func removeDuplicates(values []TestValue) []TestValue {
+	if len(values) < 2 {
+		return values
+	}
+	sort.Slice(values, func(i, j int) bool {
+		return values[i].Compare(values[j]) < 0
+	})
+	o := 1
+	for i := 1; i < len(values); i++ {
+		if values[i].Compare(values[i-1]) != 0 {
+			values[o] = values[i]
+			o++
+		}
+	}
+	return values[:o]
+}
+
+type testValue[T any] struct {
+	property Property
+	domain   Domain[T]
+	restrict func(*gen.StateGenerator, T)
+	value    T
+}
+
+func newTestValue[T any](
+	property Property,
+	domain Domain[T],
+	value T,
+	restrict func(*gen.StateGenerator, T),
+) TestValue {
+	return &testValue[T]{property, domain, restrict, value}
+}
+
+func (c *testValue[T]) Property() Property {
+	return c.property
+}
+
+func (c *testValue[T]) Compare(other TestValue) int {
+	thisProperty := c.property
+	otherProperty := other.Property()
+	if thisProperty != otherProperty {
+		if thisProperty < otherProperty {
+			return -1
+		}
+		return 1
+	}
+	otherValue, ok := other.(interface{ Value() T })
+	if !ok {
+		panic("other test value with same property is not of expected type")
+	}
+	domain := c.domain
+	if domain.Equal(c.value, otherValue.Value()) {
+		return 0
+	}
+	if domain.Less(c.value, otherValue.Value()) {
+		return -1
+	}
+	return 1
+}
+
+func (c *testValue[T]) Value() T {
+	return c.value
+}
+
+func (c *testValue[T]) Restrict(gen *gen.StateGenerator) {
+	c.restrict(gen, c.value)
+}
+
+func (c *testValue[T]) String() string {
+	return fmt.Sprintf("%v", c.value)
+}
+
+func (c *testValue[T]) private() {}

--- a/go/ct/rlz/test_value_test.go
+++ b/go/ct/rlz/test_value_test.go
@@ -1,0 +1,105 @@
+//
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the GNU Lesser General Public Licence v3
+//
+
+package rlz
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/vm"
+)
+
+func TestGetPropertyTestValues_ExtractsTestValuesFromConstraints(t *testing.T) {
+	values := getPropertyTestValues(And(
+		Eq(StackSize(), 12),
+		Gt(Gas(), vm.Gas(5)),
+		Le(Gas(), vm.Gas(50)),
+	))
+
+	if want, got := 2, len(values); want != got {
+		t.Fatalf("unexpected values size, wanted %d, got %d", want, got)
+	}
+
+	if len(values[Gas().Property()]) == 0 {
+		t.Errorf("expected test values for gas, got %v", values)
+	}
+	if len(values[StackSize().Property()]) == 0 {
+		t.Errorf("expected test values for stack size, got %v", values)
+	}
+}
+
+func TestRemoveDuplicates_CanSuccessfullyRemoveDuplicates(t *testing.T) {
+	tests := map[string][]uint16{
+		"nil":            nil,
+		"empty":          {},
+		"single":         {1},
+		"different":      {1, 2, 3},
+		"unordered":      {3, 1, 2},
+		"pair":           {1, 1},
+		"multiple pairs": {1, 2, 1, 2},
+	}
+
+	for name, list := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			input := []TestValue{}
+			for _, cur := range list {
+				input = append(input, newTestValue(Property("X"), uint16Domain{}, cur, nil))
+			}
+			output := removeDuplicates(slices.Clone(input))
+
+			// check that output contains only elements from the input
+			for _, a := range output {
+				found := slices.ContainsFunc(input, func(cur TestValue) bool {
+					return cur.Compare(a) == 0
+				})
+				if !found {
+					t.Errorf("unknown element in output: %v", a)
+				}
+			}
+
+			// check that there are no duplicates
+			for i, a := range output {
+				for j, b := range output {
+					if i != j && a.Compare(b) == 0 {
+						t.Errorf("duplicated element in output: %v", a)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestTestValue_Compare(t *testing.T) {
+	newValue := func(property string, value uint16) TestValue {
+		return newTestValue(Property(property), uint16Domain{}, value, nil)
+	}
+	tests := []struct {
+		a, b   TestValue
+		result int
+	}{
+		{newValue("a", 1), newValue("a", 1), 0},
+		{newValue("a", 1), newValue("a", 2), -1},
+		{newValue("a", 1), newValue("b", 1), -1},
+		{newValue("a", 2), newValue("a", 1), 1},
+		{newValue("b", 1), newValue("a", 1), 1},
+	}
+
+	for _, test := range tests {
+		want := test.result
+		got := test.a.Compare(test.b)
+		if want != got {
+			t.Errorf("comparing %v and %v, wanted %d, got %d", test.a, test.b, want, got)
+		}
+	}
+}

--- a/go/ct/spc/specification_test.go
+++ b/go/ct/spc/specification_test.go
@@ -184,6 +184,30 @@ func TestSpecification_AtMostOneCodeAtPC(t *testing.T) {
 	}
 }
 
+func TestSpecification_NumberOfTestCasesMatchesRuleInfo(t *testing.T) {
+	rules := getAllRules()
+
+	for _, rule := range rules {
+		rule := rule
+		t.Run(rule.Name, func(t *testing.T) {
+			t.Parallel()
+
+			info := rule.GetTestCaseEnumerationInfo()
+
+			counter := 0
+			rand := rand.New(0)
+			rule.EnumerateTestCases(rand, func(*st.State) rlz.ConsumerResult {
+				counter++
+				return rlz.ConsumeContinue
+			})
+
+			if got, limit := counter, info.TotalNumberOfCases(); got > limit {
+				t.Errorf("inconsistent number of test cases, got %d, limit %d", got, limit)
+			}
+		})
+	}
+}
+
 func BenchmarkSpecification_GetState(b *testing.B) {
 	N := 10000
 	rnd := rand.New(0)


### PR DESCRIPTION
This improvement to the test case generation process fixes support for constraints where there are multiple constraints for the same property of the state. 

Before this change, when enumerating test cases for a constraint of the form

`stackSize ≥ 3 ∧ stackSize ≤ 1024`

both clauses would be independently asked for example-stack-sizes to be used in test states. Those may have been, for instance, the values `{0, 2, 3, 4, 1024}` for the first clause and `{0, 1023, 1024}` for the second clause. From those sets, due to the implicit combination of constraints yield by both constraints, the intersection was formed and tested. In the given example, this would result in the set `{0, 1024}` as values for actual test cases, ignoring the values being closer to the boundary limits.

With this change, domains are explicitly extracted from constraints and merged instead of intersected for creating the domains for the test case enumeration.

As a side-effect, constraints like `revision(Istanbul) ∧ revision(Istanbul-London)` which so far caused the generation of the 4 sample values `{Istanbul, Berlin, London, UnknownFutureRevsion}` each, leading to a total of 16 test cases, are now only producing 4 test cases. This significantly reduces the number of test case to be executed in a full CT evaluation.

Finally, the `generation-info` tool in the driver was updated to provide additional insights on the domains. The summary for a rule now looks like this:
```
----- Rule: addmod_regular -----
Conditions:
	Gas ≥ 8
	code[PC] = ADDMOD
	revision(Istanbul-London)
	stackSize ≤ 1024
	stackSize ≥ 3
	status = running
Domains:
	code[PC]: N=2, {ADDMOD, MULMOD}
	gas: N=5, {0, 7, 8, 9, 1152921504606846976}
	revision: N=4, {Istanbul, Berlin, London, UnknownNextRevision}
	stackSize: N=6, {0, 2, 3, 4, 1023, 1024}
	status: N=4, {running, stopped, reverted, failed}
Parameters:
	0: 11
	1: 11
	2: 11
Total number of cases: 1277760
Share of total rules: 1.6%
```