### PR TITLE
evmzero: Limit init code size

### DIFF
--- a/cpp/vm/evmzero/evmzero.cc
+++ b/cpp/vm/evmzero/evmzero.cc
@@ -57,6 +57,8 @@ evmc_status_code ToEvmcStatusCode(RunState state) {
       return EVMC_FAILURE;
     case RunState::kErrorStaticCall:
       return EVMC_STATIC_MODE_VIOLATION;
+    case RunState::kErrorInitCodeSizeExceeded:
+      return EVMC_FAILURE;
   }
   return EVMC_FAILURE;
 }

--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -1519,17 +1519,19 @@ struct CreateImpl {
       return {.dynamic_gas_costs = initial_gas - gas};
 
     if (ctx.revision >= EVMC_SHANGHAI) {
-      const int64_t max_code_size = 24576;
-      const int64_t max_init_code_size = 2 * max_code_size;
-      const int64_t init_code_word_cost = 2;
+      const int64_t kMaxCodeSize = 24576;  // introduced with EIP-3860
+      const int64_t kMaxInitCodeSize = 2 * kMaxCodeSize;
+      const int64_t kInitCodeWordCost = 2;
 
-      if (init_code_size > max_init_code_size) {
+      if (init_code_size > kMaxInitCodeSize) {
         return {
             .state = RunState::kErrorInitCodeSizeExceeded,
             .dynamic_gas_costs = initial_gas - gas,
         };
       }
-      if (gas -= init_code_word_cost * static_cast<int64_t>(((init_code_size + 31) / 32)), gas < 0) {
+
+      const int64_t init_code_cost = kInitCodeWordCost * static_cast<int64_t>(((init_code_size + 31) / 32));
+      if (gas -= init_code_cost, gas < 0) {
         return {.dynamic_gas_costs = initial_gas - gas};
       }
     }

--- a/cpp/vm/evmzero/interpreter.h
+++ b/cpp/vm/evmzero/interpreter.h
@@ -41,6 +41,7 @@ enum class RunState {
   kErrorCall,
   kErrorCreate,
   kErrorStaticCall,
+  kErrorInitCodeSizeExceeded,
 };
 
 bool IsSuccess(RunState);

--- a/cpp/vm/evmzero/interpreter_test.cc
+++ b/cpp/vm/evmzero/interpreter_test.cc
@@ -5010,6 +5010,72 @@ TEST(InterpreterTest, CREATE_MemoryIsGrownAlsoWithInsufficientBalance) {
   });
 }
 
+TEST(InterpreterTest, CREATE_ShanghaiLimitInitCodeSize) {
+  RunInterpreterTest({
+      .code = {op::CREATE},
+      .state_after = RunState::kErrorInitCodeSizeExceeded,
+      .gas_before = 50000,
+      .stack_before =
+          {
+              0xc001,  // < size
+              0x00,    // < offset
+              0x00,    // < value
+          },
+      .revision = EVMC_SHANGHAI,
+  });
+}
+
+TEST(InterpreterTest, CREATE_ShanghaiCodeDepositCost) {
+  RunInterpreterTest({
+      .code = {op::CREATE},
+      .state_after = RunState::kDone,
+      .gas_before = 32005,
+      .stack_before =
+          {
+              0x0A,  // < size
+              0x00,  // < offset
+              0x00,  // < value
+          },
+      .stack_after = {0x00},
+      .memory_before = {},
+      .memory_after = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      .revision = EVMC_SHANGHAI,
+  });
+}
+
+TEST(InterpreterTest, CREATE_ShanghaiCodeDepositCostInsufficientGas) {
+  RunInterpreterTest({
+      .code = {op::CREATE},
+      .state_after = RunState::kErrorGas,
+      .gas_before = 32003,
+      .stack_before =
+          {
+              0x0A,  // < size
+              0x00,  // < offset
+              0x00,  // < value
+          },
+      .revision = EVMC_SHANGHAI,
+  });
+}
+
+TEST(InterpreterTest, CREATE_PreShanghaiCodeDepositCost) {
+  RunInterpreterTest({
+      .code = {op::CREATE},
+      .state_after = RunState::kDone,
+      .gas_before = 32003,
+      .stack_before =
+          {
+              0x0A,  // < size
+              0x00,  // < offset
+              0x00,  // < value
+          },
+      .stack_after = {0x00},
+      .memory_before = {},
+      .memory_after = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      .revision = EVMC_PARIS,
+  });
+}
+
 ///////////////////////////////////////////////////////////
 // CALL
 


### PR DESCRIPTION
Starting with Shanghai, the init code of a create call can no longer have arbitrary size. These changes are added to the evmzero create/create2 implementations.

Contributes to #489.