### PR TITLE
Unsupported Revision Error

### DIFF
--- a/go/ct/common/revisions.go
+++ b/go/ct/common/revisions.go
@@ -27,6 +27,9 @@ const (
 	R99_UnknownNextRevision
 )
 
+// Newest Revision currently supported by the CT specification
+const NewestSupportedRevision = R10_London
+
 const MinRevision = R07_Istanbul
 const MaxRevision = R99_UnknownNextRevision
 

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -274,7 +274,7 @@ func getAllRules() []Rule {
 		pops:      1,
 		pushes:    1,
 		conditions: []Condition{
-			RevisionBounds(R09_Berlin, R99_UnknownNextRevision),
+			RevisionBounds(R09_Berlin, NewestSupportedRevision),
 			IsAddressCold(Param(0)),
 		},
 		parameters: []Parameter{
@@ -295,7 +295,7 @@ func getAllRules() []Rule {
 		pops:      1,
 		pushes:    1,
 		conditions: []Condition{
-			RevisionBounds(R09_Berlin, R99_UnknownNextRevision),
+			RevisionBounds(R09_Berlin, NewestSupportedRevision),
 			IsAddressWarm(Param(0)),
 		},
 		parameters: []Parameter{
@@ -418,7 +418,7 @@ func getAllRules() []Rule {
 		pops:      1,
 		pushes:    1,
 		conditions: []Condition{
-			RevisionBounds(R09_Berlin, R10_London),
+			RevisionBounds(R09_Berlin, NewestSupportedRevision),
 			IsStorageCold(Param(0)),
 		},
 		parameters: []Parameter{
@@ -439,7 +439,7 @@ func getAllRules() []Rule {
 		pops:      1,
 		pushes:    1,
 		conditions: []Condition{
-			RevisionBounds(R09_Berlin, R10_London),
+			RevisionBounds(R09_Berlin, NewestSupportedRevision),
 			IsStorageWarm(Param(0)),
 		},
 		parameters: []Parameter{
@@ -459,7 +459,7 @@ func getAllRules() []Rule {
 		pops:      1,
 		pushes:    1,
 		conditions: []Condition{
-			RevisionBounds(R07_Istanbul, R07_Istanbul),
+			IsRevision(R07_Istanbul),
 		},
 		parameters: []Parameter{
 			NumericParameter{},
@@ -849,7 +849,7 @@ func getAllRules() []Rule {
 		pops:      1,
 		pushes:    1,
 		conditions: []Condition{
-			RevisionBounds(R09_Berlin, R99_UnknownNextRevision),
+			RevisionBounds(R09_Berlin, NewestSupportedRevision),
 			IsAddressCold(Param(0)),
 		},
 		parameters: []Parameter{
@@ -871,7 +871,7 @@ func getAllRules() []Rule {
 		pops:      1,
 		pushes:    1,
 		conditions: []Condition{
-			RevisionBounds(R09_Berlin, R99_UnknownNextRevision),
+			RevisionBounds(R09_Berlin, NewestSupportedRevision),
 			IsAddressWarm(Param(0)),
 		},
 		parameters: []Parameter{
@@ -914,7 +914,7 @@ func getAllRules() []Rule {
 		pops:      4,
 		pushes:    0,
 		conditions: []Condition{
-			RevisionBounds(R09_Berlin, R99_UnknownNextRevision),
+			RevisionBounds(R09_Berlin, NewestSupportedRevision),
 			IsAddressCold(Param(0)),
 		},
 		parameters: []Parameter{
@@ -935,7 +935,7 @@ func getAllRules() []Rule {
 		pops:      4,
 		pushes:    0,
 		conditions: []Condition{
-			RevisionBounds(R09_Berlin, R99_UnknownNextRevision),
+			RevisionBounds(R09_Berlin, NewestSupportedRevision),
 			IsAddressWarm(Param(0)),
 		},
 		parameters: []Parameter{
@@ -1016,7 +1016,7 @@ func getAllRules() []Rule {
 		pops:      1,
 		pushes:    1,
 		conditions: []Condition{
-			RevisionBounds(R09_Berlin, R99_UnknownNextRevision),
+			RevisionBounds(R09_Berlin, NewestSupportedRevision),
 			IsAddressCold(Param(0)),
 		},
 		parameters: []Parameter{
@@ -1042,7 +1042,7 @@ func getAllRules() []Rule {
 		pops:      1,
 		pushes:    1,
 		conditions: []Condition{
-			RevisionBounds(R09_Berlin, R99_UnknownNextRevision),
+			RevisionBounds(R09_Berlin, NewestSupportedRevision),
 			IsAddressWarm(Param(0)),
 		},
 		parameters: []Parameter{

--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -13,8 +13,6 @@
 package utils
 
 import (
-	"fmt"
-
 	cc "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"github.com/Fantom-foundation/Tosca/go/vm"
@@ -43,7 +41,7 @@ func ToVmParameters(state *st.State) vm.Parameters {
 	case cc.R10_London:
 		revision = vm.R10_London
 	default:
-		panic(fmt.Errorf("unsupported revision: %v", state.Revision))
+		revision = vm.Revision(state.Revision)
 	}
 
 	return vm.Parameters{

--- a/go/vm/evmc/evmc_interpreter.go
+++ b/go/vm/evmc/evmc_interpreter.go
@@ -44,6 +44,9 @@ type EvmcInterpreter struct {
 	vm *evmc.VM
 }
 
+// Defines the newest supported revision for this interpreter implementation
+const NewestSupportedRevision = vm.R10_London
+
 // SetOption enables the configuration of implementation specific options.
 func (e *EvmcInterpreter) SetOption(property string, value string) error {
 	return e.vm.SetOption(property, value)
@@ -53,6 +56,10 @@ func (e *EvmcInterpreter) Run(params vm.Parameters) (vm.Result, error) {
 	host_ctx := hostContext{
 		params:  params,
 		context: params.Context,
+	}
+
+	if params.Revision > NewestSupportedRevision {
+		return vm.Result{}, &vm.ErrUnsupportedRevision{}
 	}
 
 	revision, err := toEvmcRevision(params.Revision)

--- a/go/vm/evmc/evmc_interpreter.go
+++ b/go/vm/evmc/evmc_interpreter.go
@@ -44,9 +44,6 @@ type EvmcInterpreter struct {
 	vm *evmc.VM
 }
 
-// Defines the newest supported revision for this interpreter implementation
-const NewestSupportedRevision = vm.R10_London
-
 // SetOption enables the configuration of implementation specific options.
 func (e *EvmcInterpreter) SetOption(property string, value string) error {
 	return e.vm.SetOption(property, value)
@@ -56,10 +53,6 @@ func (e *EvmcInterpreter) Run(params vm.Parameters) (vm.Result, error) {
 	host_ctx := hostContext{
 		params:  params,
 		context: params.Context,
-	}
-
-	if params.Revision > NewestSupportedRevision {
-		return vm.Result{}, &vm.ErrUnsupportedRevision{}
 	}
 
 	revision, err := toEvmcRevision(params.Revision)

--- a/go/vm/evmzero/ct.go
+++ b/go/vm/evmzero/ct.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"github.com/Fantom-foundation/Tosca/go/ct/utils"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 	"github.com/Fantom-foundation/Tosca/go/vm/evmc"
 )
 
@@ -39,12 +40,9 @@ func NewConformanceTestingTarget() ct.Evm {
 type ctAdapter struct{}
 
 func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
-	// Hack: Special handling for unknown revision, because evmzero cannot represent an invalid revision.
-	// So we mark the status as failed already.
-	// TODO: Fix this once we add full revision support to the CT and evmzero.
-	if state.Revision > common.R10_London {
+	if state.Revision > common.Revision(evmc.NewestSupportedRevision) {
 		state.Status = st.Failed
-		return state, nil
+		return state, &vm.ErrUnsupportedRevision{}
 	}
 
 	// No need to run anything that is not in a running state.

--- a/go/vm/evmzero/ct.go
+++ b/go/vm/evmzero/ct.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 
 	"github.com/Fantom-foundation/Tosca/go/ct"
-	"github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"github.com/Fantom-foundation/Tosca/go/ct/utils"
 	"github.com/Fantom-foundation/Tosca/go/vm"
@@ -40,9 +39,9 @@ func NewConformanceTestingTarget() ct.Evm {
 type ctAdapter struct{}
 
 func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
-	if state.Revision > common.Revision(evmc.NewestSupportedRevision) {
-		state.Status = st.Failed
-		return state, &vm.ErrUnsupportedRevision{}
+	vmParams := utils.ToVmParameters(state)
+	if vmParams.Revision > newestSupportedRevision {
+		return state, &vm.ErrUnsupportedRevision{Revision: vmParams.Revision}
 	}
 
 	// No need to run anything that is not in a running state.
@@ -50,5 +49,5 @@ func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 		return state, nil
 	}
 
-	return evmzeroSteppable.StepN(utils.ToVmParameters(state), state, numSteps)
+	return evmzeroSteppable.StepN(vmParams, state, numSteps)
 }

--- a/go/vm/geth/ct.go
+++ b/go/vm/geth/ct.go
@@ -33,9 +33,9 @@ func NewConformanceTestingTarget() ct.Evm {
 type ctAdapter struct{}
 
 func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
-	if state.Revision > common.Revision(NewestSupportedRevision) {
-		state.Status = st.Failed
-		return state, &vm.ErrUnsupportedRevision{}
+	parameters := utils.ToVmParameters(state)
+	if parameters.Revision > newestSupportedRevision {
+		return state, &vm.ErrUnsupportedRevision{Revision: parameters.Revision}
 	}
 
 	// No need to run anything that is not in a running state.
@@ -48,8 +48,6 @@ func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 	if err == nil && op == common.STOP {
 		isStopInstruction = true
 	}
-
-	parameters := utils.ToVmParameters(state)
 
 	evm, contract, stateDb := createGethInterpreterContext(parameters)
 	stateDb.refund = uint64(state.GasRefund)

--- a/go/vm/geth/ct.go
+++ b/go/vm/geth/ct.go
@@ -33,12 +33,9 @@ func NewConformanceTestingTarget() ct.Evm {
 type ctAdapter struct{}
 
 func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
-	// Hack: Special handling for unknown revision, because geth cannot represent an invalid revision.
-	// So we mark the status as failed already.
-	// TODO: Fix this once we add full revision support to the CT and geth.
-	if state.Revision > common.R10_London {
+	if state.Revision > common.Revision(NewestSupportedRevision) {
 		state.Status = st.Failed
-		return state, nil
+		return state, &vm.ErrUnsupportedRevision{}
 	}
 
 	// No need to run anything that is not in a running state.

--- a/go/vm/geth/geth.go
+++ b/go/vm/geth/geth.go
@@ -30,7 +30,13 @@ func init() {
 
 type gethVm struct{}
 
+// Defines the newest supported revision for this interpreter implementation
+const NewestSupportedRevision = vm.R10_London
+
 func (m *gethVm) Run(parameters vm.Parameters) (vm.Result, error) {
+	if parameters.Revision > NewestSupportedRevision {
+		return vm.Result{}, &vm.ErrUnsupportedRevision{}
+	}
 	evm, contract, stateDb := createGethInterpreterContext(parameters)
 
 	output, err := evm.Interpreter().Run(contract, parameters.Input, false)

--- a/go/vm/geth/geth.go
+++ b/go/vm/geth/geth.go
@@ -31,11 +31,11 @@ func init() {
 type gethVm struct{}
 
 // Defines the newest supported revision for this interpreter implementation
-const NewestSupportedRevision = vm.R10_London
+const newestSupportedRevision = vm.R10_London
 
 func (m *gethVm) Run(parameters vm.Parameters) (vm.Result, error) {
-	if parameters.Revision > NewestSupportedRevision {
-		return vm.Result{}, &vm.ErrUnsupportedRevision{}
+	if parameters.Revision > newestSupportedRevision {
+		return vm.Result{}, &vm.ErrUnsupportedRevision{Revision: parameters.Revision}
 	}
 	evm, contract, stateDb := createGethInterpreterContext(parameters)
 

--- a/go/vm/interpreter.go
+++ b/go/vm/interpreter.go
@@ -12,6 +12,8 @@
 
 package vm
 
+import "fmt"
+
 //go:generate mockgen -source interpreter.go -destination interpreter_mock.go -package vm
 
 // Interpreter is a component capable of executing EVM byte-code. It is the main
@@ -25,8 +27,10 @@ type Interpreter interface {
 	// code was correctly executed (even if the execution was aborted due do to
 	// a code-internal issue). The error is not nil if some problem within the
 	// interpreter caused the execution to fail to correctly process the provided
-	// program. In such a case the result is undefined. Interpreters are required
-	// to be thread-safe. Thus, multiple runs may be conducted in parallel.
+	// program. In such a case the result is undefined. During a call with an
+	// unsupported Revision a special unsupported Revision Error is returned.
+	// Interpreters are required to be thread-safe. Thus, multiple runs may be
+	// conducted in parallel.
 	Run(Parameters) (Result, error)
 }
 
@@ -184,6 +188,15 @@ const (
 	R09_Berlin
 	R10_London
 )
+
+// Error for runs with unsupported Revision
+type ErrUnsupportedRevision struct {
+	revision Revision
+}
+
+func (e *ErrUnsupportedRevision) Error() string {
+	return fmt.Sprintf("Unsupported revision %d", e.revision)
+}
 
 // ProfilingInterpreter is an optional extension to the Interpreter interface
 // above which may be implemented by interpreters collecting statistical data

--- a/go/vm/interpreter.go
+++ b/go/vm/interpreter.go
@@ -28,7 +28,7 @@ type Interpreter interface {
 	// a code-internal issue). The error is not nil if some problem within the
 	// interpreter caused the execution to fail to correctly process the provided
 	// program. In such a case the result is undefined. During a call with an
-	// unsupported Revision a special unsupported Revision Error is returned.
+	// unsupported Revision an ErrUnsupportedRevision Error is returned.
 	// Interpreters are required to be thread-safe. Thus, multiple runs may be
 	// conducted in parallel.
 	Run(Parameters) (Result, error)

--- a/go/vm/interpreter.go
+++ b/go/vm/interpreter.go
@@ -191,11 +191,11 @@ const (
 
 // Error for runs with unsupported Revision
 type ErrUnsupportedRevision struct {
-	revision Revision
+	Revision Revision
 }
 
 func (e *ErrUnsupportedRevision) Error() string {
-	return fmt.Sprintf("Unsupported revision %d", e.revision)
+	return fmt.Sprintf("Unsupported revision %d", e.Revision)
 }
 
 // ProfilingInterpreter is an optional extension to the Interpreter interface

--- a/go/vm/lfvm/ct.go
+++ b/go/vm/lfvm/ct.go
@@ -30,17 +30,15 @@ func NewConformanceTestingTarget() ct.Evm {
 type ctAdapter struct{}
 
 func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
-	if state.Revision > common.Revision(NewestSupportedRevision) {
-		state.Status = st.Failed
-		return state, &vm.ErrUnsupportedRevision{}
+	params := utils.ToVmParameters(state)
+	if params.Revision > newestSupportedRevision {
+		return state, &vm.ErrUnsupportedRevision{Revision: params.Revision}
 	}
 
 	// No need to run anything that is not in a running state.
 	if state.Status != st.Running {
 		return state, nil
 	}
-
-	params := utils.ToVmParameters(state)
 
 	var codeHash vm.Hash
 	if params.CodeHash != nil {

--- a/go/vm/lfvm/ct.go
+++ b/go/vm/lfvm/ct.go
@@ -30,12 +30,9 @@ func NewConformanceTestingTarget() ct.Evm {
 type ctAdapter struct{}
 
 func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
-	// Hack: Special handling for unknown revision, because lfvm cannot represent an invalid revision.
-	// So we mark the status as failed already.
-	// TODO: Fix this once we add full revision support to the CT and lfvm.
-	if state.Revision > common.R10_London {
+	if state.Revision > common.Revision(NewestSupportedRevision) {
 		state.Status = st.Failed
-		return state, nil
+		return state, &vm.ErrUnsupportedRevision{}
 	}
 
 	// No need to run anything that is not in a running state.

--- a/go/vm/lfvm/lfvm.go
+++ b/go/vm/lfvm/lfvm.go
@@ -36,10 +36,17 @@ type VM struct {
 	logging                 bool
 }
 
+// Defines the newest supported revision for this interpreter implementation
+const NewestSupportedRevision = vm.R10_London
+
 func (v *VM) Run(params vm.Parameters) (vm.Result, error) {
 	var codeHash vm.Hash
 	if params.CodeHash != nil {
 		codeHash = *params.CodeHash
+	}
+
+	if params.Revision > NewestSupportedRevision {
+		return vm.Result{}, &vm.ErrUnsupportedRevision{}
 	}
 
 	converted, err := Convert(

--- a/go/vm/lfvm/lfvm.go
+++ b/go/vm/lfvm/lfvm.go
@@ -37,7 +37,7 @@ type VM struct {
 }
 
 // Defines the newest supported revision for this interpreter implementation
-const NewestSupportedRevision = vm.R10_London
+const newestSupportedRevision = vm.R10_London
 
 func (v *VM) Run(params vm.Parameters) (vm.Result, error) {
 	var codeHash vm.Hash
@@ -45,8 +45,8 @@ func (v *VM) Run(params vm.Parameters) (vm.Result, error) {
 		codeHash = *params.CodeHash
 	}
 
-	if params.Revision > NewestSupportedRevision {
-		return vm.Result{}, &vm.ErrUnsupportedRevision{}
+	if params.Revision > newestSupportedRevision {
+		return vm.Result{}, &vm.ErrUnsupportedRevision{Revision: params.Revision}
 	}
 
 	converted, err := Convert(

--- a/go/vm/test/revision_test.go
+++ b/go/vm/test/revision_test.go
@@ -1,0 +1,68 @@
+//
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the GNU Lesser General Public Licence v3
+//
+
+package vm_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/vm"
+	"go.uber.org/mock/gomock"
+
+	// This is only imported to get the EVM opcode definitions.
+	// TODO: write up our own op-code definition and remove this dependency.
+	geth "github.com/ethereum/go-ethereum/core/vm"
+)
+
+func TestUnsupportedRevision_KnownRevisions(t *testing.T) {
+	knownRevisions := []vm.Revision{vm.Revision(0), vm.Revision(1), vm.Revision(2)}
+	unknownRevisions := []vm.Revision{vm.Revision(90), vm.Revision(91), vm.Revision(92)}
+
+	ctrl := gomock.NewController(t)
+	mockStateDB := NewMockStateDB(ctrl)
+	mockStateDB.EXPECT().GetStorage(gomock.Any(), gomock.Any()).AnyTimes().Return(vm.Word{})
+	mockStateDB.EXPECT().GetBalance(gomock.Any()).AnyTimes().Return(vm.Value{})
+	mockStateDB.EXPECT().GetCodeSize(gomock.Any()).AnyTimes().Return(0)
+	mockStateDB.EXPECT().AccountExists(gomock.Any()).AnyTimes().Return(true)
+	mockStateDB.EXPECT().GetCodeHash(gomock.Any()).AnyTimes().Return(vm.Hash{})
+	mockStateDB.EXPECT().GetBlockHash(gomock.Any()).AnyTimes().Return(vm.Hash{})
+
+	code := []byte{byte(geth.PUSH2), byte(5), byte(2), byte(geth.SUB)}
+
+	for _, variant := range Variants {
+		for _, revision := range knownRevisions {
+			evm := TestEVM{
+				interpreter: vm.GetInterpreter(variant),
+				revision:    revision,
+				state:       mockStateDB,
+			}
+			_, err := evm.Run(code, []byte{})
+			if err != nil {
+				t.Errorf("unexpected error during evm run")
+			}
+		}
+
+		for _, revision := range unknownRevisions {
+			evm := TestEVM{
+				interpreter: vm.GetInterpreter(variant),
+				revision:    revision,
+				state:       mockStateDB,
+			}
+			_, err := evm.Run(code, []byte{})
+			targetError := &vm.ErrUnsupportedRevision{}
+			if !errors.As(err, &targetError) {
+				t.Errorf("Running on %s: expected unsupported revision error but got %v", variant, err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces a custom error type for unsupported revisions.
Fixes #320.
Further a newest supported revision for the CT specification is introduced. This ensures that rules that do not change with new revisions still produce test cases with new them.