### PR TITLE
CT: add CREATE2 to specification

### DIFF
--- a/go/ct/common/opcodes.go
+++ b/go/ct/common/opcodes.go
@@ -156,6 +156,7 @@ const (
 	CALL           OpCode = 0xF1
 	RETURN         OpCode = 0xF3
 	DELEGATECALL   OpCode = 0xF4
+	CREATE2        OpCode = 0xF5
 	STATICCALL     OpCode = 0xFA
 	REVERT         OpCode = 0xFD
 	INVALID        OpCode = 0xFE
@@ -470,6 +471,8 @@ func (op OpCode) String() string {
 		return "RETURN"
 	case DELEGATECALL:
 		return "DELEGATECALL"
+	case CREATE2:
+		return "CREATE2"
 	case STATICCALL:
 		return "STATICCALL"
 	case REVERT:

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -1459,6 +1459,24 @@ func getAllRules() []Rule {
 
 	rules = append(rules, rulesFor(instruction{
 		op:        CREATE2,
+		name:      "_staticcall",
+		staticGas: 32000,
+		pops:      3,
+		pushes:    1,
+		conditions: []Condition{
+			Eq(ReadOnly(), true),
+		},
+		parameters: []Parameter{
+			ValueParameter{},
+			MemoryOffsetParameter{},
+			MemorySizeParameter{},
+			NumericParameter{},
+		},
+		effect: FailEffect().Apply,
+	})...)
+
+	rules = append(rules, rulesFor(instruction{
+		op:        CREATE2,
 		staticGas: 32000,
 		pops:      4,
 		pushes:    1,

--- a/go/ct/st/call_journal.go
+++ b/go/ct/st/call_journal.go
@@ -25,8 +25,9 @@ import (
 // of calls as well as the effect of future calls to be triggered
 // by CREATE and CALL expressions.
 type CallJournal struct {
-	Past   []PastCall
-	Future []FutureCall
+	Past        []PastCall
+	Future      []FutureCall
+	ToBeCreated vm.Address
 }
 
 func NewCallJournal() *CallJournal {

--- a/go/ct/st/call_journal.go
+++ b/go/ct/st/call_journal.go
@@ -181,5 +181,8 @@ func (c *FutureCall) Diff(other *FutureCall) []string {
 	if have, got := c.GasRefund, other.GasRefund; have != got {
 		res = append(res, fmt.Sprintf("different refund: %v vs %v", have, got))
 	}
+	if have, got := c.CreatedAccount, other.CreatedAccount; have != got {
+		res = append(res, fmt.Sprintf("different created account: %v vs %v", have, got))
+	}
 	return res
 }

--- a/go/ct/st/call_journal.go
+++ b/go/ct/st/call_journal.go
@@ -25,9 +25,8 @@ import (
 // of calls as well as the effect of future calls to be triggered
 // by CREATE and CALL expressions.
 type CallJournal struct {
-	Past        []PastCall
-	Future      []FutureCall
-	ToBeCreated vm.Address
+	Past   []PastCall
+	Future []FutureCall
 }
 
 func NewCallJournal() *CallJournal {
@@ -181,9 +180,6 @@ func (c *FutureCall) Diff(other *FutureCall) []string {
 	}
 	if have, got := c.GasRefund, other.GasRefund; have != got {
 		res = append(res, fmt.Sprintf("different refund: %v vs %v", have, got))
-	}
-	if have, got := c.CreatedAccount, other.CreatedAccount; have != got {
-		res = append(res, fmt.Sprintf("different created account: %v vs %v", have, got))
 	}
 	return res
 }

--- a/go/vm/geth/ct.go
+++ b/go/vm/geth/ct.go
@@ -255,19 +255,13 @@ func (i *callInterceptor) Create2(env *geth_vm.EVM, me geth_vm.ContractRef, code
 
 	var vmValue vm.Value
 	value.FillBytes(vmValue[:])
-	res, _ := i.context.Call(vm.Create2, vm.CallParameter{
+	res, err := i.makeCall(vm.Create2, vm.CallParameter{
 		Sender: vm.Address(me.Address()),
 		Value:  vmValue,
 		Gas:    vm.Gas(gas),
 		Input:  code,
 		Salt:   salt.Bytes32(),
 	})
-
-	i.handleGasRefund(res.GasRefund)
-	err := geth_vm.ErrExecutionReverted
-	if res.Success {
-		err = nil
-	}
 
 	return res.Output, geth_common.Address(res.CreatedAddress), uint64(res.GasLeft), err
 }

--- a/go/vm/geth/ct.go
+++ b/go/vm/geth/ct.go
@@ -247,8 +247,29 @@ func (i *callInterceptor) Create(env *geth_vm.EVM, me geth_vm.ContractRef, code 
 
 }
 
-func (i *callInterceptor) Create2(env *geth_vm.EVM, me geth_vm.ContractRef, code []byte, gas uint64, endowment *big.Int, salt *uint256.Int) ([]byte, geth_common.Address, uint64, error) {
-	panic("not implemented")
+func (i *callInterceptor) Create2(env *geth_vm.EVM, me geth_vm.ContractRef, code []byte, gas uint64, value *big.Int, salt *uint256.Int) ([]byte, geth_common.Address, uint64, error) {
+	have := i.stateDb.GetBalance(me.Address())
+	if value.Cmp(have) > 0 {
+		return nil, geth_common.Address{}, gas, geth_vm.ErrInsufficientBalance
+	}
+
+	var vmValue vm.Value
+	value.FillBytes(vmValue[:])
+	res, _ := i.context.Call(vm.Create2, vm.CallParameter{
+		Sender: vm.Address(me.Address()),
+		Value:  vmValue,
+		Gas:    vm.Gas(gas),
+		Input:  code,
+		Salt:   salt.Bytes32(),
+	})
+
+	i.handleGasRefund(res.GasRefund)
+	err := geth_vm.ErrExecutionReverted
+	if res.Success {
+		err = nil
+	}
+
+	return res.Output, geth_common.Address(res.CreatedAddress), uint64(res.GasLeft), err
 }
 
 func (i *callInterceptor) handleGasRefund(refund vm.Gas) {

--- a/go/vm/lfvm/instructions.go
+++ b/go/vm/lfvm/instructions.go
@@ -814,6 +814,12 @@ func opCreate2(c *context) {
 		return
 	}
 
+	// Charge for the code size
+	words := (size.Uint64() + 31) / 32
+	if !c.UseGas(vm.Gas(6 * words)) {
+		return
+	}
+
 	if !value.IsZero() {
 		balance := c.context.GetBalance(c.params.Recipient)
 		balanceU256 := new(uint256.Int).SetBytes(balance[:])
@@ -826,12 +832,6 @@ func opCreate2(c *context) {
 	}
 
 	input := c.memory.GetSlice(offset.Uint64(), size.Uint64())
-
-	// Charge for the code size
-	words := (size.Uint64() + 31) / 32
-	if !c.UseGas(vm.Gas(6 * words)) {
-		return
-	}
 
 	// Apply EIP150
 	gas := c.gas


### PR DESCRIPTION
This PR adds the CREATE2 opcode to the CT specification. 
Fixes #385.