### PR TITLE
Restrict domain for value parameters in Call rules

### DIFF
--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -157,6 +157,28 @@ func (d u256Domain) SamplesForAll(as []U256) []U256 {
 	return res
 }
 
+// valueDomain is a domain value parameters of call expressions.
+type valueDomain struct {
+	u256Domain
+}
+
+func (d valueDomain) Samples(a U256) []U256 {
+	return d.SamplesForAll([]U256{a})
+}
+
+func (d valueDomain) SamplesForAll(as []U256) []U256 {
+	res := []U256{}
+
+	// Test every element off by one.
+	for _, a := range as {
+		res = append(res, d.Predecessor(a))
+		res = append(res, a)
+		res = append(res, d.Successor(a))
+	}
+
+	return res
+}
+
 ////////////////////////////////////////////////////////////
 // Revision
 

--- a/go/ct/rlz/expressions.go
+++ b/go/ct/rlz/expressions.go
@@ -310,17 +310,22 @@ func (stackSize) String() string {
 
 type param struct {
 	position int
+	domain   Domain[U256]
 }
 
 const ErrStackOutOfBoundsAccess = ConstErr("out-of-bounds stack access")
 
 func Param(pos int) BindableExpression[U256] {
-	return param{pos}
+	return param{pos, u256Domain{}}
+}
+
+func ValueParam(pos int) BindableExpression[U256] {
+	return param{pos, valueDomain{}}
 }
 
 func (p param) Property() Property { return Property(p.String()) }
 
-func (param) Domain() Domain[U256] { return u256Domain{} }
+func (p param) Domain() Domain[U256] { return p.domain }
 
 func (p param) Eval(s *st.State) (U256, error) {
 	stack := s.Stack

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -1962,7 +1962,7 @@ func callOpIstanbul() []Rule {
 		Condition: And(
 			isCallWithSufficientGasAndStack,
 			Eq(ReadOnly(), true),
-			Eq(Param(2), NewU256(0)),
+			Eq(ValueParam(2), NewU256(0)),
 		),
 		Parameter: parameters,
 		Effect:    performsCall,


### PR DESCRIPTION
This PR reduces the number of test samples for value parameters of Call expressions from 11 to 3.

Number of test cases before: 2141852308
Number of test cases after: 748393108 (-65%)