### PR TITLE
Improve Stack Pool

### DIFF
--- a/go/ct/rlz/rules.go
+++ b/go/ct/rlz/rules.go
@@ -54,9 +54,10 @@ func (rule *Rule) EnumerateTestCases(rnd *rand.Rand, consume func(*st.State) Con
 			enumError = err
 			return ConsumeAbort
 		}
-		return enumerateParameters(0, rule.Parameter, state, consume)
+		res := enumerateParameters(0, rule.Parameter, state, consume)
+		state.Release()
+		return res
 	})
-
 	return enumError
 }
 

--- a/go/ct/st/stack.go
+++ b/go/ct/st/stack.go
@@ -43,7 +43,6 @@ func NewStack(values ...U256) *Stack {
 	if MaxStackSize < len(values) {
 		panic("Warning: maximal stack size exceeded")
 	}
-
 	stack.stack = stack.stack[:copy(stack.stack, values)]
 	return stack
 }
@@ -54,7 +53,6 @@ func NewStackWithSize(size int) *Stack {
 	if MaxStackSize < size {
 		panic("Warning: maximal stack size exceeded")
 	}
-
 	stack.stack = stack.stack[:size]
 	return stack
 }

--- a/go/ct/st/stack.go
+++ b/go/ct/st/stack.go
@@ -57,10 +57,6 @@ func NewStackWithSize(size int) *Stack {
 	return stack
 }
 
-func (s *Stack) Release() {
-	stackPool.Put(s)
-}
-
 // Clone creates an independent copy of the stack.
 func (s *Stack) Clone() *Stack {
 	clone := stackPool.Get().(*Stack)
@@ -71,6 +67,17 @@ func (s *Stack) Clone() *Stack {
 	}
 	copy(clone.stack, s.stack)
 	return clone
+}
+
+func (s *Stack) Release() {
+	stackPool.Put(s)
+}
+
+func (s *Stack) Resize(size int) {
+	if MaxStackSize < size {
+		panic("Warning: maximal stack size exceeded")
+	}
+	s.stack = s.stack[:size]
 }
 
 // Size returns the number of elements on the stack.

--- a/go/ct/st/state.go
+++ b/go/ct/st/state.go
@@ -132,7 +132,7 @@ func NewState(code *Code) *State {
 		Status:             Running,
 		Revision:           R07_Istanbul,
 		Code:               code,
-		Stack:              NewStack(),
+		Stack:              &Stack{},
 		Memory:             NewMemory(),
 		Storage:            &Storage{},
 		Accounts:           NewAccounts(),

--- a/go/ct/st/state_test.go
+++ b/go/ct/st/state_test.go
@@ -773,6 +773,7 @@ func TestState_EqualityConsidersRelevantFieldsDependingOnStatus(t *testing.T) {
 
 func TestState_RecycledMembers(t *testing.T) {
 	state := NewState(NewCode([]byte{byte(INVALID)}))
+	state.Stack = NewStack()
 
 	if state.Stack == nil {
 		t.Error("No stack was returned from stack pool")

--- a/go/vm/evmc/evmc_steppable_interpreter.go
+++ b/go/vm/evmc/evmc_steppable_interpreter.go
@@ -148,6 +148,7 @@ func convertCtStackToEvmcStack(stack *st.Stack) []byte {
 		val := stack.Get(i).Bytes32be()
 		copy(evmcStack[stackBytes-(i+1)*32:], val[:])
 	}
+	stack.Release()
 	return evmcStack
 }
 

--- a/go/vm/evmc/evmc_steppable_interpreter_test.go
+++ b/go/vm/evmc/evmc_steppable_interpreter_test.go
@@ -238,7 +238,8 @@ func TestConvertToCt_Stack(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			for _, cur := range test {
-				ctStack, err := convertEvmcStackToCtStack(cur.evmcStack)
+				ctStack := st.NewStack()
+				ctStack, err := convertEvmcStackToCtStack(cur.evmcStack, ctStack)
 
 				if cur.convertSuccess && err != nil {
 					t.Fatalf("unexpected conversion error: %v", err)

--- a/go/vm/geth/ct.go
+++ b/go/vm/geth/ct.go
@@ -150,6 +150,7 @@ func convertCtStackToGethStack(state *st.State) *geth_vm.Stack {
 		val := state.Stack.Get(i).Uint256()
 		stack.Push(&val)
 	}
+	state.Stack.Release()
 	return stack
 }
 

--- a/go/vm/geth/ct.go
+++ b/go/vm/geth/ct.go
@@ -86,7 +86,7 @@ func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 
 	state.Gas = vm.Gas(contract.Gas)
 	state.GasRefund = vm.Gas(stateDb.GetRefund())
-	state.Stack = convertGethStackToCtStack(interpreterState)
+	state.Stack = convertGethStackToCtStack(interpreterState, state.Stack)
 	state.Memory = convertGethMemoryToCtMemory(interpreterState)
 	state.LastCallReturnData = common.NewBytes(interpreterState.Result)
 	if state.Status == st.Stopped || state.Status == st.Reverted {
@@ -150,12 +150,11 @@ func convertCtStackToGethStack(state *st.State) *geth_vm.Stack {
 		val := state.Stack.Get(i).Uint256()
 		stack.Push(&val)
 	}
-	state.Stack.Release()
 	return stack
 }
 
-func convertGethStackToCtStack(state *geth_vm.GethState) *st.Stack {
-	stack := st.NewStack()
+func convertGethStackToCtStack(state *geth_vm.GethState, stack *st.Stack) *st.Stack {
+	stack.Resize(0)
 	for i := 0; i < state.Stack.Len(); i++ {
 		val := state.Stack.Data()[i]
 		stack.Push(common.NewU256(val[3], val[2], val[1], val[0]))

--- a/go/vm/lfvm/ct.go
+++ b/go/vm/lfvm/ct.go
@@ -180,6 +180,7 @@ func convertCtStackToLfvmStack(stack *st.Stack) *Stack {
 		val := stack.Get(i).Uint256()
 		result.push(&val)
 	}
+	stack.Release()
 	return result
 }
 

--- a/go/vm/lfvm/ct.go
+++ b/go/vm/lfvm/ct.go
@@ -116,7 +116,7 @@ func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 
 	state.Gas = ctxt.gas
 	state.GasRefund = ctxt.refund
-	state.Stack = convertLfvmStackToCtStack(ctxt.stack)
+	state.Stack = convertLfvmStackToCtStack(ctxt.stack, state.Stack)
 	state.Memory = convertLfvmMemoryToCtMemory(ctxt.memory)
 	state.ReturnData = common.NewBytes(result)
 	state.LastCallReturnData = common.NewBytes(ctxt.return_data)
@@ -180,13 +180,12 @@ func convertCtStackToLfvmStack(stack *st.Stack) *Stack {
 		val := stack.Get(i).Uint256()
 		result.push(&val)
 	}
-	stack.Release()
 	return result
 }
 
-func convertLfvmStackToCtStack(stack *Stack) *st.Stack {
+func convertLfvmStackToCtStack(stack *Stack, result *st.Stack) *st.Stack {
 	len := stack.len()
-	result := st.NewStackWithSize(len)
+	result.Resize(len)
 	for i := 0; i < len; i++ {
 		result.Set(len-i-1, common.NewU256FromUint256(&stack.Data()[i]))
 	}

--- a/go/vm/lfvm/ct_test.go
+++ b/go/vm/lfvm/ct_test.go
@@ -356,7 +356,8 @@ func TestConvertToCt_Stack(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			for _, cur := range test {
 				want := cur.ctStack
-				got := convertLfvmStackToCtStack(cur.lfvmStack)
+				ctStack := st.NewStack()
+				got := convertLfvmStackToCtStack(cur.lfvmStack, ctStack)
 
 				diffs := got.Diff(want)
 
@@ -373,7 +374,8 @@ func BenchmarkLfvmStackToCtStack(b *testing.B) {
 	for i := 0; i < MAX_STACK_SIZE/2; i++ {
 		stack.pushEmpty().SetUint64(uint64(i))
 	}
+	ctStack := st.NewStack()
 	for i := 0; i < b.N; i++ {
-		convertLfvmStackToCtStack(stack)
+		convertLfvmStackToCtStack(stack, ctStack)
 	}
 }


### PR DESCRIPTION
In the profile of the CT run, stack memory allocation still had a big impact on the runtime. Stacks were garbage collected and therefore had to be newly allocated. 

This PR fixes this and returns all stacks, memory allocations are no longer visible in the profile.
