### PR TITLE
Fix flaky abort enumeration test

### DIFF
--- a/go/ct/spc/enumeration_test.go
+++ b/go/ct/spc/enumeration_test.go
@@ -164,7 +164,7 @@ func TestEnumeration_AbortedEnumeration(t *testing.T) {
 		t.Errorf("wrong number of generated test cases")
 	}
 
-	if counterAbort.Load() > int64(numRules) {
+	if counterAbort.Load() >= counterContinue.Load() {
 		t.Errorf("state enumeration did not abort correctly, number of evaluated states %d", counterAbort.Load())
 	}
 


### PR DESCRIPTION
While the number of executed tests after an abort is quite consistent on local machines, it has high fluctuations on the CI server. This PR loosens the requirements and only checks that less tests are executed than in a normal run.