### PR TITLE
Check balance in VM create implementations

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -1461,11 +1461,12 @@ struct CreateImpl {
 
     ctx.return_data.clear();
 
-    if (endowment != 0 && ToUint256(ctx.host->get_balance(ctx.message->recipient)) < endowment) {
-      return {.state = RunState::kErrorCreate};
-    }
-
     auto init_code = ctx.memory.GetSpan(init_code_offset, init_code_size);
+
+    if (endowment != 0 && ToUint256(ctx.host->get_balance(ctx.message->recipient)) < endowment) {
+      top[0] = 0;
+      return {.dynamic_gas_costs = initial_gas - gas};
+    }
 
     evmc_message msg{
         .kind = (Op == op::CREATE) ? EVMC_CREATE : EVMC_CREATE2,

--- a/go/vm/lfvm/instructions.go
+++ b/go/vm/lfvm/instructions.go
@@ -755,7 +755,7 @@ func opCreate(c *context) {
 	}
 
 	if !value.IsZero() {
-		balance := [32]byte(c.context.GetBalance(c.params.Recipient))
+		balance := c.context.GetBalance(c.params.Recipient)
 		balanceU256 := new(uint256.Int).SetBytes(balance[:])
 
 		if value.Gt(balanceU256) {

--- a/go/vm/lfvm/instructions.go
+++ b/go/vm/lfvm/instructions.go
@@ -741,8 +741,9 @@ func opExtcodehash(c *context) {
 
 func opCreate(c *context) {
 	var (
-		value        = vm.Value(c.stack.pop().Bytes32())
-		offset, size = c.stack.pop(), c.stack.pop()
+		value  = c.stack.pop()
+		offset = c.stack.pop()
+		size   = c.stack.pop()
 	)
 	if err := checkSizeOffsetUint64Overflow(offset, size); err != nil {
 		c.SignalError(err)
@@ -751,6 +752,17 @@ func opCreate(c *context) {
 
 	if c.memory.EnsureCapacity(offset.Uint64(), size.Uint64(), c) != nil {
 		return
+	}
+
+	if !value.IsZero() {
+		balance := [32]byte(c.context.GetBalance(c.params.Recipient))
+		balanceU256 := new(uint256.Int).SetBytes(balance[:])
+
+		if value.Gt(balanceU256) {
+			c.stack.pushEmpty().Clear()
+			c.return_data = nil
+			return
+		}
 	}
 
 	input := c.memory.GetSlice(offset.Uint64(), size.Uint64())
@@ -764,7 +776,7 @@ func opCreate(c *context) {
 
 	res, err := c.context.Call(vm.Create, vm.CallParameter{
 		Sender: c.params.Recipient,
-		Value:  value,
+		Value:  vm.Value(value.Bytes32()),
 		Input:  input,
 		Gas:    gas,
 	})


### PR DESCRIPTION
LFVM and evmzero did not handle the CREATE instruction correctly if a value higher than the accounts balance has been sent. This is fixed with this PR.
Regression tests are going to be added with the addition of the CREATE instruction to the CT in #441.