### PR TITLE
CT: Add interval solver

### DIFF
--- a/go/ct/gen/interval_solver.go
+++ b/go/ct/gen/interval_solver.go
@@ -13,7 +13,7 @@ import (
 //
 //	X ∈ [a1..b1] ∪ [a2..b2] ∪ ... ∪ [an..bn]
 //
-// The solver maintains a list of disjoint intervals [a..b] that represent the
+// The solver maintains a list of inclusive intervals [a..b] that represent the
 // domain of the variable x. The solver can exclude ranges from the domain and
 // check if the domain is empty, making the constraints unsatisfiable.
 type IntervalSolver[T constraints.Integer] struct {
@@ -166,7 +166,7 @@ const (
 	isEqual             relation = iota // [1..3] isEqual [1..3]
 	isBefore                            // [1..3] is before [4..6]
 	isAfter                             // [4..6] is after [1..3]
-	isSubset                            // [1..6] isContained in [2..5]
+	isSubset                            // [1..6] contains [2..5]
 	isSuperset                          // [2..5] isEnclosed in [1..6]
 	intersectsWithStart                 // [1..3] intersectsWithStart [2..6]
 	intersectsWithEnd                   // [2..6] intersectsWithEnd [1..5]

--- a/go/ct/gen/interval_solver.go
+++ b/go/ct/gen/interval_solver.go
@@ -1,0 +1,177 @@
+package gen
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/exp/constraints"
+	"pgregory.net/rand"
+)
+
+type IntervalSolver[T constraints.Integer] struct {
+	intervals []interval[T]
+}
+
+func NewIntervalSolver[T constraints.Integer](min, max T) *IntervalSolver[T] {
+	return &IntervalSolver[T]{
+		intervals: []interval[T]{{min, max}},
+	}
+}
+
+func (s *IntervalSolver[T]) Exclude(min, max T) {
+	if max < min {
+		return
+	}
+	res := []interval[T]{}
+	for _, current := range s.intervals {
+		newLeft := interval[T]{current.low, min - 1}
+		newRight := interval[T]{max + 1, current.high}
+
+		switch current.getRelationTo(&interval[T]{min, max}) {
+		case isEqual:
+			continue // we remove this interval
+		case isSubset:
+			res = append(res, newLeft, newRight)
+		case isSuperset:
+			continue // the current interval is dropped
+		case intersectsWithStart:
+			res = append(res, newRight)
+		case intersectsWithEnd:
+			res = append(res, newLeft)
+		default:
+			res = append(res, current)
+		}
+
+	}
+	s.intervals = res
+}
+
+func (s *IntervalSolver[T]) Contains(value T) bool {
+	for _, interval := range s.intervals {
+		if interval.contains(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *IntervalSolver[T]) AddEqualityConstraint(value T) {
+	s.AddLowerBoundary(value)
+	s.AddUpperBoundary(value)
+}
+
+func (s *IntervalSolver[T]) AddLowerBoundary(value T) {
+	if len(s.intervals) == 0 {
+		return
+	}
+	min := s.intervals[0].low
+	s.Exclude(min, value-1)
+}
+
+func (s *IntervalSolver[T]) AddUpperBoundary(value T) {
+	if len(s.intervals) == 0 {
+		return
+	}
+	max := s.intervals[len(s.intervals)-1].high
+	s.Exclude(value+1, max)
+}
+
+func (s *IntervalSolver[T]) IsSatisfiable() bool {
+	return len(s.intervals) > 0
+}
+
+func (s *IntervalSolver[T]) Generate(rnd *rand.Rand) (T, error) {
+	if len(s.intervals) == 0 {
+		return 0, ErrUnsatisfiable
+	}
+
+	domainSize := uint64(0)
+	for _, interval := range s.intervals {
+		domainSize += uint64(interval.high - interval.low + 1)
+	}
+
+	if domainSize == 0 { // the domain is the full uint64 domain
+		return T(rnd.Uint64()), nil
+	}
+
+	sample := rnd.Uint64n(domainSize)
+	for _, interval := range s.intervals {
+		if uint64(interval.high-interval.low+1) > sample {
+			return interval.low + T(sample), nil
+		}
+		sample -= uint64(interval.high - interval.low + 1)
+	}
+	return 0, fmt.Errorf("internal error")
+}
+
+func (s *IntervalSolver[T]) String() string {
+	if len(s.intervals) == 0 {
+		return "false"
+	}
+	clauses := []string{}
+	for _, interval := range s.intervals {
+		clauses = append(clauses, fmt.Sprintf("[%d..%d]", interval.low, interval.high))
+	}
+	return fmt.Sprintf("X ∈ %s", strings.Join(clauses, " ∪ "))
+}
+
+func (s *IntervalSolver[T]) Clone() *IntervalSolver[T] {
+	return &IntervalSolver[T]{intervals: append([]interval[T]{}, s.intervals...)}
+}
+
+func (s *IntervalSolver[T]) Equals(other *IntervalSolver[T]) bool {
+	if len(s.intervals) != len(other.intervals) {
+		return false
+	}
+	for i, interval := range s.intervals {
+		if interval != other.intervals[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// [a..b] ... pick one element in the range
+// [a..b][c..d][e..f] ... pick one element in any of those ranges
+
+type interval[T constraints.Integer] struct {
+	low, high T
+}
+
+func (i *interval[T]) contains(x T) bool {
+	return i.low <= x && x <= i.high
+}
+
+type relation int
+
+const (
+	isEqual             relation = iota // [1..3] isEqual [1..3]
+	isBefore                            // [1..3] is before [4..6]
+	isAfter                             // [4..6] is after [1..3]
+	isSubset                            // [1..6] isContained in [2..5]
+	isSuperset                          // [2..5] isEnclosed in [1..6]
+	intersectsWithStart                 // [1..3] intersectsWithStart [2..6]
+	intersectsWithEnd                   // [2..6] intersectsWithEnd [1..5]
+)
+
+func (i *interval[T]) getRelationTo(other *interval[T]) relation {
+	if *i == *other {
+		return isEqual
+	}
+	if i.high < other.low {
+		return isBefore
+	}
+	if i.low > other.high {
+		return isAfter
+	}
+	if i.low < other.low && other.high < i.high {
+		return isSubset
+	}
+	if other.low <= i.low && i.high <= other.high {
+		return isSuperset
+	}
+	if other.low <= i.high && i.high <= other.high {
+		return intersectsWithEnd
+	}
+	return intersectsWithStart
+}

--- a/go/ct/gen/interval_solver.go
+++ b/go/ct/gen/interval_solver.go
@@ -13,8 +13,12 @@ type IntervalSolver[T constraints.Integer] struct {
 }
 
 func NewIntervalSolver[T constraints.Integer](min, max T) *IntervalSolver[T] {
+	initialInterval := interval[T]{low: min, high: max}
+	if initialInterval.isEmpty() {
+		return &IntervalSolver[T]{}
+	}
 	return &IntervalSolver[T]{
-		intervals: []interval[T]{{min, max}},
+		intervals: []interval[T]{initialInterval},
 	}
 }
 
@@ -81,12 +85,15 @@ func (s *IntervalSolver[T]) IsSatisfiable() bool {
 }
 
 func (s *IntervalSolver[T]) Generate(rnd *rand.Rand) (T, error) {
-	if len(s.intervals) == 0 {
+	if s.intervals == nil || len(s.intervals) == 0 {
 		return 0, ErrUnsatisfiable
 	}
 
 	domainSize := uint64(0)
 	for _, interval := range s.intervals {
+		if interval.isEmpty() {
+			return 0, ErrUnsatisfiable
+		}
 		domainSize += uint64(interval.high - interval.low + 1)
 	}
 
@@ -140,6 +147,10 @@ type interval[T constraints.Integer] struct {
 
 func (i *interval[T]) contains(x T) bool {
 	return i.low <= x && x <= i.high
+}
+
+func (i *interval[T]) isEmpty() bool {
+	return i.low > i.high
 }
 
 type relation int

--- a/go/ct/gen/interval_solver_test.go
+++ b/go/ct/gen/interval_solver_test.go
@@ -178,7 +178,7 @@ func TestIntervalSolver_ExcludeEmptyIntervalHasNoEffect(t *testing.T) {
 	}
 }
 
-func TestIntervalSolver_TestIntervals(t *testing.T) {
+func TestIntervalSolver_GenerateProducesValuesFromWithinTheIntervals(t *testing.T) {
 	solver := NewIntervalSolver[int32](200, 400)
 	solver.Exclude(250, 300)
 
@@ -284,6 +284,12 @@ func TestIntervalSolver_uint64fullrangeAndEdges(t *testing.T) {
 		"remove-max": {
 			setup: func(s *IntervalSolver[uint64]) { s.Exclude(math.MaxUint64, math.MaxUint64) },
 			check: func(v uint64) bool { return v >= 0 && v < math.MaxUint64-1 }},
+		"fix-max": {
+			setup: func(s *IntervalSolver[uint64]) { s.AddEqualityConstraint(math.MaxUint64) },
+			check: func(v uint64) bool { return v == math.MaxUint64 }},
+		"fix-zero": {
+			setup: func(s *IntervalSolver[uint64]) { s.AddEqualityConstraint(0) },
+			check: func(v uint64) bool { return v == 0 }},
 	}
 
 	rnd := rand.New()
@@ -329,6 +335,12 @@ func TestIntervalSolver_int64fullrangeAndEdges(t *testing.T) {
 		"remove-zero": {
 			setup: func(s *IntervalSolver[int64]) { s.Exclude(0, 0) },
 			check: func(v int64) bool { return v != 0 }},
+		"fix-max": {
+			setup: func(s *IntervalSolver[int64]) { s.AddEqualityConstraint(math.MaxInt64) },
+			check: func(v int64) bool { return v == math.MaxInt64 }},
+		"fix-min": {
+			setup: func(s *IntervalSolver[int64]) { s.AddEqualityConstraint(math.MinInt64) },
+			check: func(v int64) bool { return v == math.MinInt64 }},
 	}
 
 	rnd := rand.New(0)
@@ -442,6 +454,24 @@ func TestIntervalSolver_allValuesAreGenerated(t *testing.T) {
 
 							return false
 						}
+					}
+				}
+				return true
+			},
+		},
+		"fix-value": {
+			solver: func() *IntervalSolver[int32] {
+				solver := NewIntervalSolver[int32](20, 40)
+				solver.AddEqualityConstraint(30)
+				return solver
+			}(),
+			check: func(seen map[int32]int) bool {
+				for i := 20; i <= 40; i++ {
+					if i == 30 && seen[int32(i)] == 0 {
+						return false
+					}
+					if i != 30 && seen[int32(i)] != 0 {
+						return false
 					}
 				}
 				return true

--- a/go/ct/gen/interval_solver_test.go
+++ b/go/ct/gen/interval_solver_test.go
@@ -1,0 +1,208 @@
+package gen
+
+import (
+	"testing"
+
+	"pgregory.net/rand"
+)
+
+func TestIntervalSolver_CanFormulateConstraints(t *testing.T) {
+	tests := map[string]struct {
+		setup func(*IntervalSolver[int32])
+		want  string
+	}{
+		"empty": {
+			setup: func(s *IntervalSolver[int32]) {},
+			want:  "X ∈ [200..400]",
+		},
+		"remove-something-before": {
+			setup: func(s *IntervalSolver[int32]) {
+				s.Exclude(100, 150)
+			},
+			want: "X ∈ [200..400]",
+		},
+		"remove-something-after": {
+			setup: func(s *IntervalSolver[int32]) {
+				s.Exclude(500, 550)
+			},
+			want: "X ∈ [200..400]",
+		},
+		"remove-equal": {
+			setup: func(s *IntervalSolver[int32]) {
+				s.Exclude(200, 400)
+			},
+			want: "false",
+		},
+		"remove-subset": {
+			setup: func(s *IntervalSolver[int32]) {
+				s.Exclude(250, 340)
+			},
+			want: "X ∈ [200..249] ∪ [341..400]",
+		},
+		"remove-superset": {
+			setup: func(s *IntervalSolver[int32]) {
+				s.Exclude(150, 440)
+			},
+			want: "false",
+		},
+		"remove-touches-on-the-left": {
+			setup: func(s *IntervalSolver[int32]) {
+				s.Exclude(150, 250)
+			},
+			want: "X ∈ [251..400]",
+		},
+		"remove-touches-on-the-right": {
+			setup: func(s *IntervalSolver[int32]) {
+				s.Exclude(350, 450)
+			},
+			want: "X ∈ [200..349]",
+		},
+		"fragment-range": {
+			setup: func(s *IntervalSolver[int32]) {
+				s.Exclude(250, 300)
+				s.Exclude(320, 380)
+			},
+			want: "X ∈ [200..249] ∪ [301..319] ∪ [381..400]",
+		},
+		"fragment-range-with-overlap": {
+			setup: func(s *IntervalSolver[int32]) {
+				s.Exclude(250, 300)
+				s.Exclude(320, 380)
+				s.Exclude(220, 310)
+			},
+			want: "X ∈ [200..219] ∪ [311..319] ∪ [381..400]",
+		},
+		"remove-empty-interval": {
+			setup: func(s *IntervalSolver[int32]) {
+				s.Exclude(300, 250) // < considered empty
+			},
+			want: "X ∈ [200..400]",
+		},
+		"equality-constraint": {
+			setup: func(s *IntervalSolver[int32]) {
+				s.AddEqualityConstraint(300)
+			},
+			want: "X ∈ [300..300]",
+		},
+		"lower-boundary-constraint": {
+			setup: func(s *IntervalSolver[int32]) {
+				s.AddLowerBoundary(300)
+			},
+			want: "X ∈ [300..400]",
+		},
+		"upper-boundary-constraint": {
+			setup: func(s *IntervalSolver[int32]) {
+				s.AddUpperBoundary(300)
+			},
+			want: "X ∈ [200..300]",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			solver := NewIntervalSolver[int32](200, 400)
+			test.setup(solver)
+			got := solver.String()
+			if got != test.want {
+				t.Errorf("unexpected result, got %v, want %v", got, test.want)
+			}
+		})
+	}
+
+}
+
+func TestIntervalSolver_Exclude(t *testing.T) {
+	const N = 20
+	// remove interval [c..d] from [a..b]
+	for a := 0; a < N; a++ {
+		for b := 0; b < N; b++ {
+			for c := 0; c < N; c++ {
+				for d := 0; d < N; d++ {
+					solver := NewIntervalSolver(uint32(a), uint32(b))
+					solver.Exclude(uint32(c), uint32(d))
+					for i := 0; i < N; i++ {
+						inAtoB := a <= i && i <= b
+						inCtoD := c <= i && i <= d
+						want := inAtoB && !inCtoD
+						got := solver.Contains(uint32(i))
+						if got != want {
+							t.Fatalf("unexpected result for %d ∈ [%d..%d] \\ [%d..%d]: got %v, want %v", i, a, b, c, d, got, want)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestIntervalSolver_TestIntervals(t *testing.T) {
+	solver := NewIntervalSolver[int32](200, 400)
+	solver.Exclude(250, 300)
+
+	rnd := rand.New()
+	for i := 0; i < 100; i++ {
+		res, err := solver.Generate(rnd)
+		if err != nil {
+			t.Fatalf("error solving intervals: %v", err)
+		}
+		if res < 200 || res > 400 || (res >= 250 && res <= 300) {
+			t.Fatalf("produced unexpected result for condition %v: %d", solver, res)
+		}
+	}
+}
+
+func TestIntervalSolver_IsSatisfiable(t *testing.T) {
+	solver := NewIntervalSolver[int32](200, 400)
+	if !solver.IsSatisfiable() {
+		t.Fatalf("interval should be solvable: %s", solver.String())
+	}
+	solver.intervals = nil
+	if solver.IsSatisfiable() {
+		t.Fatalf("empty interval should be unsolvable")
+	}
+}
+
+func TestIntervalSolver_AddBoundariesInEmptySolverHasNoEffect(t *testing.T) {
+
+	tests := map[string]func(*IntervalSolver[int32]){
+		"lower":    func(s *IntervalSolver[int32]) { s.AddLowerBoundary(300) },
+		"upper":    func(s *IntervalSolver[int32]) { s.AddUpperBoundary(300) },
+		"equality": func(s *IntervalSolver[int32]) { s.AddEqualityConstraint(300) },
+	}
+
+	for name, setup := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			solver := NewIntervalSolver[int32](200, 400)
+			solver.intervals = nil
+			clone := solver.Clone()
+			setup(clone)
+			if !solver.Equals(clone) {
+				t.Fatalf("empty interval solver should not be modified by adding boundaries")
+			}
+		})
+	}
+}
+
+func TestIntervalSolver_Clone(t *testing.T) {
+	solver := NewIntervalSolver[int32](200, 400)
+	clone := solver.Clone()
+	if !solver.Equals(clone) {
+		t.Errorf("cloned should be same as original")
+	}
+	clone.AddLowerBoundary(300)
+	if solver.Equals(clone) {
+		t.Fatalf("cloned solver should be a distinct instance")
+	}
+}
+
+func TestIntervalSolver_Equals(t *testing.T) {
+	solver1 := NewIntervalSolver[int32](200, 400)
+	solver2 := NewIntervalSolver[int32](100, 400)
+	if !solver1.Equals(solver1) {
+		t.Errorf("equals fails comparison with same instance")
+	}
+	if solver1.Equals(solver2) {
+		t.Errorf("equals fails to report different instances")
+	}
+}


### PR DESCRIPTION
This PR adds an interval solver. This tool can be used to describe a set of intervals and get a random number uniformly from all the possible values considering all the intervals. 

This PR contributes to #459 

