### PR TITLE
Replace unbounded code conversion cache with limited LRU cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/dsnet/golib/unitconv v1.0.2
 	github.com/ethereum/evmc/v10 v10.0.0
 	github.com/ethereum/go-ethereum v1.10.25
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/holiman/uint256 v1.2.4
 	github.com/urfave/cli/v2 v2.25.7
 	go.uber.org/mock v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
 github.com/holiman/uint256 v1.2.4 h1:jUc4Nk8fm9jZabQuqr2JzednajVmBpC+oiTiXZJEApU=

--- a/go/vm/lfvm/converter.go
+++ b/go/vm/lfvm/converter.go
@@ -13,16 +13,14 @@
 package lfvm
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"log"
 	"slices"
 	"strings"
-	"sync"
 
 	"github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/vm"
+	lru "github.com/hashicorp/golang-lru/v2"
 
 	// This is only imported to get the EVM opcode definitions.
 	// TODO: write up our own op-code definition and remove this dependency.
@@ -30,58 +28,40 @@ import (
 	evm "github.com/ethereum/go-ethereum/core/vm"
 )
 
-type cache_val struct {
-	oldCode []byte
-	code    Code
+var cache *lru.Cache[vm.Hash, Code]
+
+func init() {
+	res, err := lru.New[vm.Hash, Code](50_000) // up to ~ 1 GB for 22 KiB max code size
+	if err != nil {
+		panic(fmt.Errorf("failed to create cache: %v", err))
+	}
+	cache = res
 }
 
-var mu = sync.Mutex{}
-var cache = map[vm.Hash]cache_val{}
-
 func clearConversionCache() {
-	mu.Lock()
-	defer mu.Unlock()
-	cache = map[vm.Hash]cache_val{}
+	cache.Purge()
 }
 
 func Convert(code []byte, with_super_instructions bool, create bool, noCodeCache bool, codeHash vm.Hash) (Code, error) {
-	// TODO: clean up this code; it does some checks that seems to be once used
-	// for debugging an issue that do not make sense any more.
-
 	// Do not cache use-once code in create calls.
 	// In those cases the codeHash is also invalid.
-	if create {
+	if create || noCodeCache {
 		return convert(code, with_super_instructions)
 	}
 
-	mu.Lock()
-	res, exists := cache[codeHash]
-	if exists && !create {
-		isEqual := true
-		if noCodeCache {
-
-			if !bytes.Equal(res.oldCode, code) {
-				log.Printf("Different code for hash %v", codeHash)
-				isEqual = false
-			}
-		}
-
-		if isEqual {
-			mu.Unlock()
-			return res.code, nil
-		}
+	res, exists := cache.Get(codeHash)
+	if exists {
+		return res, nil
 	}
-	mu.Unlock()
-	resCode, error := convert(code, with_super_instructions)
+
+	res, error := convert(code, with_super_instructions)
 	if error != nil {
 		return nil, error
 	}
 	if !create {
-		mu.Lock()
-		cache[codeHash] = cache_val{oldCode: code, code: resCode}
-		mu.Unlock()
+		cache.Add(codeHash, res)
 	}
-	return resCode, nil
+	return res, nil
 }
 
 type codeBuilder struct {

--- a/go/vm/lfvm/converter_test.go
+++ b/go/vm/lfvm/converter_test.go
@@ -30,7 +30,7 @@ func TestConversionCacheSizeLimit(t *testing.T) {
 	// This test checks that the conversion cache does not grow indefinitely
 	// by converting a large number of different code snippets.
 	clearConversionCache()
-	const limit = 100_000
+	const limit = codeCacheCapacity
 	for i := 0; i < limit*10; i++ {
 		hash := vm.Hash{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24)}
 		_, err := Convert([]byte{0}, false, false, false, hash)

--- a/go/vm/lfvm/converter_test.go
+++ b/go/vm/lfvm/converter_test.go
@@ -26,10 +26,53 @@ func TestConvertLongExampleCode(t *testing.T) {
 	}
 }
 
+func TestConversionCacheSizeLimit(t *testing.T) {
+	// This test checks that the conversion cache does not grow indefinitely
+	// by converting a large number of different code snippets.
+	clearConversionCache()
+	const limit = 100_000
+	for i := 0; i < limit*10; i++ {
+		hash := vm.Hash{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24)}
+		_, err := Convert([]byte{0}, false, false, false, hash)
+		if err != nil {
+			t.Errorf("Failed to convert example code with error %v", err)
+		}
+	}
+	if got := len(cache.Keys()); got > limit {
+		t.Errorf("Conversion cache grew to %d entries", got)
+	}
+
+}
+
 func BenchmarkConvertLongExampleCode(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		clearConversionCache()
 		_, err := Convert(longExampleCode, false, false, false, vm.Hash{byte(i)})
+		if err != nil {
+			b.Errorf("Failed to convert example code with error %v", err)
+		}
+	}
+}
+
+func BenchmarkConversionCacheLookupSpeed(b *testing.B) {
+	// This benchmark measures the lookup speed of the conversion cache
+	// by converting the same code snippet multiple times.
+	clearConversionCache()
+	for i := 0; i < b.N; i++ {
+		_, err := Convert([]byte{}, false, false, false, vm.Hash{})
+		if err != nil {
+			b.Errorf("Failed to convert example code with error %v", err)
+		}
+	}
+}
+
+func BenchmarkConversionCacheUpdateSpeed(b *testing.B) {
+	// This benchmark measures the update speed of the conversion cache
+	// by converting codes with different (reported) hashes.
+	clearConversionCache()
+	for i := 0; i < b.N; i++ {
+		hash := vm.Hash{byte(i), byte(i >> 8), byte(i >> 16), byte(i >> 24)}
+		_, err := Convert([]byte{}, false, false, false, hash)
 		if err != nil {
 			b.Errorf("Failed to convert example code with error %v", err)
 		}


### PR DESCRIPTION
This PR replaces the former unbound cache for converted codes in the LFVM interpreter with a fixed-sized LRU cache. Additionally, some unnecessary debug code was removed.

This fixes #314.

The PR also adds benchmarks for the cache to identify the performance impact:
```
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Tosca/go/vm/lfvm
cpu: Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
                              │   old.txt   │               new.txt               │
                              │   sec/op    │   sec/op     vs base                │
ConversionCacheLookupSpeed-12   31.61n ± 4%   51.20n ± 4%  +61.97% (p=0.000 n=10)
ConversionCacheUpdateSpeed-12   573.1n ± 6%   427.7n ± 6%  -25.38% (p=0.000 n=10)
geomean                         134.6n        148.0n        +9.94%

                              │   old.txt    │               new.txt                │
                              │     B/op     │    B/op     vs base                  │
ConversionCacheLookupSpeed-12   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
ConversionCacheUpdateSpeed-12   318.0 ± 8%     112.0 ± 0%  -64.78% (p=0.000 n=10)
geomean                                    ²               -40.65%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                              │   old.txt    │            new.txt             │
                              │  allocs/op   │ allocs/op   vs base            │
ConversionCacheLookupSpeed-12   0.000 ± 0%     0.000 ± 0%  ~ (p=1.000 n=10) ¹
ConversionCacheUpdateSpeed-12   0.000 ± 0%     1.000 ± 0%  ? (p=0.000 n=10)
geomean                                    ²               ?                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

By changing to the utilization of an LRU instead of the previous map, an ~62% increase in the lookup time is observed. This is likely due to the additional need to track the least-recently-used order. However, as shown in the following result, this does not have any significant impact on the interpreter performance when running codes.
```
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Tosca/go/vm/test
cpu: Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
               │   old.txt   │              new.txt               │
               │   sec/op    │   sec/op     vs base               │
Inc/1/lfvm-12    3.373µ ± 5%   3.327µ ± 9%       ~ (p=0.393 n=10)
Inc/10/lfvm-12   3.263µ ± 7%   3.389µ ± 4%       ~ (p=0.123 n=10)
geomean          3.317µ        3.357µ       +1.21%
```
The `Inc` stress-tests the interpreter startup and shutdown time by running a simple code merely increasing a given value by a fixed offset and returning the result.

Remaining tasks:
- [x] check end-to-end impact using micro benchmarks
- [x] test potential impact on CT tests
- [x] do a test-run on historic data
