### PR TITLE
LFVM: Add init code size check

### DIFF
--- a/go/vm/lfvm/ct.go
+++ b/go/vm/lfvm/ct.go
@@ -161,7 +161,7 @@ func convertLfvmStatusToCtStatus(status Status) (st.StatusCode, error) {
 	case SUICIDED:
 		// Suicide is not yet modeled by the CT, and for now it just maps to the STOPPED status.
 		return st.Stopped, nil
-	case INVALID_INSTRUCTION, OUT_OF_GAS, SEGMENTATION_FAULT, ERROR:
+	case INVALID_INSTRUCTION, OUT_OF_GAS, SEGMENTATION_FAULT, MAX_INIT_CODE_SIZE_EXCEEDED, ERROR:
 		return st.Failed, nil
 	default:
 		return st.Failed, fmt.Errorf("unable to convert lfvm status %v to ct status", status)

--- a/go/vm/lfvm/instructions.go
+++ b/go/vm/lfvm/instructions.go
@@ -800,6 +800,14 @@ func opExtcodehash(c *context) {
 	}
 }
 
+// Constants for CREATE / CREATE2 opcodes
+const (
+	MaxCodeSize     = 24576           // Maximum bytecode to permit for a contract
+	MaxInitCodeSize = 2 * MaxCodeSize // Maximum initcode to permit in a creation transaction and create instructions
+
+	InitCodeWordGas = 2 // Once per word of the init code when creating a contract.
+)
+
 func opCreate(c *context) {
 	var (
 		value  = c.stack.pop()
@@ -813,6 +821,18 @@ func opCreate(c *context) {
 
 	if c.memory.EnsureCapacity(offset.Uint64(), size.Uint64(), c) != nil {
 		return
+	}
+
+	if c.revision >= vm.R12_Shanghai {
+		if !size.IsUint64() || size.Uint64() > MaxInitCodeSize {
+			c.UseGas(c.gas)
+			c.status = MAX_INIT_CODE_SIZE_EXCEEDED
+			return
+		}
+		if !c.UseGas(vm.Gas(InitCodeWordGas * ((size.Uint64() + 31) / 32))) {
+			c.status = OUT_OF_GAS
+			return
+		}
 	}
 
 	if !value.IsZero() {
@@ -873,6 +893,18 @@ func opCreate2(c *context) {
 
 	if c.memory.EnsureCapacity(offset.Uint64(), size.Uint64(), c) != nil {
 		return
+	}
+
+	if c.revision >= vm.R12_Shanghai {
+		if !size.IsUint64() || size.Uint64() > MaxInitCodeSize {
+			c.UseGas(c.gas)
+			c.status = MAX_INIT_CODE_SIZE_EXCEEDED
+			return
+		}
+		if !c.UseGas(vm.Gas(InitCodeWordGas * ((size.Uint64() + 31) / 32))) {
+			c.status = OUT_OF_GAS
+			return
+		}
 	}
 
 	// Charge for the code size

--- a/go/vm/lfvm/interpreter.go
+++ b/go/vm/lfvm/interpreter.go
@@ -34,6 +34,7 @@ const (
 	INVALID_INSTRUCTION
 	OUT_OF_GAS
 	SEGMENTATION_FAULT
+	MAX_INIT_CODE_SIZE_EXCEEDED
 	ERROR
 )
 
@@ -174,7 +175,7 @@ func Run(
 			Output:  res,
 			GasLeft: ctxt.gas,
 		}, nil
-	case INVALID_INSTRUCTION, OUT_OF_GAS, SEGMENTATION_FAULT, ERROR:
+	case INVALID_INSTRUCTION, OUT_OF_GAS, SEGMENTATION_FAULT, MAX_INIT_CODE_SIZE_EXCEEDED, ERROR:
 		return vm.Result{
 			Success: false,
 		}, nil

--- a/go/vm/lfvm/memory.go
+++ b/go/vm/lfvm/memory.go
@@ -28,6 +28,7 @@ func NewMemory() *Memory {
 	return &Memory{}
 }
 
+// TODO: add overflow check, issue #524
 func toValidMemorySize(size uint64) uint64 {
 	// Target size seems to need to be a multiple of 32
 	return ((size + 31) / 32) * 32


### PR DESCRIPTION
Starting with Shanghai, the init code of a create call can no longer have arbitrary size. These changes are added to the LFVM create/create2 implementations.

Contributes to #489.