### PR TITLE
Unifies handling of range constraints

### DIFF
--- a/go/ct/common/revisions.go
+++ b/go/ct/common/revisions.go
@@ -27,6 +27,9 @@ const (
 	R99_UnknownNextRevision
 )
 
+const MinRevision = R07_Istanbul
+const MaxRevision = R99_UnknownNextRevision
+
 func (r Revision) String() string {
 	switch r {
 	case R07_Istanbul:

--- a/go/ct/gen/range_solver.go
+++ b/go/ct/gen/range_solver.go
@@ -1,0 +1,99 @@
+//
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the GNU Lesser General Public Licence v3
+//
+
+package gen
+
+import (
+	"fmt"
+	"math"
+
+	"golang.org/x/exp/constraints"
+	"pgregory.net/rand"
+)
+
+// RangeSolver is a generic utility to solve constraints of the form
+//
+//	constraint ::= true | constraint ∧ clause
+//	clause     ::= X op C
+//	op         ::= < | ≤ | = | ≥ | >
+//
+// where X is a numeric property to be solved for and C are constants.
+// Type T is the the domain for X and C.
+type RangeSolver[T constraints.Integer] struct {
+	min, max T // < inclusive boundaries
+}
+
+func NewRangeSolver[T constraints.Integer](min, max T) *RangeSolver[T] {
+	return &RangeSolver[T]{min: min, max: max}
+}
+
+func (s *RangeSolver[T]) GetMin() T {
+	return s.min
+}
+
+func (s *RangeSolver[T]) AddLowerBoundary(min T) {
+	if min > s.min {
+		s.min = min
+	}
+}
+
+func (s *RangeSolver[T]) GetMax() T {
+	return s.max
+}
+
+func (s *RangeSolver[T]) AddUpperBoundary(max T) {
+	if max < s.max {
+		s.max = max
+	}
+}
+
+func (s *RangeSolver[T]) AddEqualityConstraint(value T) {
+	s.AddLowerBoundary(value)
+	s.AddUpperBoundary(value)
+}
+
+func (s *RangeSolver[T]) IsSatisfiable() bool {
+	return !(s.min > s.max)
+}
+
+func (s *RangeSolver[T]) Clone() *RangeSolver[T] {
+	return &RangeSolver[T]{min: s.min, max: s.max}
+}
+
+func (s *RangeSolver[T]) Restore(backup *RangeSolver[T]) {
+	*s = *backup
+}
+
+func (s *RangeSolver[T]) Generate(rnd *rand.Rand) (T, error) {
+	if s.min > s.max {
+		return 0, ErrUnsatisfiable
+	}
+	diff := s.max - s.min
+	if uint64(diff) == math.MaxUint64 {
+		return T(rnd.Uint64()), nil
+	}
+	return T(rnd.Uint64n(uint64(diff)+1)) + s.min, nil
+}
+
+func (s *RangeSolver[T]) String() string {
+	return s.Print("X")
+}
+
+func (s *RangeSolver[T]) Print(value string) string {
+	if s.min == s.max {
+		return fmt.Sprintf("%s=%v", value, s.min)
+	}
+	if s.min > s.max {
+		return fmt.Sprintf("unsatisfiable(%s)", value)
+	}
+	return fmt.Sprintf("%v≤%s≤%v", s.min, value, s.max)
+}

--- a/go/ct/gen/range_solver_test.go
+++ b/go/ct/gen/range_solver_test.go
@@ -1,0 +1,128 @@
+//
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the GNU Lesser General Public Licence v3
+//
+
+package gen
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+
+	"pgregory.net/rand"
+)
+
+func TestRangeSolver_ProducesValueInRange(t *testing.T) {
+	tests := []struct {
+		min, max int
+	}{
+		{math.MinInt, 12},          // without effective lower boundary
+		{5, math.MaxInt},           // without effective upper boundary
+		{5, 12},                    // lower and upper boundary
+		{6, 6},                     // a fixed value
+		{math.MinInt, math.MaxInt}, // the maximum range
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("[%d,%d]", test.min, test.max), func(t *testing.T) {
+			rnd := rand.New()
+			solver := NewRangeSolver(test.min, test.max)
+			for i := 0; i < 10; i++ {
+				sample, err := solver.Generate(rnd)
+				if err != nil {
+					t.Fatalf("failed to sample value from range, got %v", err)
+				}
+				if sample < test.min {
+					t.Errorf("generated element out of bounds, got %d which should be ≥ %d", sample, test.min)
+				}
+				if sample > test.max {
+					t.Errorf("generated element out of bounds, got %d which should be ≤ %d", sample, test.max)
+				}
+			}
+		})
+	}
+}
+
+func TestRangeSolver_EmptyRegionsFailToProduceAValue(t *testing.T) {
+	rnd := rand.New()
+	solver := NewRangeSolver[uint8](4, 2)
+	sample, err := solver.Generate(rnd)
+	if !errors.Is(err, ErrUnsatisfiable) {
+		t.Errorf("solver should have failed to produce a value in unsatisfiable range, got %d with error %v", sample, err)
+	}
+}
+
+func TestRangeSolver_RangesCanBeIncrementallyConstraint(t *testing.T) {
+	// initial boundaries are considered
+	solver := NewRangeSolver[int32](1, 200)
+	if want, got := "1≤X≤200", solver.String(); want != got {
+		t.Errorf("unexpected range restriction, wanted %s, got %s", want, got)
+	}
+
+	// boundaries can be further restricted
+	solver.AddLowerBoundary(5)
+	if want, got := "5≤X≤200", solver.String(); want != got {
+		t.Errorf("unexpected range restriction, wanted %s, got %s", want, got)
+	}
+	solver.AddUpperBoundary(64)
+	if want, got := "5≤X≤64", solver.String(); want != got {
+		t.Errorf("unexpected range restriction, wanted %s, got %s", want, got)
+	}
+
+	// weaker boundaries are ignored
+	solver.AddLowerBoundary(3)
+	if want, got := "5≤X≤64", solver.String(); want != got {
+		t.Errorf("unexpected range restriction, wanted %s, got %s", want, got)
+	}
+	solver.AddUpperBoundary(100)
+	if want, got := "5≤X≤64", solver.String(); want != got {
+		t.Errorf("unexpected range restriction, wanted %s, got %s", want, got)
+	}
+	if !solver.IsSatisfiable() {
+		t.Errorf("interval should be solvable: %s", solver.String())
+	}
+
+	// equality constraints are supported
+	solver.AddEqualityConstraint(7)
+	if want, got := "X=7", solver.String(); want != got {
+		t.Errorf("unexpected range restriction, wanted %s, got %s", want, got)
+	}
+	if !solver.IsSatisfiable() {
+		t.Errorf("interval should be solvable: %s", solver.String())
+	}
+
+	// conflicts lead to unsatisfiable solution
+	solver.AddLowerBoundary(8)
+	if want, got := "unsatisfiable(X)", solver.String(); want != got {
+		t.Errorf("unexpected range restriction, wanted %s, got %s", want, got)
+	}
+	if solver.IsSatisfiable() {
+		t.Errorf("interval should not be solvable: %s", solver.String())
+	}
+}
+
+func TestRangeSolver_CanHandleMaximumRangeInt64(t *testing.T) {
+	rnd := rand.New()
+	solver := NewRangeSolver[int64](math.MinInt64, math.MaxInt64)
+	_, err := solver.Generate(rnd)
+	if err != nil {
+		t.Fatalf("failed to produce a sample: %v", err)
+	}
+}
+
+func TestRangeSolver_CanHandleMaximumRangeUint64(t *testing.T) {
+	rnd := rand.New(0)
+	solver := NewRangeSolver[uint64](0, math.MaxUint64)
+	_, err := solver.Generate(rnd)
+	if err != nil {
+		t.Fatalf("failed to produce a sample: %v", err)
+	}
+}

--- a/go/ct/gen/stack_test.go
+++ b/go/ct/gen/stack_test.go
@@ -66,8 +66,8 @@ func TestStackGenerator_SizeRangesAreEnforced(t *testing.T) {
 	rnd := rand.New(0)
 	for _, size := range sizes {
 		generator := NewStackGenerator()
-		generator.SetMinSize(size.min)
-		generator.SetMaxSize(size.max)
+		generator.AddMinSize(size.min)
+		generator.AddMaxSize(size.max)
 		stack, err := generator.Generate(nil, rnd)
 		if err != nil {
 			t.Fatalf("unexpected error during build: %v", err)
@@ -99,8 +99,8 @@ func TestStackGenerator_ConflictingSizesAreDetected(t *testing.T) {
 
 func TestStackGenerator_EmptySizeIntervalIsDetected(t *testing.T) {
 	generator := NewStackGenerator()
-	generator.SetMinSize(14)
-	generator.SetMaxSize(12)
+	generator.AddMinSize(14)
+	generator.AddMaxSize(12)
 	rnd := rand.New(0)
 	if _, err := generator.Generate(nil, rnd); !errors.Is(err, ErrUnsatisfiable) {
 		t.Errorf("unsatisfiable constraint not detected, got %v", err)
@@ -255,8 +255,8 @@ func TestStackGenerator_NonConflictingValuePositionsWithRangeSizesAreAccepted(t 
 
 	for _, test := range tests {
 		generator := NewStackGenerator()
-		generator.SetMinSize(test.min)
-		generator.SetMaxSize(test.max)
+		generator.AddMinSize(test.min)
+		generator.AddMaxSize(test.max)
 		generator.SetValue(test.pos, NewU256(21))
 		rnd := rand.New(0)
 		stack, err := generator.Generate(nil, rnd)
@@ -301,8 +301,8 @@ func TestStackGenerator_ConflictingValuePositionsWithSizeRangeAreDetected(t *tes
 
 	for _, test := range tests {
 		generator := NewStackGenerator()
-		generator.SetMinSize(test.min)
-		generator.SetMaxSize(test.max)
+		generator.AddMinSize(test.min)
+		generator.AddMaxSize(test.max)
 		generator.SetValue(test.pos, NewU256(21))
 		rnd := rand.New(0)
 		if _, err := generator.Generate(nil, rnd); !errors.Is(err, ErrUnsatisfiable) {
@@ -356,12 +356,12 @@ func TestStackGenerator_ClonesAreIndependent(t *testing.T) {
 	clone2.SetValue(0, NewU256(17))
 	clone2.BindValue(1, v)
 
-	want := "{5≤size≤5,value[0]=0000000000000000 0000000000000000 0000000000000000 0000000000000010,value[2]=$v}"
+	want := "{size=5,value[0]=0000000000000000 0000000000000000 0000000000000000 0000000000000010,value[2]=$v}"
 	if got := clone1.String(); got != want {
 		t.Errorf("invalid clone, wanted %s, got %s", want, got)
 	}
 
-	want = "{5≤size≤5,value[0]=0000000000000000 0000000000000000 0000000000000000 0000000000000011,value[1]=$v}"
+	want = "{size=5,value[0]=0000000000000000 0000000000000000 0000000000000000 0000000000000011,value[1]=$v}"
 	if got := clone2.String(); got != want {
 		t.Errorf("invalid clone, wanted %s, got %s", want, got)
 	}
@@ -380,13 +380,13 @@ func TestStackGenerator_ClonesCanBeUsedToResetGenerator(t *testing.T) {
 	generator.SetValue(1, NewU256(16))
 	generator.BindValue(3, v)
 
-	want := "{5≤size≤5,value[0]=0000000000000000 0000000000000000 0000000000000000 000000000000002a,value[1]=0000000000000000 0000000000000000 0000000000000000 0000000000000010,value[2]=$v,value[3]=$v}"
+	want := "{size=5,value[0]=0000000000000000 0000000000000000 0000000000000000 000000000000002a,value[1]=0000000000000000 0000000000000000 0000000000000000 0000000000000010,value[2]=$v,value[3]=$v}"
 	if got := generator.String(); got != want {
 		t.Errorf("unexpected generator state, wanted %s, got %s", want, got)
 	}
 
 	generator.Restore(backup)
-	want = "{value[0]=0000000000000000 0000000000000000 0000000000000000 000000000000002a,value[2]=$v}"
+	want = "{0≤size≤1024,value[0]=0000000000000000 0000000000000000 0000000000000000 000000000000002a,value[2]=$v}"
 	if got := generator.String(); got != want {
 		t.Errorf("unexpected generator state, wanted %s, got %s", want, got)
 	}

--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -337,7 +337,7 @@ func (c *revisionBounds) Check(s *st.State) (bool, error) {
 }
 
 func (c *revisionBounds) Restrict(generator *gen.StateGenerator) {
-	generator.SetRevisionBounds(c.min, c.max)
+	generator.AddRevisionBounds(c.min, c.max)
 }
 
 func (e *revisionBounds) GetTestValues() []TestValue {

--- a/go/ct/rlz/expressions.go
+++ b/go/ct/rlz/expressions.go
@@ -145,11 +145,15 @@ func (gas) Eval(s *st.State) (vm.Gas, error) {
 func (gas) Restrict(kind RestrictionKind, amount vm.Gas, generator *gen.StateGenerator) {
 	switch kind {
 	case RestrictLess:
-		generator.SetGas(amount - 1)
-	case RestrictLessEqual, RestrictEqual, RestrictGreaterEqual:
+		generator.AddGasUpperBound(amount - 1)
+	case RestrictLessEqual:
+		generator.AddGasUpperBound(amount)
+	case RestrictEqual:
 		generator.SetGas(amount)
+	case RestrictGreaterEqual:
+		generator.AddGasLowerBound(amount)
 	case RestrictGreater:
-		generator.SetGas(amount + 1)
+		generator.AddGasLowerBound(amount + 1)
 	}
 }
 
@@ -175,10 +179,18 @@ func (gasRefund) Eval(s *st.State) (vm.Gas, error) {
 }
 
 func (gasRefund) Restrict(kind RestrictionKind, amount vm.Gas, generator *gen.StateGenerator) {
-	if kind != RestrictEqual {
-		panic("GasRefund only supports equality constraints")
+	switch kind {
+	case RestrictLess:
+		generator.AddGasRefundUpperBound(amount - 1)
+	case RestrictLessEqual:
+		generator.AddGasRefundUpperBound(amount)
+	case RestrictEqual:
+		generator.SetGasRefund(amount)
+	case RestrictGreaterEqual:
+		generator.AddGasRefundLowerBound(amount)
+	case RestrictGreater:
+		generator.AddGasRefundLowerBound(amount + 1)
 	}
-	generator.SetGasRefund(amount)
 }
 
 func (gasRefund) String() string {
@@ -277,15 +289,15 @@ func (stackSize) Eval(s *st.State) (int, error) {
 func (stackSize) Restrict(kind RestrictionKind, size int, generator *gen.StateGenerator) {
 	switch kind {
 	case RestrictLess:
-		generator.SetMaxStackSize(size - 1)
+		generator.AddStackSizeUpperBound(size - 1)
 	case RestrictLessEqual:
-		generator.SetMaxStackSize(size)
+		generator.AddStackSizeUpperBound(size)
 	case RestrictEqual:
 		generator.SetStackSize(size)
 	case RestrictGreaterEqual:
-		generator.SetMinStackSize(size)
+		generator.AddStackSizeLowerBound(size)
 	case RestrictGreater:
-		generator.SetMinStackSize(size + 1)
+		generator.AddStackSizeLowerBound(size + 1)
 	}
 }
 

--- a/go/ct/rlz/expressions_test.go
+++ b/go/ct/rlz/expressions_test.go
@@ -193,10 +193,10 @@ func TestExpression_GasConstraints(t *testing.T) {
 				return ConsumeContinue
 			})
 			if hits == 0 && !test.unsatisfiable {
-				t.Errorf("failed to generate matching test case")
+				t.Errorf("failed to generate matching test case, got %d hits and %d misses", hits, misses)
 			}
 			if misses == 0 && !test.valid {
-				t.Errorf("failed to generate non-matching test case")
+				t.Errorf("failed to generate non-matching test case, got %d hits and %d misses", hits, misses)
 			}
 		})
 	}


### PR DESCRIPTION
This PR introduces a new `RangeSolver` utility capable of handling range constraints of the shape
```
constraint ::= true | constraint ∧ clause
clause     ::= X op C
op         ::= < | ≤ | = | ≥ | >
```
where `X` is a numeric property to be solved for and `C` are constants.

This common range solver is integrated into the `StateGenerator` to cover `Gas`, `GasRefund`, `Revision`, and `StackSize` constraints. By doing so, also the terminology used for defining constraints on those parameters was aligned.