### PR TITLE
Refactor CT driver arguments into a single definition module. 

### DIFF
--- a/go/ct/driver/cli/utils.go
+++ b/go/ct/driver/cli/utils.go
@@ -20,11 +20,11 @@ import (
 )
 
 type filterFlagType struct {
-	flag cli.StringFlag
+	cli.StringFlag
 }
 
-var FilterFlag = filterFlagType{
-	flag: cli.StringFlag{
+var FilterFlag = &filterFlagType{
+	cli.StringFlag{
 		Name:    "filter",
 		Aliases: []string{"f"},
 		Usage:   "execute only for rules which name matches the given regex",
@@ -32,20 +32,16 @@ var FilterFlag = filterFlagType{
 	},
 }
 
-func (f *filterFlagType) GetFlag() cli.Flag {
-	return &f.flag
-}
-
 func (f *filterFlagType) Fetch(context *cli.Context) (*regexp.Regexp, error) {
-	return regexp.Compile(context.String(f.flag.Name))
+	return regexp.Compile(context.String(f.Name))
 }
 
 type jobsFlagType struct {
-	flag cli.IntFlag
+	cli.IntFlag
 }
 
-var JobsFlag = jobsFlagType{
-	flag: cli.IntFlag{
+var JobsFlag = &jobsFlagType{
+	cli.IntFlag{
 		Name:    "jobs",
 		Aliases: []string{"j"},
 		Usage:   "number of jobs run simultaneously",
@@ -53,69 +49,53 @@ var JobsFlag = jobsFlagType{
 	},
 }
 
-func (f *jobsFlagType) GetFlag() cli.Flag {
-	return &f.flag
-}
-
 func (f *jobsFlagType) Fetch(context *cli.Context) int {
-	return context.Int(f.flag.Name)
+	return context.Int(f.Name)
 }
 
 type seedFlagType struct {
-	flag cli.Uint64Flag
+	cli.Uint64Flag
 }
 
-var SeedFlag = seedFlagType{
-	flag: cli.Uint64Flag{
+var SeedFlag = &seedFlagType{
+	cli.Uint64Flag{
 		Name:    "seed",
 		Aliases: []string{"s"},
 		Usage:   "seed for the random number generator",
 	},
 }
 
-func (f *seedFlagType) GetFlag() cli.Flag {
-	return &f.flag
-}
-
 func (f *seedFlagType) Fetch(context *cli.Context) uint64 {
-	return context.Uint64(f.flag.Name)
+	return context.Uint64(f.Name)
 }
 
 type cpuProfileType struct {
-	flag cli.StringFlag
+	cli.StringFlag
 }
 
-var CpuProfileFlag = cpuProfileType{
-	flag: cli.StringFlag{
+var CpuProfileFlag = &cpuProfileType{
+	cli.StringFlag{
 		Name:      "cpuprofile",
 		Usage:     "store CPU profile in the provided filename",
 		TakesFile: true,
 	},
 }
 
-func (f *cpuProfileType) GetFlag() cli.Flag {
-	return &f.flag
-}
-
 func (f *cpuProfileType) Fetch(context *cli.Context) string {
-	return context.String(f.flag.Name)
+	return context.String(f.Name)
 }
 
 type fullModeFlagType struct {
-	flag cli.BoolFlag
+	cli.BoolFlag
 }
 
-var FullModeFlag = fullModeFlagType{
-	flag: cli.BoolFlag{
+var FullModeFlag = &fullModeFlagType{
+	cli.BoolFlag{
 		Name:  "full-mode",
 		Usage: "if enabled, test cases targeting rules other than the one generating the case will be executed",
 	},
 }
 
-func (f *fullModeFlagType) GetFlag() cli.Flag {
-	return &f.flag
-}
-
 func (f *fullModeFlagType) Fetch(context *cli.Context) bool {
-	return context.Bool(f.flag.Name)
+	return context.Bool(f.Name)
 }

--- a/go/ct/driver/cli/utils.go
+++ b/go/ct/driver/cli/utils.go
@@ -23,12 +23,13 @@ type filterFlagType struct {
 	flag cli.StringFlag
 }
 
-var FilterFlag = filterFlagType{flag: cli.StringFlag{
-	Name:    "filter",
-	Aliases: []string{"f"},
-	Usage:   "execute only for rules which name matches the given regex",
-	Value:   "",
-},
+var FilterFlag = filterFlagType{
+	flag: cli.StringFlag{
+		Name:    "filter",
+		Aliases: []string{"f"},
+		Usage:   "execute only for rules which name matches the given regex",
+		Value:   "",
+	},
 }
 
 func (f *filterFlagType) GetFlag() cli.Flag {
@@ -44,7 +45,7 @@ type jobsFlagType struct {
 }
 
 var JobsFlag = jobsFlagType{
-	cli.IntFlag{
+	flag: cli.IntFlag{
 		Name:    "jobs",
 		Aliases: []string{"j"},
 		Usage:   "number of jobs run simultaneously",
@@ -65,7 +66,7 @@ type seedFlagType struct {
 }
 
 var SeedFlag = seedFlagType{
-	cli.Uint64Flag{
+	flag: cli.Uint64Flag{
 		Name:    "seed",
 		Aliases: []string{"s"},
 		Usage:   "seed for the random number generator",
@@ -85,7 +86,7 @@ type cpuProfileType struct {
 }
 
 var CpuProfileFlag = cpuProfileType{
-	cli.StringFlag{
+	flag: cli.StringFlag{
 		Name:      "cpuprofile",
 		Usage:     "store CPU profile in the provided filename",
 		TakesFile: true,
@@ -105,7 +106,7 @@ type fullModeFlagType struct {
 }
 
 var FullModeFlag = fullModeFlagType{
-	cli.BoolFlag{
+	flag: cli.BoolFlag{
 		Name:  "full-mode",
 		Usage: "if enabled, test cases targeting rules other than the one generating the case will be executed",
 	},

--- a/go/ct/driver/cli/utils.go
+++ b/go/ct/driver/cli/utils.go
@@ -1,0 +1,120 @@
+//
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use
+// of this software will be governed by the GNU Lesser General Public Licence v3
+//
+
+package cliUtils
+
+import (
+	"regexp"
+	"runtime"
+
+	"github.com/urfave/cli/v2"
+)
+
+type filterFlagType struct {
+	flag cli.StringFlag
+}
+
+var FilterFlag = filterFlagType{flag: cli.StringFlag{
+	Name:    "filter",
+	Aliases: []string{"f"},
+	Usage:   "execute only for rules which name matches the given regex",
+	Value:   "",
+},
+}
+
+func (f *filterFlagType) GetFlag() cli.Flag {
+	return &f.flag
+}
+
+func (f *filterFlagType) Fetch(context *cli.Context) (*regexp.Regexp, error) {
+	return regexp.Compile(context.String(f.flag.Name))
+}
+
+type jobsFlagType struct {
+	flag cli.IntFlag
+}
+
+var JobsFlag = jobsFlagType{
+	cli.IntFlag{
+		Name:    "jobs",
+		Aliases: []string{"j"},
+		Usage:   "number of jobs run simultaneously",
+		Value:   runtime.NumCPU(),
+	},
+}
+
+func (f *jobsFlagType) GetFlag() cli.Flag {
+	return &f.flag
+}
+
+func (f *jobsFlagType) Fetch(context *cli.Context) int {
+	return context.Int(f.flag.Name)
+}
+
+type seedFlagType struct {
+	flag cli.Uint64Flag
+}
+
+var SeedFlag = seedFlagType{
+	cli.Uint64Flag{
+		Name:    "seed",
+		Aliases: []string{"s"},
+		Usage:   "seed for the random number generator",
+	},
+}
+
+func (f *seedFlagType) GetFlag() cli.Flag {
+	return &f.flag
+}
+
+func (f *seedFlagType) Fetch(context *cli.Context) uint64 {
+	return context.Uint64(f.flag.Name)
+}
+
+type cpuProfileType struct {
+	flag cli.StringFlag
+}
+
+var CpuProfileFlag = cpuProfileType{
+	cli.StringFlag{
+		Name:      "cpuprofile",
+		Usage:     "store CPU profile in the provided filename",
+		TakesFile: true,
+	},
+}
+
+func (f *cpuProfileType) GetFlag() cli.Flag {
+	return &f.flag
+}
+
+func (f *cpuProfileType) Fetch(context *cli.Context) string {
+	return context.String(f.flag.Name)
+}
+
+type fullModeFlagType struct {
+	flag cli.BoolFlag
+}
+
+var FullModeFlag = fullModeFlagType{
+	cli.BoolFlag{
+		Name:  "full-mode",
+		Usage: "if enabled, test cases targeting rules other than the one generating the case will be executed",
+	},
+}
+
+func (f *fullModeFlagType) GetFlag() cli.Flag {
+	return &f.flag
+}
+
+func (f *fullModeFlagType) Fetch(context *cli.Context) bool {
+	return context.Bool(f.flag.Name)
+}

--- a/go/ct/driver/generator_info.go
+++ b/go/ct/driver/generator_info.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"sort"
 
+	cliUtils "github.com/Fantom-foundation/Tosca/go/ct/driver/cli"
 	"github.com/Fantom-foundation/Tosca/go/ct/rlz"
 	"github.com/Fantom-foundation/Tosca/go/ct/spc"
 	"github.com/urfave/cli/v2"
@@ -26,10 +27,18 @@ var GeneratorInfoCmd = cli.Command{
 	Action: doListGeneratorInfo,
 	Name:   "generator-info",
 	Usage:  "Lists details on the number of test cases produced per rule",
+	Flags: []cli.Flag{
+		cliUtils.FilterFlag.GetFlag(),
+	},
 }
 
 func doListGeneratorInfo(context *cli.Context) error {
-	rules := spc.Spec.GetRules()
+
+	filter, err := cliUtils.FilterFlag.Fetch(context)
+	if err != nil {
+		return err
+	}
+	rules := spc.FilterRules(spc.Spec.GetRules(), filter)
 
 	infos := map[string]rlz.TestCaseEnumerationInfo{}
 	for _, rule := range rules {

--- a/go/ct/driver/generator_info.go
+++ b/go/ct/driver/generator_info.go
@@ -28,7 +28,7 @@ var GeneratorInfoCmd = cli.Command{
 	Name:   "generator-info",
 	Usage:  "Lists details on the number of test cases produced per rule",
 	Flags: []cli.Flag{
-		cliUtils.FilterFlag.GetFlag(),
+		cliUtils.FilterFlag,
 	},
 }
 

--- a/go/ct/driver/list.go
+++ b/go/ct/driver/list.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"sort"
 
+	cliUtils "github.com/Fantom-foundation/Tosca/go/ct/driver/cli"
 	"github.com/Fantom-foundation/Tosca/go/ct/spc"
 	"github.com/urfave/cli/v2"
 )
@@ -24,10 +25,19 @@ var ListCmd = cli.Command{
 	Action: doList,
 	Name:   "list",
 	Usage:  "List all rules by name",
+	Flags: []cli.Flag{
+		cliUtils.FilterFlag.GetFlag(),
+	},
 }
 
 func doList(context *cli.Context) error {
-	rules := spc.Spec.GetRules()
+
+	filter, err := cliUtils.FilterFlag.Fetch(context)
+	if err != nil {
+		return err
+	}
+
+	rules := spc.FilterRules(spc.Spec.GetRules(), filter)
 	sort.Slice(rules, func(i, j int) bool { return rules[i].Name < rules[j].Name })
 	for _, rule := range rules {
 		fmt.Println(rule.Name)

--- a/go/ct/driver/list.go
+++ b/go/ct/driver/list.go
@@ -26,7 +26,7 @@ var ListCmd = cli.Command{
 	Name:   "list",
 	Usage:  "List all rules by name",
 	Flags: []cli.Flag{
-		cliUtils.FilterFlag.GetFlag(),
+		cliUtils.FilterFlag,
 	},
 }
 

--- a/go/ct/driver/run.go
+++ b/go/ct/driver/run.go
@@ -44,11 +44,11 @@ var RunCmd = cli.Command{
 	Usage:     "Run Conformance Tests on an EVM implementation",
 	ArgsUsage: "<EVM>",
 	Flags: []cli.Flag{
-		cliUtils.FilterFlag.GetFlag(),
-		cliUtils.JobsFlag.GetFlag(),
-		cliUtils.SeedFlag.GetFlag(),
-		cliUtils.CpuProfileFlag.GetFlag(),
-		cliUtils.FullModeFlag.GetFlag(), // < TODO: make every run a full mode once tests pass
+		cliUtils.FilterFlag,
+		cliUtils.JobsFlag,
+		cliUtils.SeedFlag,
+		cliUtils.CpuProfileFlag,
+		cliUtils.FullModeFlag, // < TODO: make every run a full mode once tests pass
 		&cli.IntFlag{
 			Name:  "max-errors",
 			Usage: "aborts testing after the given number of issues",

--- a/go/ct/driver/stats.go
+++ b/go/ct/driver/stats.go
@@ -89,7 +89,6 @@ func doStats(context *cli.Context) error {
 	}
 
 	// Summarize the result.
-	fmt.Printf("\n")
 	fmt.Printf("%v", statsCollector.getStatistics())
 	return nil
 }

--- a/go/ct/driver/stats.go
+++ b/go/ct/driver/stats.go
@@ -35,11 +35,11 @@ var StatsCmd = cli.Command{
 	Name:   "stats",
 	Usage:  "Computes statistics on rule coverage",
 	Flags: []cli.Flag{
-		cliUtils.FilterFlag.GetFlag(),
-		cliUtils.JobsFlag.GetFlag(),
-		cliUtils.SeedFlag.GetFlag(),
-		cliUtils.CpuProfileFlag.GetFlag(),
-		cliUtils.FullModeFlag.GetFlag(),
+		cliUtils.FilterFlag,
+		cliUtils.JobsFlag,
+		cliUtils.SeedFlag,
+		cliUtils.CpuProfileFlag,
+		cliUtils.FullModeFlag,
 	},
 }
 

--- a/go/ct/driver/stats_test.go
+++ b/go/ct/driver/stats_test.go
@@ -52,7 +52,7 @@ func TestStatisticCollector_InitializesAllRulesToZero(t *testing.T) {
 		{Name: "a"}, {Name: "b"},
 	})
 
-	collector := newStatsCollector(spec)
+	collector := newStatsCollector(spec.GetRules())
 	stats := collector.getStatistics()
 
 	if want, got := 2, len(stats.data); want != got {
@@ -73,7 +73,7 @@ func TestStatisticCollector_RegisteringTestsIncreasesCounter(t *testing.T) {
 	spec := spc.NewMockSpecification(ctrl)
 	spec.EXPECT().GetRules().Return([]rlz.Rule{{Name: "a"}})
 
-	collector := newStatsCollector(spec)
+	collector := newStatsCollector(spec.GetRules())
 	if want, got := uint64(0), collector.getStatistics().getNumTestsFor("a"); want != got {
 		t.Errorf("unexpected number of tests for 'a', wanted %d, got %d", want, got)
 	}

--- a/go/ct/driver/test.go
+++ b/go/ct/driver/test.go
@@ -15,12 +15,11 @@ package main
 import (
 	"fmt"
 	"os"
-	"regexp"
-	"runtime"
 	"runtime/pprof"
 	"sync/atomic"
 	"time"
 
+	cliUtils "github.com/Fantom-foundation/Tosca/go/ct/driver/cli"
 	"github.com/Fantom-foundation/Tosca/go/ct/rlz"
 	"github.com/Fantom-foundation/Tosca/go/ct/spc"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
@@ -33,33 +32,16 @@ var TestCmd = cli.Command{
 	Name:   "test",
 	Usage:  "Check test case rule coverage",
 	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:  "filter",
-			Usage: "check only rules which name matches the given regex",
-			Value: ".*",
-		},
-		&cli.IntFlag{
-			Name:  "jobs",
-			Usage: "number of jobs run simultaneously",
-			Value: runtime.NumCPU(),
-		},
-		&cli.Uint64Flag{
-			Name:  "seed",
-			Usage: "seed for the random number generator",
-		},
-		&cli.StringFlag{
-			Name:  "cpuprofile",
-			Usage: "store CPU profile in the provided filename",
-		},
-		&cli.BoolFlag{
-			Name:  "full-mode",
-			Usage: "if enabled, test cases targeting rules other than the one generating the case will be executed",
-		},
+		cliUtils.FilterFlag.GetFlag(),
+		cliUtils.JobsFlag.GetFlag(),
+		cliUtils.SeedFlag.GetFlag(),
+		cliUtils.CpuProfileFlag.GetFlag(),
+		cliUtils.FullModeFlag.GetFlag(),
 	},
 }
 
 func doTest(context *cli.Context) error {
-	if cpuprofileFilename := context.String("cpuprofile"); cpuprofileFilename != "" {
+	if cpuprofileFilename := cliUtils.CpuProfileFlag.Fetch(context); cpuprofileFilename != "" {
 		f, err := os.Create(cpuprofileFilename)
 		if err != nil {
 			return fmt.Errorf("could not create CPU profile: %w", err)
@@ -69,14 +51,14 @@ func doTest(context *cli.Context) error {
 		}
 		defer pprof.StopCPUProfile()
 	}
-	filter, err := regexp.Compile(context.String("filter"))
+
+	filter, err := cliUtils.FilterFlag.Fetch(context)
 	if err != nil {
 		return err
 	}
-
-	jobCount := context.Int("jobs")
-	seed := context.Uint64("seed")
-	fullMode := context.Bool("full-mode")
+	jobCount := cliUtils.JobsFlag.Fetch(context)
+	seed := cliUtils.SeedFlag.Fetch(context)
+	fullMode := cliUtils.FullModeFlag.Fetch(context)
 
 	issuesCollector := issuesCollector{}
 	var skippedCount atomic.Int32

--- a/go/ct/driver/test.go
+++ b/go/ct/driver/test.go
@@ -32,11 +32,11 @@ var TestCmd = cli.Command{
 	Name:   "test",
 	Usage:  "Check test case rule coverage",
 	Flags: []cli.Flag{
-		cliUtils.FilterFlag.GetFlag(),
-		cliUtils.JobsFlag.GetFlag(),
-		cliUtils.SeedFlag.GetFlag(),
-		cliUtils.CpuProfileFlag.GetFlag(),
-		cliUtils.FullModeFlag.GetFlag(),
+		cliUtils.FilterFlag,
+		cliUtils.JobsFlag,
+		cliUtils.SeedFlag,
+		cliUtils.CpuProfileFlag,
+		cliUtils.FullModeFlag,
 	},
 }
 


### PR DESCRIPTION
This PR refactors command line arguments from the CT driver into a single module. 

Adds short form for some of them:
- filter: f
- jobs: j
- seed: s

cpuprofile argument must include a file
Add Filter option to stats command. 

