### PR TITLE
CT: define boundaries on the revision to be used in explicit test cases

### DIFF
--- a/go/ct/evm_test.go
+++ b/go/ct/evm_test.go
@@ -37,6 +37,7 @@ var evms = map[string]ct.Evm{
 func TestCt_ExplicitCases(t *testing.T) {
 	tests := map[string]Condition{
 		"jump_to_2^32": And(
+			RevisionBounds(R07_Istanbul, NewestSupportedRevision),
 			Eq(Status(), st.Running),
 			Eq(Op(Pc()), JUMP),
 			Eq(Op(Constant(NewU256(0))), JUMPDEST),
@@ -44,6 +45,7 @@ func TestCt_ExplicitCases(t *testing.T) {
 			Ge(Gas(), vm.Gas(8)),
 		),
 		"jumpi_to_2^32": And(
+			RevisionBounds(R07_Istanbul, NewestSupportedRevision),
 			Eq(Status(), st.Running),
 			Eq(Op(Pc()), JUMPI),
 			Eq(Op(Constant(NewU256(0))), JUMPDEST),


### PR DESCRIPTION
This test was relying on the random number generator using always the same seed and being used the same number of times. As elements were added to the state generator, this test stopped working. With this fix we can always ensure that the test runs with states generated with supported revision by the CT and the implementations.