### PR TITLE
Fix enumeration test to match new Condition interface

### DIFF
--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -135,7 +135,7 @@ func (e *eq[T]) GetTestValues() []TestValue {
 	}
 	res := []TestValue{}
 	for _, value := range domain.Samples(e.rhs) {
-		res = append(res, newTestValue(property, domain, value, restrict))
+		res = append(res, NewTestValue(property, domain, value, restrict))
 	}
 	return res
 }
@@ -348,7 +348,7 @@ func (e *revisionBounds) GetTestValues() []TestValue {
 	}
 	res := []TestValue{}
 	for r := Revision(0); r <= R99_UnknownNextRevision; r++ {
-		res = append(res, newTestValue(property, domain, r, restrict))
+		res = append(res, NewTestValue(property, domain, r, restrict))
 	}
 	return res
 }
@@ -401,8 +401,8 @@ func (c *isCode) GetTestValues() []TestValue {
 		}
 	}
 	return []TestValue{
-		newTestValue(property, domain, true, restrict),
-		newTestValue(property, domain, false, restrict),
+		NewTestValue(property, domain, true, restrict),
+		NewTestValue(property, domain, false, restrict),
 	}
 }
 
@@ -484,8 +484,8 @@ func (c *isStorageWarm) GetTestValues() []TestValue {
 		}
 	}
 	return []TestValue{
-		newTestValue(property, domain, true, restrict),
-		newTestValue(property, domain, false, restrict),
+		NewTestValue(property, domain, true, restrict),
+		NewTestValue(property, domain, false, restrict),
 	}
 }
 
@@ -569,7 +569,7 @@ func (c *storageConfiguration) GetTestValues() []TestValue {
 	restrict := func(generator *gen.StateGenerator, _ bool) {
 		c.Restrict(generator)
 	}
-	return []TestValue{newTestValue(property, domain, true, restrict)}
+	return []TestValue{NewTestValue(property, domain, true, restrict)}
 }
 
 func (c *storageConfiguration) String() string {
@@ -614,8 +614,8 @@ func (c *isAddressWarm) GetTestValues() []TestValue {
 		}
 	}
 	return []TestValue{
-		newTestValue(property, domain, true, restrict),
-		newTestValue(property, domain, false, restrict),
+		NewTestValue(property, domain, true, restrict),
+		NewTestValue(property, domain, false, restrict),
 	}
 }
 

--- a/go/ct/rlz/test_value.go
+++ b/go/ct/rlz/test_value.go
@@ -115,7 +115,7 @@ type testValue[T any] struct {
 	value    T
 }
 
-func newTestValue[T any](
+func NewTestValue[T any](
 	property Property,
 	domain Domain[T],
 	value T,

--- a/go/ct/rlz/test_value_test.go
+++ b/go/ct/rlz/test_value_test.go
@@ -54,7 +54,7 @@ func TestRemoveDuplicates_CanSuccessfullyRemoveDuplicates(t *testing.T) {
 
 			input := []TestValue{}
 			for _, cur := range list {
-				input = append(input, newTestValue(Property("X"), uint16Domain{}, cur, nil))
+				input = append(input, NewTestValue(Property("X"), uint16Domain{}, cur, nil))
 			}
 			output := removeDuplicates(slices.Clone(input))
 
@@ -82,7 +82,7 @@ func TestRemoveDuplicates_CanSuccessfullyRemoveDuplicates(t *testing.T) {
 
 func TestTestValue_Compare(t *testing.T) {
 	newValue := func(property string, value uint16) TestValue {
-		return newTestValue(Property(property), uint16Domain{}, value, nil)
+		return NewTestValue(Property(property), uint16Domain{}, value, nil)
 	}
 	tests := []struct {
 		a, b   TestValue

--- a/go/ct/spc/enumeration_test.go
+++ b/go/ct/spc/enumeration_test.go
@@ -44,16 +44,15 @@ func (e testCondition) Check(s *st.State) (bool, error) {
 func (e testCondition) Restrict(generator *gen.StateGenerator) {
 }
 
-// the test condition produces exactly one test state per rule
-func (e testCondition) EnumerateTestCases(generator *gen.StateGenerator, consume func(*gen.StateGenerator) rlz.ConsumerResult) rlz.ConsumerResult {
+// GetTestValues produces test values for the specified number of test states.
+func (e testCondition) GetTestValues() []rlz.TestValue {
+	res := []rlz.TestValue{}
+	property := rlz.Property("test")
+	domain := rlz.StackSize().Domain()
 	for i := 0; i < e.numStates; i++ {
-		g := generator.Clone()
-		res := consume(g)
-		if res == rlz.ConsumeAbort {
-			return rlz.ConsumeAbort
-		}
+		res = append(res, rlz.NewTestValue(property, domain, i, func(*gen.StateGenerator, int) {}))
 	}
-	return rlz.ConsumeContinue
+	return res
 }
 
 func (e testCondition) String() string {


### PR DESCRIPTION
This PR fixes a merge issue between #429 and #432. The latter introduced an interface change for something introduced by the former.