### PR TITLE
CT: Increase range of block number per revision

### DIFF
--- a/go/ct/common/revisions.go
+++ b/go/ct/common/revisions.go
@@ -107,17 +107,17 @@ func GetForkBlock(revision Revision) (uint64, error) {
 	case R07_Istanbul:
 		return 0, nil
 	case R09_Berlin:
-		return 10, nil
+		return 1000, nil
 	case R10_London:
-		return 20, nil
+		return 2000, nil
 	case R11_Paris:
-		return 30, nil
+		return 3000, nil
 	case R12_Shanghai:
-		return 40, nil
+		return 4000, nil
 	case R13_Cancun:
-		return 50, nil
+		return 5000, nil
 	case R99_UnknownNextRevision:
-		return 60, nil
+		return 6000, nil
 	}
 	return 0, fmt.Errorf("unknown revision: %v", revision)
 }

--- a/go/ct/common/revisions_test.go
+++ b/go/ct/common/revisions_test.go
@@ -22,12 +22,12 @@ func TestRevisions_RangeLength(t *testing.T) {
 		revision    Revision
 		rangeLength uint64
 	}{
-		"Istanbul":    {R07_Istanbul, 10},
-		"Berlin":      {R09_Berlin, 10},
-		"London":      {R10_London, 10},
-		"Paris":       {R11_Paris, 10},
-		"Shanghai":    {R12_Shanghai, 10},
-		"Cancun":      {R13_Cancun, 10},
+		"Istanbul":    {R07_Istanbul, 1000},
+		"Berlin":      {R09_Berlin, 1000},
+		"London":      {R10_London, 1000},
+		"Paris":       {R11_Paris, 1000},
+		"Shanghai":    {R12_Shanghai, 1000},
+		"Cancun":      {R13_Cancun, 1000},
 		"UnknownNext": {R99_UnknownNextRevision, 0},
 	}
 
@@ -60,12 +60,12 @@ func TestRevisions_GetForkBlock(t *testing.T) {
 		forkBlock uint64
 	}{
 		"Istanbul":    {R07_Istanbul, 0},
-		"Berlin":      {R09_Berlin, 10},
-		"London":      {R10_London, 20},
-		"Paris":       {R11_Paris, 30},
-		"Shanghai":    {R12_Shanghai, 40},
-		"Cancun":      {R13_Cancun, 50},
-		"UnknownNext": {R99_UnknownNextRevision, 60},
+		"Berlin":      {R09_Berlin, 1000},
+		"London":      {R10_London, 2000},
+		"Paris":       {R11_Paris, 3000},
+		"Shanghai":    {R12_Shanghai, 4000},
+		"Cancun":      {R13_Cancun, 5000},
+		"UnknownNext": {R99_UnknownNextRevision, 6000},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
We noticed that since each revision was getting only 10 block number, this would be a problem for generating states with block numbers over  30. (or 50 with the new revisions). Because of this we decided to increase the range of block number per revision to 1000. This should be sufficient for the current tests, and generating interesting states. 

This PR contributes to  #459 