### PR TITLE
Add default limit to number of errors

### DIFF
--- a/go/ct/driver/run.go
+++ b/go/ct/driver/run.go
@@ -57,7 +57,7 @@ var RunCmd = cli.Command{
 		&cli.IntFlag{
 			Name:  "max-errors",
 			Usage: "aborts testing after the given number of issues",
-			Value: -1,
+			Value: 100,
 		},
 		&cli.Uint64Flag{
 			Name:  "seed",


### PR DESCRIPTION
If something is off in the specification it can happen that millions of errors are detected. In such cases, the driver would crash with an out-of-memory errors.

There is usually no need to ever produce that many issues, thus this PR reduces the default limit for errors to 100.