### PR TITLE
CT: Fix Interval flaky test

### DIFF
--- a/go/ct/gen/interval_solver_test.go
+++ b/go/ct/gen/interval_solver_test.go
@@ -482,7 +482,7 @@ func TestIntervalSolver_allValuesAreGenerated(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			seen := map[int32]int{}
-			rnd := rand.New()
+			rnd := rand.New(0)
 			for i := 0; i <= 100; i++ {
 				res, err := test.solver.Generate(rnd)
 				if err != nil {


### PR DESCRIPTION
This PR fixes the seed for an unstable test.
Since the test aims to randomly generate all the values inside the range, it is hard to ensure how many iterations are needed for this. 
One options is to fix the seed, hence ensuring the same sequence of random numbers.
Another alternative would be to keep iterating until all the elements in the range have been generated at least once.

Let me know if you think this suffices or I should implement the second alternative.
