### PR TITLE
CT: Add BlockHash op

### DIFF
--- a/go/ct/common/opcodes.go
+++ b/go/ct/common/opcodes.go
@@ -63,6 +63,7 @@ const (
 	RETURNDATASIZE OpCode = 0x3D
 	RETURNDATACOPY OpCode = 0x3E
 	EXTCODEHASH    OpCode = 0x3F
+	BLOCKHASH      OpCode = 0x40
 	COINBASE       OpCode = 0x41
 	TIMESTAMP      OpCode = 0x42
 	NUMBER         OpCode = 0x43
@@ -286,6 +287,8 @@ func (op OpCode) String() string {
 		return "RETURNDATACOPY"
 	case EXTCODEHASH:
 		return "EXTCODEHASH"
+	case BLOCKHASH:
+		return "BLOCKHASH"
 	case COINBASE:
 		return "COINBASE"
 	case TIMESTAMP:

--- a/go/ct/common/revisions.go
+++ b/go/ct/common/revisions.go
@@ -131,8 +131,8 @@ func GetBlockRangeLengthFor(revision Revision) (uint64, error) {
 	}
 	revisionNumberLength := uint64(0)
 
-	// if it's the last supported revision, the blockNumber range has no limit.
-	// if it's not, we want to limit this range to the first block number of next revision.
+	// if it's the last supported revision, the blockNumber length has no limit.
+	// if it's not, we want to limit this length to the first block number of next revision.
 	if revision < R99_UnknownNextRevision {
 		nextRevisionNumber, err := GetForkBlock(revision + 1)
 		if err != nil {

--- a/go/ct/common/revisions.go
+++ b/go/ct/common/revisions.go
@@ -107,17 +107,17 @@ func GetForkBlock(revision Revision) (uint64, error) {
 	case R07_Istanbul:
 		return 0, nil
 	case R09_Berlin:
-		return 10, nil
+		return 1000, nil
 	case R10_London:
-		return 20, nil
+		return 2000, nil
 	case R11_Paris:
-		return 30, nil
+		return 3000, nil
 	case R12_Shanghai:
-		return 40, nil
+		return 4000, nil
 	case R13_Cancun:
-		return 50, nil
+		return 5000, nil
 	case R99_UnknownNextRevision:
-		return 60, nil
+		return 6000, nil
 	}
 	return 0, fmt.Errorf("unknown revision: %v", revision)
 }
@@ -129,7 +129,7 @@ func GetBlockRangeLengthFor(revision Revision) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	revisionNumberRange := uint64(0)
+	revisionNumberLength := uint64(0)
 
 	// if it's the last supported revision, the blockNumber range has no limit.
 	// if it's not, we want to limit this range to the first block number of next revision.
@@ -140,7 +140,7 @@ func GetBlockRangeLengthFor(revision Revision) (uint64, error) {
 		}
 		// since we know both numbers are positive, and nextRevisionNumber is bigger,
 		// we can safely convert them to uint64
-		revisionNumberRange = nextRevisionNumber - revisionNumber
+		revisionNumberLength = nextRevisionNumber - revisionNumber
 	}
-	return revisionNumberRange, nil
+	return revisionNumberLength, nil
 }

--- a/go/ct/common/revisions_test.go
+++ b/go/ct/common/revisions_test.go
@@ -22,12 +22,12 @@ func TestRevisions_RangeLength(t *testing.T) {
 		revision    Revision
 		rangeLength uint64
 	}{
-		"Istanbul":    {R07_Istanbul, 10},
-		"Berlin":      {R09_Berlin, 10},
-		"London":      {R10_London, 10},
-		"Paris":       {R11_Paris, 10},
-		"Shanghai":    {R12_Shanghai, 10},
-		"Cancun":      {R13_Cancun, 10},
+		"Istanbul":    {R07_Istanbul, 1000},
+		"Berlin":      {R09_Berlin, 1000},
+		"London":      {R10_London, 1000},
+		"Paris":       {R11_Paris, 1000},
+		"Shanghai":    {R12_Shanghai, 1000},
+		"Cancun":      {R13_Cancun, 1000},
 		"UnknownNext": {R99_UnknownNextRevision, 0},
 	}
 
@@ -60,12 +60,12 @@ func TestRevisions_GetForkBlock(t *testing.T) {
 		forkBlock uint64
 	}{
 		"Istanbul":    {R07_Istanbul, 0},
-		"Berlin":      {R09_Berlin, 10},
-		"London":      {R10_London, 20},
-		"Paris":       {R11_Paris, 30},
-		"Shanghai":    {R12_Shanghai, 40},
-		"Cancun":      {R13_Cancun, 50},
-		"UnknownNext": {R99_UnknownNextRevision, 60},
+		"Berlin":      {R09_Berlin, 1000},
+		"London":      {R10_London, 2000},
+		"Paris":       {R11_Paris, 3000},
+		"Shanghai":    {R12_Shanghai, 4000},
+		"Cancun":      {R13_Cancun, 5000},
+		"UnknownNext": {R99_UnknownNextRevision, 6000},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/go/ct/evm_test.go
+++ b/go/ct/evm_test.go
@@ -37,7 +37,7 @@ var evms = map[string]ct.Evm{
 func TestCt_ExplicitCases(t *testing.T) {
 	tests := map[string]Condition{
 		"jump_to_2^32": And(
-			AnyKnownRevision(),
+			RevisionBounds(Revision(0), R10_London),
 			Eq(Status(), st.Running),
 			Eq(Op(Pc()), JUMP),
 			Eq(Op(Constant(NewU256(0))), JUMPDEST),
@@ -45,7 +45,7 @@ func TestCt_ExplicitCases(t *testing.T) {
 			Ge(Gas(), vm.Gas(8)),
 		),
 		"jumpi_to_2^32": And(
-			AnyKnownRevision(),
+			RevisionBounds(Revision(0), R10_London),
 			Eq(Status(), st.Running),
 			Eq(Op(Pc()), JUMPI),
 			Eq(Op(Constant(NewU256(0))), JUMPDEST),

--- a/go/ct/evm_test.go
+++ b/go/ct/evm_test.go
@@ -37,6 +37,7 @@ var evms = map[string]ct.Evm{
 func TestCt_ExplicitCases(t *testing.T) {
 	tests := map[string]Condition{
 		"jump_to_2^32": And(
+			AnyKnownRevision(),
 			Eq(Status(), st.Running),
 			Eq(Op(Pc()), JUMP),
 			Eq(Op(Constant(NewU256(0))), JUMPDEST),
@@ -44,6 +45,7 @@ func TestCt_ExplicitCases(t *testing.T) {
 			Ge(Gas(), vm.Gas(8)),
 		),
 		"jumpi_to_2^32": And(
+			AnyKnownRevision(),
 			Eq(Status(), st.Running),
 			Eq(Op(Pc()), JUMPI),
 			Eq(Op(Constant(NewU256(0))), JUMPDEST),

--- a/go/ct/gen/block_context.go
+++ b/go/ct/gen/block_context.go
@@ -13,43 +13,153 @@
 package gen
 
 import (
+	"fmt"
+	"math"
+	"slices"
+
 	"pgregory.net/rand"
 
 	"github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 )
 
+type inequalityType int
+
+const (
+	offsetLessThan inequalityType = iota
+	offsetGreaterThan
+)
+
+// variableInequality represents an inequality regarding the block number to be generated.
+// it should be interpreted as
+// `variable < (currentBlock - offset)` or `variable > (currentBlock - offset)`
+type variableInequality struct {
+	variable Variable
+	kind     inequalityType
+	offset   int64
+}
+
+// constraintPari is a pair of inequalities that represent a constraint that can either be that the variable is in a range such as
+// `(currentBlock - ofset) < variable < current block`
+// or that the variable should be out of the range such as
+// `variable < (currentBlock - offset) or variable > currentBlock`
+// it is assumed that both inequalities are regarding the same variable.
+type constraintPair struct {
+	lower variableInequality
+	upper variableInequality
+}
+
 type BlockContextGenerator struct {
+	variablesOffsetConstraints []constraintPair
 }
 
 func NewBlockContextGenerator() *BlockContextGenerator {
-	return &BlockContextGenerator{}
+	return &BlockContextGenerator{variablesOffsetConstraints: []constraintPair{}}
 }
 
-func (*BlockContextGenerator) Generate(rnd *rand.Rand, revision common.Revision) (st.BlockContext, error) {
+func (b *BlockContextGenerator) Generate(assignment Assignment, rnd *rand.Rand, revision common.Revision) (st.BlockContext, error) {
 	baseFee := common.RandU256(rnd)
+	blockNumberRangeSolver := NewRangeSolver(uint64(0), math.MaxUint64)
 
 	revisionNumber, err := common.GetForkBlock(revision)
 	if err != nil {
 		return st.BlockContext{}, err
 	}
-	revisionNumberRange, err := common.GetBlockRangeLengthFor(revision)
+
+	blockNumberRangeSolver.AddLowerBoundary(revisionNumber)
+	revisionNumberLength, err := common.GetBlockRangeLengthFor(revision)
 	if err != nil {
 		return st.BlockContext{}, err
 	}
-	var randomOffset uint64
-	if revisionNumberRange != 0 {
-		randomOffset = rnd.Uint64n(revisionNumberRange)
-	} else {
-		randomOffset = rnd.Uint64()
+	var blockNumber uint64
+	if revisionNumberLength != 0 {
+		blockNumberRangeSolver.AddUpperBoundary(revisionNumber + revisionNumberLength)
 	}
-	blockNumber := revisionNumber + randomOffset
+
+	// if any relevant variable is already bound, then we need to constraint the block number to be generated.
+	for _, offsetConstraint := range b.variablesOffsetConstraints {
+		if assignedValue, isBound := assignment[offsetConstraint.lower.variable]; isBound {
+
+			assignedValueI64 := int64(assignedValue.Uint64())
+			lowerBound := assignedValueI64 - offsetConstraint.upper.offset
+			upperBound := assignedValueI64 + offsetConstraint.lower.offset - 1
+
+			// if the range is only one number ( aka diff 2 ), then the assigned value must be within the range.
+			diff := offsetConstraint.upper.offset - offsetConstraint.lower.offset
+			isFixedValue := diff == 2 || diff == -2
+			isSameAsfixed := offsetConstraint.lower.offset-1 == assignedValueI64
+			if isFixedValue && !isSameAsfixed {
+				return st.BlockContext{}, ErrUnsatisfiable
+			} else if isFixedValue && isSameAsfixed {
+				blockNumberRangeSolver.AddEqualityConstraint(uint64(upperBound - 1))
+			}
+			// in case of desired out of range and bound value too small.
+			if lowerBound < 0 {
+				lowerBound = 0
+			}
+
+			blockNumberRangeSolver.AddLowerBoundary(uint64(lowerBound))
+			blockNumberRangeSolver.AddUpperBoundary(uint64(upperBound))
+
+			// if the range solver is now unsatisfiable, it is most likely because the assigned value is out of the range
+			// of the first number of the current revision - 256.
+			if !blockNumberRangeSolver.IsSatisfiable() {
+				return st.BlockContext{}, ErrUnsatisfiable
+			}
+		}
+	}
+
+	// generate block number
+	blockNumber, err = blockNumberRangeSolver.Generate(rnd)
+	if err != nil {
+		return st.BlockContext{}, err
+	}
+
+	variableRangeSolver := NewRangeSolver(math.MinInt64, int64(blockNumber))
+	baseSolver := NewRangeSolver(math.MinInt64, int64(blockNumber))
+	// for all non bound relevante variables, assign them a value based on the constraints.
+	for i, offsetConstraint := range b.variablesOffsetConstraints {
+		if _, isBound := assignment[offsetConstraint.lower.variable]; !isBound {
+			variableRangeSolver.Restore(baseSolver)
+			if difference := offsetConstraint.lower.offset - offsetConstraint.upper.offset; difference == 2 || difference == -2 {
+				// if the difference between the two offsets is 2, then we can only generate a fix value.
+				variableRangeSolver.AddEqualityConstraint(offsetConstraint.lower.offset - 1)
+			} else if offsetConstraint.lower.offset > 1 && offsetConstraint.upper.offset < 256 {
+				// if lower offset is greater than 1 and upper is less than 256 we generate in range.
+				variableRangeSolver.AddLowerBoundary(offsetConstraint.upper.offset)
+				variableRangeSolver.AddUpperBoundary(offsetConstraint.lower.offset)
+			} else {
+				// else have to generate out of range
+				// if blockNumber is too small, then we can only generate over the range.
+				if blockNumber < 256 {
+					variableRangeSolver.AddLowerBoundary(int64(blockNumber))
+					variableRangeSolver.AddUpperBoundary(math.MaxInt64)
+				} else {
+					// if blockNumber is large enough, we can generate under the range.
+					variableRangeSolver.AddLowerBoundary(256)
+					variableRangeSolver.AddUpperBoundary(int64(blockNumber) - 256)
+				}
+			}
+			newValue, err := variableRangeSolver.Generate(rnd)
+			if err != nil {
+				return st.BlockContext{}, err
+			}
+			assignment[offsetConstraint.lower.variable] = common.NewU256(uint64(int64(blockNumber) - newValue))
+		} else {
+			// if the variable is bound, then we need to check that it does not clash with any other constraint.
+			for _, previousConstraint := range b.variablesOffsetConstraints[:i] {
+				if previousConstraint.lower.variable == offsetConstraint.lower.variable {
+					if previousConstraint.lower.offset > offsetConstraint.upper.offset ||
+						previousConstraint.upper.offset < offsetConstraint.lower.offset {
+						return st.BlockContext{}, ErrUnsatisfiable
+					}
+				}
+			}
+		}
+	}
 
 	chainId := common.RandU256(rnd)
-	coinbase, err := common.RandAddress(rnd)
-	if err != nil {
-		return st.BlockContext{}, err
-	}
+	coinbase := common.RandomAddress(rnd)
 	gasLimit := rnd.Uint64()
 	gasPrice := common.RandU256(rnd)
 
@@ -68,13 +178,64 @@ func (*BlockContextGenerator) Generate(rnd *rand.Rand, revision common.Revision)
 	}, nil
 }
 
-func (*BlockContextGenerator) Clone() *BlockContextGenerator {
-	return &BlockContextGenerator{}
+func (b *BlockContextGenerator) Clone() *BlockContextGenerator {
+	return &BlockContextGenerator{variablesOffsetConstraints: slices.Clone(b.variablesOffsetConstraints)}
 }
 
-func (*BlockContextGenerator) Restore(*BlockContextGenerator) {
+func (b *BlockContextGenerator) Restore(other *BlockContextGenerator) {
+	if b == other {
+		return
+	}
+	b.variablesOffsetConstraints = slices.Clone(other.variablesOffsetConstraints)
 }
 
-func (*BlockContextGenerator) String() string {
-	return "{}"
+func (b *BlockContextGenerator) String() string {
+	defineOperatorString := func(val int64) (int64, string) {
+		if val >= 0 {
+			return val, "-"
+		} else {
+			return -val, "+"
+		}
+	}
+
+	var variablesOffsetConstraints string
+	for _, v := range b.variablesOffsetConstraints {
+		lower := v.lower
+		upper := v.upper
+		lowerOffset, lowerOperator := defineOperatorString(lower.offset)
+		upperOffset, upperOperator := defineOperatorString(upper.offset)
+		variablesOffsetConstraints += fmt.Sprintf("[%v > BlockNumber %v %v Λ %v < BlockNumber %v %v]", upper.variable, upperOperator, upperOffset, lower.variable, lowerOperator, lowerOffset) + " "
+	}
+	if len(variablesOffsetConstraints) != 0 {
+		variablesOffsetConstraints = variablesOffsetConstraints[:len(variablesOffsetConstraints)-1]
+	}
+
+	return "{variablesOffsetConstraints: " + variablesOffsetConstraints + "}"
+}
+
+func (b *BlockContextGenerator) AddBlockNumberOffsetConstraintIn(variable Variable) {
+	offsetLessThan := variableInequality{variable, offsetLessThan, 257}
+	offsetGreaterThan := variableInequality{variable, offsetGreaterThan, 0}
+	constraintIn := constraintPair{offsetLessThan, offsetGreaterThan}
+	if !slices.Contains(b.variablesOffsetConstraints, constraintIn) {
+		b.variablesOffsetConstraints = append(b.variablesOffsetConstraints, constraintIn)
+	}
+}
+
+func (b *BlockContextGenerator) AddBlockNumberOffsetConstraintOut(variable Variable) {
+	offsetLessThan := variableInequality{variable, offsetLessThan, 1}
+	offsetGreaterThan := variableInequality{variable, offsetGreaterThan, 256}
+	constraintOut := constraintPair{offsetLessThan, offsetGreaterThan}
+	if !slices.Contains(b.variablesOffsetConstraints, constraintOut) {
+		b.variablesOffsetConstraints = append(b.variablesOffsetConstraints, constraintOut)
+	}
+}
+
+func (b *BlockContextGenerator) SetBlockNumberOffsetValue(variable Variable, value int64) {
+	offsetLessThan := variableInequality{variable, offsetLessThan, value + 1}
+	offsetGreaterThan := variableInequality{variable, offsetGreaterThan, value - 1}
+	constraintValue := constraintPair{offsetLessThan, offsetGreaterThan}
+	if !slices.Contains(b.variablesOffsetConstraints, constraintValue) {
+		b.variablesOffsetConstraints = append(b.variablesOffsetConstraints, constraintValue)
+	}
 }

--- a/go/ct/gen/block_context_test.go
+++ b/go/ct/gen/block_context_test.go
@@ -272,14 +272,12 @@ func TestBlockContextGen_BlockNumberOffsetVariableBound(t *testing.T) {
 func TestBlockContextGen_Clone(t *testing.T) {
 	blockContextGenerator := NewBlockContextGenerator()
 	blockContextGenerator.variablesOffsetConstraints = append(blockContextGenerator.variablesOffsetConstraints, constraintPair{
-		lower: variableInequality{variable: "v1", offset: 1},
-		upper: variableInequality{variable: "v2", offset: 2},
-	})
+		variable: "v1", lowerOffset: 1, upperOffset: 2})
 
 	clone := blockContextGenerator.Clone()
-	clone.variablesOffsetConstraints[0].lower.offset = 3
+	clone.variablesOffsetConstraints[0].lowerOffset = 3
 
-	if blockContextGenerator.variablesOffsetConstraints[0].lower.offset != 1 {
+	if blockContextGenerator.variablesOffsetConstraints[0].lowerOffset != 1 {
 		t.Errorf("Original generator should not be affected by clone.")
 	}
 }

--- a/go/ct/gen/block_context_test.go
+++ b/go/ct/gen/block_context_test.go
@@ -14,6 +14,7 @@ package gen
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/vm"
@@ -21,9 +22,13 @@ import (
 )
 
 func TestBlockContextGen_Generate(t *testing.T) {
+	v1 := Variable("v1")
+	assignment := Assignment{}
+
 	rnd := rand.New(0)
 	blockContextGenerator := NewBlockContextGenerator()
-	blockCtx, err := blockContextGenerator.Generate(rnd, common.Revision(rnd.Int31n(int32(common.R99_UnknownNextRevision)+1)))
+	blockContextGenerator.AddBlockNumberOffsetConstraintIn(v1)
+	blockCtx, err := blockContextGenerator.Generate(assignment, rnd, common.Revision(rnd.Int31n(int32(common.R99_UnknownNextRevision)+1)))
 
 	if err != nil {
 		t.Errorf("Error generating block context: %v", err)
@@ -52,6 +57,9 @@ func TestBlockContextGen_Generate(t *testing.T) {
 	if blockCtx.TimeStamp == (uint64(0)) {
 		t.Errorf("Generated timestamp has default value.")
 	}
+	if _, isAssigned := assignment[v1]; !isAssigned {
+		t.Errorf("variable should have been assigned.")
+	}
 }
 
 func TestBlockContextGen_BlockNumber(t *testing.T) {
@@ -72,6 +80,8 @@ func TestBlockContextGen_BlockNumber(t *testing.T) {
 		t.Errorf("Failed to get future fork block number. %v", err)
 	}
 
+	assignment := Assignment{}
+
 	tests := map[string]struct {
 		revision common.Revision
 		min      uint64
@@ -86,7 +96,7 @@ func TestBlockContextGen_BlockNumber(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			blockContextGenerator := NewBlockContextGenerator()
-			blockCtx, err := blockContextGenerator.Generate(rnd, test.revision)
+			blockCtx, err := blockContextGenerator.Generate(assignment, rnd, test.revision)
 			if err != nil {
 				t.Errorf("Error generating block context: %v", err)
 			}
@@ -100,10 +110,176 @@ func TestBlockContextGen_BlockNumber(t *testing.T) {
 }
 
 func TestBlockContextGen_BlockNumberError(t *testing.T) {
+	assignment := Assignment{}
+
 	rnd := rand.New(0)
 	blockContextGenerator := NewBlockContextGenerator()
-	_, err := blockContextGenerator.Generate(rnd, common.R99_UnknownNextRevision+1)
+	_, err := blockContextGenerator.Generate(assignment, rnd, common.R99_UnknownNextRevision+1)
 	if err == nil {
 		t.Errorf("Failed to produce error with invalid revision.")
+	}
+}
+
+func TestBlockContextGen_BlockNumberOffsetVariableUnbound(t *testing.T) {
+	v1 := Variable("v1")
+	rnd := rand.New()
+
+	tests := map[string]struct {
+		addConstraint func(*BlockContextGenerator)
+		check         func(value, assignmentValue uint64) bool
+	}{
+		"WithinRange": {addConstraint: func(b *BlockContextGenerator) { b.AddBlockNumberOffsetConstraintIn("v1") },
+			check: func(blockNumber, assignmentValue uint64) bool {
+				return blockNumber > assignmentValue && assignmentValue >= blockNumber-256
+			}},
+		"FixedValue257": {addConstraint: func(b *BlockContextGenerator) { b.SetBlockNumberOffsetValue("v1", 257) },
+			check: func(blockNumber, assignmentValue uint64) bool {
+				return assignmentValue == blockNumber-257
+			}},
+		"FixedValue256": {addConstraint: func(b *BlockContextGenerator) { b.SetBlockNumberOffsetValue("v1", 256) },
+			check: func(blockNumber, assignmentValue uint64) bool {
+				return assignmentValue == blockNumber-256
+			}},
+		"FixedValue255": {addConstraint: func(b *BlockContextGenerator) { b.SetBlockNumberOffsetValue("v1", 255) },
+			check: func(blockNumber, assignmentValue uint64) bool {
+				return assignmentValue == blockNumber-255
+			}},
+		"FixedValue1": {addConstraint: func(b *BlockContextGenerator) { b.SetBlockNumberOffsetValue("v1", 1) },
+			check: func(blockNumber, assignmentValue uint64) bool {
+				return assignmentValue == blockNumber-1
+			}},
+		"FixedValue0": {addConstraint: func(b *BlockContextGenerator) { b.SetBlockNumberOffsetValue("v1", 0) },
+			check: func(blockNumber, assignmentValue uint64) bool {
+				return assignmentValue == blockNumber-0
+			}},
+		"FixedValue-1": {addConstraint: func(b *BlockContextGenerator) { b.SetBlockNumberOffsetValue("v1", -1) },
+			check: func(blockNumber, assignmentValue uint64) bool {
+				return assignmentValue == blockNumber+1
+			}},
+		"OutOfRange": {addConstraint: func(b *BlockContextGenerator) { b.AddBlockNumberOffsetConstraintOut("v1") },
+			check: func(blockNumber, assignmentValue uint64) bool {
+				return blockNumber <= assignmentValue || assignmentValue < blockNumber-256
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			assignment := Assignment{}
+			blockContextGenerator := NewBlockContextGenerator()
+			test.addConstraint(blockContextGenerator)
+			blockCtx, err := blockContextGenerator.Generate(assignment, rnd, common.MaxRevision-1)
+			if err != nil {
+				t.Errorf("Error generating block context: %v", err)
+			}
+			assignmentValue := assignment[v1].Uint64()
+			if !test.check(blockCtx.BlockNumber, assignmentValue) {
+				t.Errorf("Generated variable %v not in desired distance from block number %v.", assignment[v1].Uint64(), blockCtx.BlockNumber)
+			}
+		})
+	}
+}
+
+func TestBlockContextGen_BlockNumberOffsetError(t *testing.T) {
+	rnd := rand.New(0)
+
+	tests := map[string]struct {
+		fn func(*BlockContextGenerator)
+	}{
+		"outFirst": {fn: func(b *BlockContextGenerator) {
+			b.AddBlockNumberOffsetConstraintOut("v1")
+			b.AddBlockNumberOffsetConstraintIn("v1")
+		}},
+		"inFirst": {fn: func(b *BlockContextGenerator) {
+			b.AddBlockNumberOffsetConstraintIn("v1")
+			b.AddBlockNumberOffsetConstraintOut("v1")
+		}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assignment := Assignment{}
+			blockContextGenerator := NewBlockContextGenerator()
+			test.fn(blockContextGenerator)
+			_, err := blockContextGenerator.Generate(assignment, rnd, common.R07_Istanbul)
+			if err != ErrUnsatisfiable {
+				t.Errorf("Failed to produce error with conflicting range constraints.")
+			}
+		})
+	}
+}
+
+func TestBlockContextGen_BlockNumberOffsetVariableBound(t *testing.T) {
+	v1 := Variable("v1")
+	rnd := rand.New(uint64(time.Now().UnixNano()))
+	assignment := Assignment{}
+
+	assignmentValues := []common.U256{common.NewU256(512), common.NewU256(257),
+		common.NewU256(256), common.NewU256(255), common.NewU256(1), common.NewU256(0)}
+
+	tests := map[string]struct {
+		fn    func(*BlockContextGenerator)
+		check func(uint64, uint64) bool
+	}{
+		"inRange": {fn: func(b *BlockContextGenerator) { b.AddBlockNumberOffsetConstraintIn("v1") },
+			check: func(blockNumber, generated uint64) bool {
+				min := uint64(0)
+				if blockNumber > 256 {
+					min = blockNumber - 256
+				}
+				return blockNumber > generated && min <= generated
+			},
+		},
+		"outRange": {fn: func(b *BlockContextGenerator) { b.AddBlockNumberOffsetConstraintOut("v1") },
+			check: func(blockNumber, generated uint64) bool {
+				return blockNumber < generated || blockNumber-256 >= generated
+			},
+		},
+		"fixedValue": {fn: func(b *BlockContextGenerator) { b.SetBlockNumberOffsetValue("v1", 256) },
+			check: func(blockNumber, generated uint64) bool {
+				return generated == 256 && blockNumber-generated < 257
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			for _, value := range assignmentValues {
+				assignment[v1] = value
+				blockContextGenerator := NewBlockContextGenerator()
+				test.fn(blockContextGenerator)
+				blockContext, err := blockContextGenerator.Generate(assignment, rnd, common.R07_Istanbul)
+				if err != nil {
+					if value != common.NewU256(256) && err != ErrUnsatisfiable {
+						t.Errorf("Error generating block context: %v", err)
+					} else if value != common.NewU256(256) && err == ErrUnsatisfiable {
+						continue
+					}
+				}
+				blckNum := blockContext.BlockNumber
+				if assignment[v1] != value {
+					t.Error("assigned value should not have changed.")
+				}
+				if !test.check(blckNum, assignment[v1].Uint64()) {
+					t.Errorf("Block number should be in the expected range. got %v. assigned %v.", blckNum, assignment[v1].Uint64())
+				}
+			}
+		})
+	}
+}
+
+func TestBlockContextGen_Clone(t *testing.T) {
+	blockContextGenerator := NewBlockContextGenerator()
+	blockContextGenerator.variablesOffsetConstraints = append(blockContextGenerator.variablesOffsetConstraints, constraintPair{
+		lower: variableInequality{variable: "v1", offset: 1},
+		upper: variableInequality{variable: "v2", offset: 2},
+	})
+
+	clone := blockContextGenerator.Clone()
+	clone.variablesOffsetConstraints[0].lower.offset = 3
+
+	if blockContextGenerator.variablesOffsetConstraints[0].lower.offset != 1 {
+		t.Errorf("Original generator should not be affected by clone.")
 	}
 }

--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -398,10 +398,10 @@ func (g *StateGenerator) Generate(rnd *rand.Rand) (*st.State, error) {
 		return nil, err
 	}
 
-	// generate old block hashes
-	newBlockNumberHashes := [256]vm.Hash{}
+	// generate recent block hashes
+	resultRecentBlockHashes := [256]vm.Hash{}
 	for i := 0; i < 256; i++ {
-		newBlockNumberHashes[i] = getRandomHash(rnd)
+		resultRecentBlockHashes[i] = getRandomHash(rnd)
 	}
 
 	// Sub-generators can modify the assignment when unassigned variables are
@@ -456,7 +456,7 @@ func (g *StateGenerator) Generate(rnd *rand.Rand) (*st.State, error) {
 	result.LastCallReturnData = resultLastCallReturnData
 	result.ReturnData = resultReturnData
 	result.HasSelfDestructed = resultHasSelfdestructed
-	result.RecentBlockHashes = newBlockNumberHashes
+	result.RecentBlockHashes = resultRecentBlockHashes
 
 	return result, nil
 }

--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -248,12 +248,12 @@ func (g *StateGenerator) MustNotBeSelfDestructed() {
 	g.hasSelfDestructedGen.MarkAsNotSelfDestructed()
 }
 
-func (g *StateGenerator) AddBlockNumberOffsetConstraintIn(variable Variable) {
-	g.blockContextGen.AddBlockNumberOffsetConstraintIn(variable)
+func (g *StateGenerator) RestrictVariableToOneOfTheLast256Blocks(variable Variable) {
+	g.blockContextGen.RestrictVariableToOneOfTheLast256Blocks(variable)
 }
 
-func (g *StateGenerator) AddBlockNumberOffsetConstraintOut(variable Variable) {
-	g.blockContextGen.AddBlockNumberOffsetConstraintOut(variable)
+func (g *StateGenerator) RestrictVariableToNoneOfTheLast256Blocks(variable Variable) {
+	g.blockContextGen.RestrictVariableToNoneOfTheLast256Blocks(variable)
 }
 
 func (g *StateGenerator) SetBlockNumberOffsetValue(variable Variable, value int64) {

--- a/go/ct/gen/state_test.go
+++ b/go/ct/gen/state_test.go
@@ -307,7 +307,7 @@ func TestStateGenerator_ClonesAreIndependent(t *testing.T) {
 	clone1.AddStackSizeLowerBound(2)
 	clone1.AddStackSizeUpperBound(200)
 	clone1.BindValue(Variable("x"), NewU256(12))
-	clone1.SetBlockNumberOffsetValue(Variable("t"), 13)
+	clone1.RestrictVariableToOneOfTheLast256Blocks(Variable("t"))
 	clone1.MustBeSelfDestructed()
 
 	clone2 := base.Clone()
@@ -319,7 +319,7 @@ func TestStateGenerator_ClonesAreIndependent(t *testing.T) {
 	clone2.AddStackSizeLowerBound(3)
 	clone2.AddStackSizeUpperBound(300)
 	clone2.BindValue(Variable("y"), NewU256(14))
-	clone2.SetBlockNumberOffsetValue(Variable("s"), -15)
+	clone2.RestrictVariableToNoneOfTheLast256Blocks(Variable("s"))
 	clone2.MustNotBeSelfDestructed()
 
 	checkPrint := func(clone *StateGenerator, want []string) {
@@ -348,7 +348,7 @@ func TestStateGenerator_ClonesAreIndependent(t *testing.T) {
 		"accounts={}",
 		"callContext={}",
 		"callJournal={}",
-		"blockContext={variablesOffsetConstraints: [$t => BlockNumber - 13 Λ $t <= BlockNumber - 13]}",
+		"blockContext={variablesOffsetConstraints: [$t ≥ BlockNumber - 256 Λ $t ≤ BlockNumber - 1]}",
 		"selfdestruct={mustBeSelfDestructed}",
 	})
 
@@ -366,7 +366,7 @@ func TestStateGenerator_ClonesAreIndependent(t *testing.T) {
 		"accounts={}",
 		"callContext={}",
 		"callJournal={}",
-		"blockContext={variablesOffsetConstraints: [$s => BlockNumber + 15 Λ $s <= BlockNumber + 15]}",
+		"blockContext={variablesOffsetConstraints: [$s ≥ BlockNumber - 0 Λ $s ≤ BlockNumber - 257]}",
 		"selfdestruct={mustNotBeSelfDestructed}",
 	})
 }

--- a/go/ct/gen/state_test.go
+++ b/go/ct/gen/state_test.go
@@ -348,7 +348,7 @@ func TestStateGenerator_ClonesAreIndependent(t *testing.T) {
 		"accounts={}",
 		"callContext={}",
 		"callJournal={}",
-		"blockContext={variablesOffsetConstraints: [$t > BlockNumber - 12 Λ $t < BlockNumber - 14]}",
+		"blockContext={variablesOffsetConstraints: [$t => BlockNumber - 13 Λ $t <= BlockNumber - 13]}",
 		"selfdestruct={mustBeSelfDestructed}",
 	})
 
@@ -366,7 +366,7 @@ func TestStateGenerator_ClonesAreIndependent(t *testing.T) {
 		"accounts={}",
 		"callContext={}",
 		"callJournal={}",
-		"blockContext={variablesOffsetConstraints: [$s > BlockNumber + 16 Λ $s < BlockNumber + 14]}",
+		"blockContext={variablesOffsetConstraints: [$s => BlockNumber + 15 Λ $s <= BlockNumber + 15]}",
 		"selfdestruct={mustNotBeSelfDestructed}",
 	})
 }

--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -719,3 +719,89 @@ func (c *hasNotSelfDestructed) GetTestValues() []TestValue {
 func (c *hasNotSelfDestructed) String() string {
 	return "hasNotSelfDestructed()"
 }
+
+////////////////////////////////////////////////////////////
+// In Range 256 From Current Block
+
+type inRange256FromCurrentBlock struct {
+	blockNumber BindableExpression[U256]
+}
+
+func InRange256FromCurrentBlock(blockNumber BindableExpression[U256]) Condition {
+	return &inRange256FromCurrentBlock{blockNumber}
+}
+
+func (c *inRange256FromCurrentBlock) Check(s *st.State) (bool, error) {
+	paramBlockNumber, err := c.blockNumber.Eval(s)
+	if err != nil {
+		return false, err
+	}
+	if !paramBlockNumber.IsUint64() {
+		return false, nil
+	}
+	uintParam := paramBlockNumber.Uint64()
+	bottom := uint64(0)
+	if s.BlockContext.BlockNumber > 256 {
+		bottom = s.BlockContext.BlockNumber - 256
+	}
+
+	return bottom <= uintParam && uintParam < s.BlockContext.BlockNumber, nil
+}
+
+func (c *inRange256FromCurrentBlock) Restrict(generator *gen.StateGenerator) {
+	paramVariable := c.blockNumber.GetVariable()
+	c.blockNumber.BindTo(generator)
+	generator.AddBlockNumberOffsetConstraintIn(paramVariable)
+}
+
+func (c *inRange256FromCurrentBlock) GetTestValues() []TestValue {
+	property := Property(c.String())
+	domain := BlockNumberRangeDomain{}
+	restrict := func(generator *gen.StateGenerator, offset int64) {
+		paramVariable := c.blockNumber.GetVariable()
+		c.blockNumber.BindTo(generator)
+		generator.SetBlockNumberOffsetValue(paramVariable, offset)
+	}
+	testValues := []TestValue{}
+	var blockNumberDomain BlockNumberRangeDomain
+	for _, value := range blockNumberDomain.SamplesForAll([]int64{}) {
+		testValues = append(testValues, NewTestValue(property, domain, value, restrict))
+	}
+	return testValues
+}
+
+func (c *inRange256FromCurrentBlock) String() string {
+	return fmt.Sprintf("%v in range [CurrentBlockNumber - 256, CurrentBlockNumber)", c.blockNumber)
+}
+
+////////////////////////////////////////////////////////////
+// Out Of Range 256 From Current Block
+
+type outOfRange256FromCurrentBlock struct {
+	blockNumber BindableExpression[U256]
+}
+
+func OutOfRange256FromCurrentBlock(blockNumber BindableExpression[U256]) Condition {
+	return &outOfRange256FromCurrentBlock{blockNumber}
+}
+
+func (c *outOfRange256FromCurrentBlock) Check(s *st.State) (bool, error) {
+	res, err := InRange256FromCurrentBlock(c.blockNumber).Check(s)
+	return !res, err
+}
+
+func (c *outOfRange256FromCurrentBlock) Restrict(generator *gen.StateGenerator) {
+	paramVariable := c.blockNumber.GetVariable()
+	c.blockNumber.BindTo(generator)
+	generator.AddBlockNumberOffsetConstraintOut(paramVariable)
+}
+
+func (c *outOfRange256FromCurrentBlock) GetTestValues() []TestValue {
+	return InRange256FromCurrentBlock(c.blockNumber).GetTestValues()
+}
+
+func (c *outOfRange256FromCurrentBlock) String() string {
+	return fmt.Sprintf("%v out of range [CurrentBlockNumber - 256, CurrentBlockNumber)", c.blockNumber)
+}
+
+////////////////////////////////////////////////////////////

--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -751,27 +751,26 @@ func (c *inRange256FromCurrentBlock) Check(s *st.State) (bool, error) {
 func (c *inRange256FromCurrentBlock) Restrict(generator *gen.StateGenerator) {
 	paramVariable := c.blockNumber.GetVariable()
 	c.blockNumber.BindTo(generator)
-	generator.AddBlockNumberOffsetConstraintIn(paramVariable)
+	generator.RestrictVariableToOneOfTheLast256Blocks(paramVariable)
 }
 
 func (c *inRange256FromCurrentBlock) GetTestValues() []TestValue {
 	property := Property(c.String())
-	domain := BlockNumberRangeDomain{}
+	domain := BlockNumberOffsetDomain{}
 	restrict := func(generator *gen.StateGenerator, offset int64) {
 		paramVariable := c.blockNumber.GetVariable()
 		c.blockNumber.BindTo(generator)
 		generator.SetBlockNumberOffsetValue(paramVariable, offset)
 	}
 	testValues := []TestValue{}
-	var blockNumberDomain BlockNumberRangeDomain
-	for _, value := range blockNumberDomain.SamplesForAll([]int64{}) {
+	for _, value := range domain.SamplesForAll([]int64{}) {
 		testValues = append(testValues, NewTestValue(property, domain, value, restrict))
 	}
 	return testValues
 }
 
 func (c *inRange256FromCurrentBlock) String() string {
-	return fmt.Sprintf("%v in range [CurrentBlockNumber - 256, CurrentBlockNumber)", c.blockNumber)
+	return c.blockNumber.String()
 }
 
 ////////////////////////////////////////////////////////////
@@ -793,7 +792,7 @@ func (c *outOfRange256FromCurrentBlock) Check(s *st.State) (bool, error) {
 func (c *outOfRange256FromCurrentBlock) Restrict(generator *gen.StateGenerator) {
 	paramVariable := c.blockNumber.GetVariable()
 	c.blockNumber.BindTo(generator)
-	generator.AddBlockNumberOffsetConstraintOut(paramVariable)
+	generator.RestrictVariableToNoneOfTheLast256Blocks(paramVariable)
 }
 
 func (c *outOfRange256FromCurrentBlock) GetTestValues() []TestValue {
@@ -801,7 +800,7 @@ func (c *outOfRange256FromCurrentBlock) GetTestValues() []TestValue {
 }
 
 func (c *outOfRange256FromCurrentBlock) String() string {
-	return fmt.Sprintf("%v out of range [CurrentBlockNumber - 256, CurrentBlockNumber)", c.blockNumber)
+	return c.blockNumber.String()
 }
 
 ////////////////////////////////////////////////////////////

--- a/go/ct/rlz/conditions_test.go
+++ b/go/ct/rlz/conditions_test.go
@@ -13,6 +13,7 @@
 package rlz
 
 import (
+	"math"
 	"testing"
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
@@ -425,7 +426,7 @@ func TestCondition_InOut_Restrict(t *testing.T) {
 }
 
 func TestCondition_InOutOfRangeGetTestValues(t *testing.T) {
-	want := []int64{-1, 0, 1, 255, 256, 257}
+	want := []int64{math.MinInt64, -1, 0, 1, 255, 256, 257, math.MaxInt64}
 	tests := map[string]struct {
 		condition Condition
 	}{

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -404,7 +404,7 @@ func (d BlockNumberRangeDomain) Samples(a int64) []int64 {
 }
 
 func (BlockNumberRangeDomain) SamplesForAll(as []int64) []int64 {
-	res := []int64{-1, 0, 1, 255, 256, 257}
+	res := []int64{math.MinInt64, -1, 0, 1, 255, 256, 257, math.MaxInt64}
 
 	// Test every element off by one.
 	for _, a := range as {

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -389,21 +389,21 @@ func (gasDomain) SamplesForAll(as []vm.Gas) []vm.Gas {
 ////////////////////////////////////////////////////////////
 // BlockNumber Range Domain
 
-type BlockNumberRangeDomain struct{}
+type BlockNumberOffsetDomain struct{}
 
-func (BlockNumberRangeDomain) Equal(a int64, b int64) bool { return a == b }
-func (BlockNumberRangeDomain) Less(a int64, b int64) bool  { return a < b }
-func (BlockNumberRangeDomain) Predecessor(a int64) int64   { return a - 1 }
-func (BlockNumberRangeDomain) Successor(a int64) int64     { return a + 1 }
-func (BlockNumberRangeDomain) SomethingNotEqual(a int64) int64 {
+func (BlockNumberOffsetDomain) Equal(a int64, b int64) bool { return a == b }
+func (BlockNumberOffsetDomain) Less(a int64, b int64) bool  { return a < b }
+func (BlockNumberOffsetDomain) Predecessor(a int64) int64   { return a - 1 }
+func (BlockNumberOffsetDomain) Successor(a int64) int64     { return a + 1 }
+func (BlockNumberOffsetDomain) SomethingNotEqual(a int64) int64 {
 	return a + 1
 }
 
-func (d BlockNumberRangeDomain) Samples(a int64) []int64 {
+func (d BlockNumberOffsetDomain) Samples(a int64) []int64 {
 	return d.SamplesForAll([]int64{a})
 }
 
-func (BlockNumberRangeDomain) SamplesForAll(as []int64) []int64 {
+func (BlockNumberOffsetDomain) SamplesForAll(as []int64) []int64 {
 	res := []int64{math.MinInt64, -1, 0, 1, 255, 256, 257, math.MaxInt64}
 
 	// Test every element off by one.

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -385,3 +385,33 @@ func (gasDomain) SamplesForAll(as []vm.Gas) []vm.Gas {
 
 	return res
 }
+
+////////////////////////////////////////////////////////////
+// BlockNumber Range Domain
+
+type BlockNumberRangeDomain struct{}
+
+func (BlockNumberRangeDomain) Equal(a int64, b int64) bool { return a == b }
+func (BlockNumberRangeDomain) Less(a int64, b int64) bool  { return a < b }
+func (BlockNumberRangeDomain) Predecessor(a int64) int64   { return a - 1 }
+func (BlockNumberRangeDomain) Successor(a int64) int64     { return a + 1 }
+func (BlockNumberRangeDomain) SomethingNotEqual(a int64) int64 {
+	return a + 1
+}
+
+func (d BlockNumberRangeDomain) Samples(a int64) []int64 {
+	return d.SamplesForAll([]int64{a})
+}
+
+func (BlockNumberRangeDomain) SamplesForAll(as []int64) []int64 {
+	res := []int64{-1, 0, 1, 255, 256, 257}
+
+	// Test every element off by one.
+	for _, a := range as {
+		res = append(res, a-1)
+		res = append(res, a)
+		res = append(res, a+1)
+	}
+
+	return res
+}

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -791,6 +791,40 @@ func getAllRules() []Rule {
 		},
 	})...)
 
+	// --- BLOCKHASH ---
+
+	rules = append(rules, rulesFor(instruction{
+		op:        BLOCKHASH,
+		staticGas: 20,
+		pops:      1,
+		pushes:    1,
+		conditions: []Condition{
+			InRange256FromCurrentBlock(Param(0)),
+		},
+		parameters: []Parameter{NumericParameter{}},
+		effect: func(s *st.State) {
+			targetBlockNumber := s.Stack.Pop()
+			index := s.BlockContext.BlockNumber - targetBlockNumber.Uint64()
+			s.Stack.Push(NewU256FromBytes(s.RecentBlockHashes[index-1][:]...))
+		},
+	})...)
+
+	rules = append(rules, rulesFor(instruction{
+		op:        BLOCKHASH,
+		name:      "_out_of_range",
+		staticGas: 20,
+		pops:      1,
+		pushes:    1,
+		conditions: []Condition{
+			OutOfRange256FromCurrentBlock(Param(0)),
+		},
+		parameters: []Parameter{NumericParameter{}},
+		effect: func(s *st.State) {
+			s.Stack.Pop()
+			s.Stack.Push(NewU256(0))
+		},
+	})...)
+
 	// --- COINBASE ---
 
 	rules = append(rules, rulesFor(instruction{

--- a/go/ct/st/serialization.go
+++ b/go/ct/st/serialization.go
@@ -78,6 +78,7 @@ type stateSerializable struct {
 	CallJournal           *CallJournal
 	HasSelfDestructed     bool
 	SelfDestructedJournal []serializableSelfDestructEntry
+	RecentBlockHashes     [256]vm.Hash
 }
 
 // storageSerializable is a serializable representation of the Storage struct.
@@ -156,6 +157,7 @@ func newStateSerializableFromState(state *State) *stateSerializable {
 		CallJournal:           state.CallJournal,
 		HasSelfDestructed:     state.HasSelfDestructed,
 		SelfDestructedJournal: newSerializableJournal(state.SelfDestructedJournal),
+		RecentBlockHashes:     state.RecentBlockHashes,
 	}
 }
 
@@ -240,6 +242,7 @@ func (s *stateSerializable) deserialize() *State {
 			state.SelfDestructedJournal = append(state.SelfDestructedJournal, SelfDestructEntry{entry.Account, entry.Beneficiary})
 		}
 	}
+	state.RecentBlockHashes = s.RecentBlockHashes
 	return state
 }
 

--- a/go/ct/st/serialization_test.go
+++ b/go/ct/st/serialization_test.go
@@ -167,6 +167,7 @@ func TestSerialization_NewStateSerializableIsIndependent(t *testing.T) {
 	serializableState.LastCallReturnData = NewBytes([]byte{6})
 	serializableState.HasSelfDestructed = false
 	serializableState.SelfDestructedJournal = newSerializableJournal([]SelfDestructEntry{})
+	serializableState.RecentBlockHashes[0] = vm.Hash{0x02}
 
 	ok := s.Status == Running &&
 		s.Revision == R10_London &&
@@ -197,7 +198,8 @@ func TestSerialization_NewStateSerializableIsIndependent(t *testing.T) {
 		s.LastCallReturnData.Get(0, 1)[0] == 1 &&
 		s.HasSelfDestructed &&
 		len(s.SelfDestructedJournal) == 1 &&
-		s.SelfDestructedJournal[0] == SelfDestructEntry{vm.Address{1}, vm.Address{2}}
+		s.SelfDestructedJournal[0] == SelfDestructEntry{vm.Address{1}, vm.Address{2}} &&
+		s.RecentBlockHashes[0] == vm.Hash{0x01}
 
 	if !ok {
 		t.Errorf("new serializable state is not independent")
@@ -231,6 +233,7 @@ func TestSerialization_DeserializedStateIsIndependent(t *testing.T) {
 	deserializedState.LastCallReturnData = NewBytes([]byte{6})
 	deserializedState.HasSelfDestructed = false
 	deserializedState.SelfDestructedJournal = []SelfDestructEntry{}
+	deserializedState.RecentBlockHashes[0] = vm.Hash{0x02}
 
 	ok := s.Status == Running &&
 		s.Revision == R10_London &&
@@ -261,7 +264,8 @@ func TestSerialization_DeserializedStateIsIndependent(t *testing.T) {
 		s.LastCallReturnData.ToBytes()[0] == 1 &&
 		s.HasSelfDestructed &&
 		len(s.SelfDestructedJournal) == 1 &&
-		s.SelfDestructedJournal[0] == serializableSelfDestructEntry{vm.Address{1}, vm.Address{2}}
+		s.SelfDestructedJournal[0] == serializableSelfDestructEntry{vm.Address{1}, vm.Address{2}} &&
+		s.RecentBlockHashes[0] == vm.Hash{0x01}
 
 	if !ok {
 		t.Errorf("deserialized state is not independent")

--- a/go/ct/st/state.go
+++ b/go/ct/st/state.go
@@ -136,6 +136,7 @@ type State struct {
 	ReturnData            Bytes
 	HasSelfDestructed     bool
 	SelfDestructedJournal []SelfDestructEntry
+	RecentBlockHashes     [256]vm.Hash
 }
 
 // NewState creates a new State instance with the given code.
@@ -153,6 +154,7 @@ func NewState(code *Code) *State {
 		CallData:              Bytes{},
 		LastCallReturnData:    Bytes{},
 		SelfDestructedJournal: []SelfDestructEntry{},
+		RecentBlockHashes:     [256]vm.Hash{},
 	}
 }
 
@@ -184,6 +186,7 @@ func (s *State) Clone() *State {
 	clone.ReturnData = s.ReturnData
 	clone.HasSelfDestructed = s.HasSelfDestructed
 	clone.SelfDestructedJournal = slices.Clone(s.SelfDestructedJournal)
+	clone.RecentBlockHashes = s.RecentBlockHashes
 	return clone
 }
 
@@ -216,7 +219,8 @@ func (s *State) Eq(other *State) bool {
 		s.Accounts.Eq(other.Accounts) &&
 		s.Logs.Eq(other.Logs) &&
 		s.HasSelfDestructed == other.HasSelfDestructed &&
-		slices.Equal(s.SelfDestructedJournal, other.SelfDestructedJournal)
+		slices.Equal(s.SelfDestructedJournal, other.SelfDestructedJournal) &&
+		s.RecentBlockHashes == other.RecentBlockHashes
 
 	// For terminal states, internal state can be ignored, but the result is important.
 	if s.Status != Running {
@@ -341,6 +345,14 @@ func (s *State) String() string {
 	write("\tHasSelfDestructed: %v\n", s.HasSelfDestructed)
 	write("\tSelfDestructedJournal: %v\n", s.SelfDestructedJournal)
 
+	// only print if next instruction is blockhash and the top of the stack is a valid uint64
+	if s.Code != nil && s.Code.Length() > int(s.Pc) {
+		if s.Code.IsCode(int(s.Pc)) && OpCode(s.Code.code[s.Pc]) == BLOCKHASH &&
+			s.Stack.stack[s.Stack.Size()-1].IsUint64() {
+			write("\tBlockNumberHashes: %v\n", s.RecentBlockHashes[s.Stack.stack[s.Stack.Size()-1].Uint64()])
+		}
+	}
+
 	write("}")
 	return builder.String()
 }
@@ -436,6 +448,12 @@ func (s *State) Diff(o *State) []string {
 						entry1.account, entry1.beneficiary, entry2.account, entry2.beneficiary))
 				}
 			}
+		}
+	}
+
+	for i := 0; i < 256; i++ {
+		if s.RecentBlockHashes[i] != o.RecentBlockHashes[i] {
+			res = append(res, fmt.Sprintf("Different block number hash at index %d: %x vs %x", i, s.RecentBlockHashes[i], o.RecentBlockHashes[i]))
 		}
 	}
 

--- a/go/ct/st/state.go
+++ b/go/ct/st/state.go
@@ -346,10 +346,11 @@ func (s *State) String() string {
 	write("\tSelfDestructedJournal: %v\n", s.SelfDestructedJournal)
 
 	// only print if next instruction is blockhash and the top of the stack is a valid uint64
-	if s.Code != nil && s.Code.Length() > int(s.Pc) {
+	if s.Code != nil && s.Code.Length() > int(s.Pc) && s.Stack != nil && s.Stack.Size() > 0 {
+		offset := s.Stack.stack[s.Stack.Size()-1]
 		if s.Code.IsCode(int(s.Pc)) && OpCode(s.Code.code[s.Pc]) == BLOCKHASH &&
-			s.Stack.stack[s.Stack.Size()-1].IsUint64() {
-			write("\tBlockNumberHashes: %v\n", s.RecentBlockHashes[s.Stack.stack[s.Stack.Size()-1].Uint64()])
+			offset.IsUint64() {
+			write("\tHash of block %d-%d: %v\n", s.BlockContext.BlockNumber, offset, s.RecentBlockHashes[offset.Uint64()])
 		}
 	}
 

--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -121,7 +121,16 @@ func (c *ctRunContext) GetTransactionContext() vm.TransactionContext {
 }
 
 func (c *ctRunContext) GetBlockHash(number int64) vm.Hash {
-	panic("not implemented")
+	min := int64(0)
+	max := int64(c.state.BlockContext.BlockNumber)
+	if c.state.BlockContext.BlockNumber > 256 {
+		min = max - 256
+	}
+	if min > number || number >= max {
+		return vm.Hash{0x0}
+	}
+
+	return c.state.RecentBlockHashes[max-number-1]
 }
 
 // TODO: add unit test

--- a/go/vm/geth/geth.go
+++ b/go/vm/geth/geth.go
@@ -107,7 +107,7 @@ func createGethInterpreterContext(parameters vm.Parameters) (*geth.EVM, *geth.Co
 
 	// Hashing function used in the context for BLOCKHASH instruction
 	getHash := func(num uint64) common.Hash {
-		return common.Hash{}
+		return common.Hash(parameters.Context.GetBlockHash(int64(num)))
 	}
 
 	var transactionContext vm.TransactionContext


### PR DESCRIPTION
This PR adds the rules for BLOCKHASH operation, a new condition to enforce whether the stack top is within or out of the range of the current block number and tests for it.

This PR fixes #459 
