### PR TITLE
CT: Add recent block hashes to state, and generator

### DIFF
--- a/go/ct/common/opcodes.go
+++ b/go/ct/common/opcodes.go
@@ -63,6 +63,7 @@ const (
 	RETURNDATASIZE OpCode = 0x3D
 	RETURNDATACOPY OpCode = 0x3E
 	EXTCODEHASH    OpCode = 0x3F
+	BLOCKHASH      OpCode = 0x40
 	COINBASE       OpCode = 0x41
 	TIMESTAMP      OpCode = 0x42
 	NUMBER         OpCode = 0x43
@@ -286,6 +287,8 @@ func (op OpCode) String() string {
 		return "RETURNDATACOPY"
 	case EXTCODEHASH:
 		return "EXTCODEHASH"
+	case BLOCKHASH:
+		return "BLOCKHASH"
 	case COINBASE:
 		return "COINBASE"
 	case TIMESTAMP:

--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -261,6 +261,12 @@ func getRandomData(rnd *rand.Rand) ([]byte, error) {
 	return dataBuffer, nil
 }
 
+func getRandomHash(rnd *rand.Rand) vm.Hash {
+	var res vm.Hash
+	rnd.Read(res[:])
+	return res
+}
+
 // Generate produces a State instance satisfying the constraints set on this
 // generator or returns ErrUnsatisfiable on conflicting constraints. Subsequent
 // generators are invoked automatically.
@@ -386,6 +392,12 @@ func (g *StateGenerator) Generate(rnd *rand.Rand) (*st.State, error) {
 		return nil, err
 	}
 
+	// generate recent block hashes
+	resultRecentBlockHashes := [256]vm.Hash{}
+	for i := 0; i < 256; i++ {
+		resultRecentBlockHashes[i] = getRandomHash(rnd)
+	}
+
 	// Sub-generators can modify the assignment when unassigned variables are
 	// encountered. The order in which sub-generators are invoked influences
 	// this process.
@@ -432,6 +444,7 @@ func (g *StateGenerator) Generate(rnd *rand.Rand) (*st.State, error) {
 	result.LastCallReturnData = resultLastCallReturnData
 	result.ReturnData = resultReturnData
 	result.HasSelfDestructed = resultHasSelfdestructed
+	result.RecentBlockHashes = resultRecentBlockHashes
 
 	return result, nil
 }

--- a/go/ct/gen/state_test.go
+++ b/go/ct/gen/state_test.go
@@ -434,3 +434,19 @@ func TestStateGenerator_ReturnDataShouldBeEmpty(t *testing.T) {
 		t.Errorf("unexpected length of generated return data, wanted %d, got %d", want, got)
 	}
 }
+
+// //////////////////////////////////////////////////////////
+// Block number hashes
+func TestStateGenerator_BlockNumberHashes(t *testing.T) {
+	newHashes := []vm.Hash{}
+	state := genRandomState(t)
+	for i := 0; i < 256; i++ {
+		if state.RecentBlockHashes[i] == (vm.Hash{}) {
+			t.Error("unexpected hash value, should not be zero")
+		}
+		if slices.Contains(newHashes, state.RecentBlockHashes[i]) {
+			t.Errorf("unexpected hash value, should be unique %v", state.RecentBlockHashes[i])
+		}
+		newHashes = append(newHashes, state.RecentBlockHashes[i])
+	}
+}

--- a/go/ct/gen/state_test.go
+++ b/go/ct/gen/state_test.go
@@ -441,9 +441,6 @@ func TestStateGenerator_BlockNumberHashes(t *testing.T) {
 	newHashes := []vm.Hash{}
 	state := genRandomState(t)
 	for i := 0; i < 256; i++ {
-		if state.RecentBlockHashes[i] == (vm.Hash{}) {
-			t.Error("unexpected hash value, should not be zero")
-		}
 		if slices.Contains(newHashes, state.RecentBlockHashes[i]) {
 			t.Errorf("unexpected hash value, should be unique %v", state.RecentBlockHashes[i])
 		}

--- a/go/ct/st/serialization.go
+++ b/go/ct/st/serialization.go
@@ -78,6 +78,7 @@ type stateSerializable struct {
 	CallJournal           *CallJournal
 	HasSelfDestructed     bool
 	SelfDestructedJournal []serializableSelfDestructEntry
+	RecentBlockHashes     [256]vm.Hash
 }
 
 // storageSerializable is a serializable representation of the Storage struct.
@@ -156,6 +157,7 @@ func newStateSerializableFromState(state *State) *stateSerializable {
 		CallJournal:           state.CallJournal,
 		HasSelfDestructed:     state.HasSelfDestructed,
 		SelfDestructedJournal: newSerializableJournal(state.SelfDestructedJournal),
+		RecentBlockHashes:     state.RecentBlockHashes,
 	}
 }
 
@@ -240,6 +242,7 @@ func (s *stateSerializable) deserialize() *State {
 			state.SelfDestructedJournal = append(state.SelfDestructedJournal, SelfDestructEntry{entry.Account, entry.Beneficiary})
 		}
 	}
+	state.RecentBlockHashes = s.RecentBlockHashes
 	return state
 }
 

--- a/go/ct/st/serialization_test.go
+++ b/go/ct/st/serialization_test.go
@@ -167,6 +167,7 @@ func TestSerialization_NewStateSerializableIsIndependent(t *testing.T) {
 	serializableState.LastCallReturnData = NewBytes([]byte{6})
 	serializableState.HasSelfDestructed = false
 	serializableState.SelfDestructedJournal = newSerializableJournal([]SelfDestructEntry{})
+	serializableState.RecentBlockHashes[0] = vm.Hash{0x02}
 
 	ok := s.Status == Running &&
 		s.Revision == R10_London &&
@@ -197,7 +198,8 @@ func TestSerialization_NewStateSerializableIsIndependent(t *testing.T) {
 		s.LastCallReturnData.Get(0, 1)[0] == 1 &&
 		s.HasSelfDestructed &&
 		len(s.SelfDestructedJournal) == 1 &&
-		s.SelfDestructedJournal[0] == SelfDestructEntry{vm.Address{1}, vm.Address{2}}
+		s.SelfDestructedJournal[0] == SelfDestructEntry{vm.Address{1}, vm.Address{2}} &&
+		s.RecentBlockHashes[0] == vm.Hash{0x01}
 
 	if !ok {
 		t.Errorf("new serializable state is not independent")
@@ -231,6 +233,7 @@ func TestSerialization_DeserializedStateIsIndependent(t *testing.T) {
 	deserializedState.LastCallReturnData = NewBytes([]byte{6})
 	deserializedState.HasSelfDestructed = false
 	deserializedState.SelfDestructedJournal = []SelfDestructEntry{}
+	deserializedState.RecentBlockHashes[0] = vm.Hash{0x02}
 
 	ok := s.Status == Running &&
 		s.Revision == R10_London &&
@@ -261,7 +264,8 @@ func TestSerialization_DeserializedStateIsIndependent(t *testing.T) {
 		s.LastCallReturnData.ToBytes()[0] == 1 &&
 		s.HasSelfDestructed &&
 		len(s.SelfDestructedJournal) == 1 &&
-		s.SelfDestructedJournal[0] == serializableSelfDestructEntry{vm.Address{1}, vm.Address{2}}
+		s.SelfDestructedJournal[0] == serializableSelfDestructEntry{vm.Address{1}, vm.Address{2}} &&
+		s.RecentBlockHashes[0] == vm.Hash{0x01}
 
 	if !ok {
 		t.Errorf("deserialized state is not independent")

--- a/go/ct/st/state.go
+++ b/go/ct/st/state.go
@@ -136,6 +136,7 @@ type State struct {
 	ReturnData            Bytes
 	HasSelfDestructed     bool
 	SelfDestructedJournal []SelfDestructEntry
+	RecentBlockHashes     [256]vm.Hash
 }
 
 // NewState creates a new State instance with the given code.
@@ -153,6 +154,7 @@ func NewState(code *Code) *State {
 		CallData:              Bytes{},
 		LastCallReturnData:    Bytes{},
 		SelfDestructedJournal: []SelfDestructEntry{},
+		RecentBlockHashes:     [256]vm.Hash{},
 	}
 }
 
@@ -184,6 +186,7 @@ func (s *State) Clone() *State {
 	clone.ReturnData = s.ReturnData
 	clone.HasSelfDestructed = s.HasSelfDestructed
 	clone.SelfDestructedJournal = slices.Clone(s.SelfDestructedJournal)
+	clone.RecentBlockHashes = s.RecentBlockHashes
 	return clone
 }
 
@@ -216,7 +219,8 @@ func (s *State) Eq(other *State) bool {
 		s.Accounts.Eq(other.Accounts) &&
 		s.Logs.Eq(other.Logs) &&
 		s.HasSelfDestructed == other.HasSelfDestructed &&
-		slices.Equal(s.SelfDestructedJournal, other.SelfDestructedJournal)
+		slices.Equal(s.SelfDestructedJournal, other.SelfDestructedJournal) &&
+		s.RecentBlockHashes == other.RecentBlockHashes
 
 	// For terminal states, internal state can be ignored, but the result is important.
 	if s.Status != Running {
@@ -341,6 +345,15 @@ func (s *State) String() string {
 	write("\tHasSelfDestructed: %v\n", s.HasSelfDestructed)
 	write("\tSelfDestructedJournal: %v\n", s.SelfDestructedJournal)
 
+	// only print if next instruction is blockhash and the top of the stack is a valid uint64
+	if s.Code != nil && s.Code.Length() > int(s.Pc) && s.Stack != nil && s.Stack.Size() > 0 {
+		offset := s.Stack.stack[s.Stack.Size()-1]
+		if s.Code.IsCode(int(s.Pc)) && OpCode(s.Code.code[s.Pc]) == BLOCKHASH &&
+			offset.IsUint64() {
+			write("\tHash of block %d-%d: %v\n", s.BlockContext.BlockNumber, offset, s.RecentBlockHashes[offset.Uint64()])
+		}
+	}
+
 	write("}")
 	return builder.String()
 }
@@ -436,6 +449,12 @@ func (s *State) Diff(o *State) []string {
 						entry1.account, entry1.beneficiary, entry2.account, entry2.beneficiary))
 				}
 			}
+		}
+	}
+
+	for i := 0; i < 256; i++ {
+		if s.RecentBlockHashes[i] != o.RecentBlockHashes[i] {
+			res = append(res, fmt.Sprintf("Different block number hash at index %d: %x vs %x", i, s.RecentBlockHashes[i], o.RecentBlockHashes[i]))
 		}
 	}
 

--- a/go/ct/st/state_test.go
+++ b/go/ct/st/state_test.go
@@ -444,6 +444,24 @@ func TestState_PrinterMemorySize(t *testing.T) {
 	}
 }
 
+func TestState_PrinterRecentBlockHashes(t *testing.T) {
+	s := NewState(NewCode([]byte{byte(BLOCKHASH)}))
+	s.Stack.Push(NewU256(0))
+	s.RecentBlockHashes = [256]vm.Hash{{0x01}}
+
+	r := regexp.MustCompile(`Hash of block 0: 0x([0-9a-fA-F]+)`) // \[([0-9a-f]+)\]
+	str := s.String()
+	match := r.FindStringSubmatch(str)
+
+	if len(match) != 2 {
+		t.Fatal("invalid print, did not find recent block hashes")
+	}
+
+	if want, got := "0100000000000000000000000000000000000000000000000000000000000000", match[1]; want != got {
+		t.Errorf("invalid recent block hashes, want %v, got %v", want, got)
+	}
+}
+
 func TestState_DiffMatch(t *testing.T) {
 	s1 := NewState(NewCode([]byte{byte(PUSH2), 7, 4, byte(ADD), byte(STOP)}))
 	s1.Status = Running

--- a/go/ct/st/state_test.go
+++ b/go/ct/st/state_test.go
@@ -53,6 +53,7 @@ func getNewFilledState() *State {
 	s.LastCallReturnData = NewBytes([]byte{1})
 	s.HasSelfDestructed = true
 	s.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{1}, vm.Address{2}}}
+	s.RecentBlockHashes = [256]vm.Hash{{0x01}}
 	return s
 }
 
@@ -157,6 +158,11 @@ func getTestChanges() map[string]testStruct {
 			state.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0x01}, vm.Address{0x04}}}
 		},
 			"Different has-self-destructed journal entry",
+		},
+		"block_number_hashes": {func(state *State) {
+			state.RecentBlockHashes = [256]vm.Hash{{0x02}}
+		},
+			"Different block number hash at index 0: 0200000000000000000000000000000000000000000000000000000000000000 vs 0100000000000000000000000000000000000000000000000000000000000000",
 		},
 	}
 	return tests
@@ -455,6 +461,7 @@ func TestState_DiffMatch(t *testing.T) {
 	s1.LastCallReturnData = NewBytes([]byte{1})
 	s1.HasSelfDestructed = true
 	s1.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0x01}, vm.Address{0x01}}}
+	s1.RecentBlockHashes = [256]vm.Hash{{0x01}}
 
 	s2 := NewState(NewCode([]byte{byte(PUSH2), 7, 4, byte(ADD), byte(STOP)}))
 	s2.Status = Running
@@ -472,6 +479,7 @@ func TestState_DiffMatch(t *testing.T) {
 	s2.LastCallReturnData = NewBytes([]byte{1})
 	s2.HasSelfDestructed = true
 	s2.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0x01}, vm.Address{0x01}}}
+	s2.RecentBlockHashes = [256]vm.Hash{{0x01}}
 
 	diffs := s1.Diff(s2)
 
@@ -502,6 +510,7 @@ func TestState_DiffMismatch(t *testing.T) {
 	s1.LastCallReturnData = NewBytes([]byte{1})
 	s1.HasSelfDestructed = true
 	s1.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0x01}, vm.Address{0x01}}}
+	s1.RecentBlockHashes = [256]vm.Hash{{0x01}}
 
 	s2 := NewState(NewCode([]byte{byte(PUSH2), 7, 5, byte(ADD)}))
 	s2.Status = Running
@@ -519,6 +528,7 @@ func TestState_DiffMismatch(t *testing.T) {
 	s2.LastCallReturnData = NewBytes([]byte{249})
 	s2.HasSelfDestructed = false
 	s2.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0xf3}, vm.Address{0xf3}}}
+	s2.RecentBlockHashes = [256]vm.Hash{{0xf2}}
 
 	diffs := s1.Diff(s2)
 
@@ -541,6 +551,7 @@ func TestState_DiffMismatch(t *testing.T) {
 		"Different last call return data",
 		"Different has-self-destructed",
 		"Different has-self-destructed journal entry",
+		"Different block number hash at index 0: 0100000000000000000000000000000000000000000000000000000000000000 vs f200000000000000000000000000000000000000000000000000000000000000",
 	}
 
 	if len(diffs) != len(expectedDiffs) {

--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -123,7 +123,7 @@ func (c *ctRunContext) GetTransactionContext() vm.TransactionContext {
 func (c *ctRunContext) GetBlockHash(number int64) vm.Hash {
 	min := int64(0)
 	max := int64(c.state.BlockContext.BlockNumber)
-	if c.state.BlockContext.BlockNumber > 256 {
+	if max > 256 {
 		min = max - 256
 	}
 	if min > number || number >= max {

--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -121,7 +121,16 @@ func (c *ctRunContext) GetTransactionContext() vm.TransactionContext {
 }
 
 func (c *ctRunContext) GetBlockHash(number int64) vm.Hash {
-	panic("not implemented")
+	min := int64(0)
+	max := int64(c.state.BlockContext.BlockNumber)
+	if c.state.BlockContext.BlockNumber > 256 {
+		min = max - 256
+	}
+	if min > number || number >= max {
+		return vm.Hash{0x0}
+	}
+
+	return c.state.RecentBlockHashes[max-number-1]
 }
 
 // TODO: add unit test

--- a/go/vm/geth/geth.go
+++ b/go/vm/geth/geth.go
@@ -107,7 +107,7 @@ func createGethInterpreterContext(parameters vm.Parameters) (*geth.EVM, *geth.Co
 
 	// Hashing function used in the context for BLOCKHASH instruction
 	getHash := func(num uint64) common.Hash {
-		return common.Hash{}
+		return common.Hash(parameters.Context.GetBlockHash(int64(num)))
 	}
 
 	var transactionContext vm.TransactionContext


### PR DESCRIPTION
This PR adds a list of the last 256 blocks' hashes to the CT's state and the opcode for `BLOCKHASH`. 
This list of hashes will be needed for the implementation of the rule, but since it can be in its own PR for ease of read and understanding. 

This PR contributes to #459 