### PR TITLE
CT: Add create init code limit

### DIFF
--- a/go/ct/rlz/parameters.go
+++ b/go/ct/rlz/parameters.go
@@ -59,6 +59,11 @@ func (MemorySizeParameter) Samples() []U256 {
 		NewU256(31),
 		NewU256(32),
 		NewU256(1, 0),
+
+		// Samples stressing the max init code size introduced with Shanghai
+		NewU256(2*24576 - 1),
+		NewU256(2 * 24576),
+		NewU256(2*24576 + 1),
 	}
 }
 

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -1500,7 +1500,6 @@ func getAllRules() []Rule {
 		pushes:    1,
 		conditions: []Condition{
 			Eq(ReadOnly(), true),
-			RevisionBounds(MinRevision, R11_Paris),
 		},
 		parameters: []Parameter{
 			ValueParameter{},
@@ -1517,7 +1516,6 @@ func getAllRules() []Rule {
 		pushes:    1,
 		conditions: []Condition{
 			Eq(ReadOnly(), false),
-			RevisionBounds(MinRevision, R11_Paris),
 		},
 		parameters: []Parameter{
 			ValueParameter{},
@@ -1539,7 +1537,6 @@ func getAllRules() []Rule {
 		pushes:    1,
 		conditions: []Condition{
 			Eq(ReadOnly(), true),
-			RevisionBounds(MinRevision, R11_Paris),
 		},
 		parameters: []Parameter{
 			ValueParameter{},
@@ -1557,7 +1554,6 @@ func getAllRules() []Rule {
 		pushes:    1,
 		conditions: []Condition{
 			Eq(ReadOnly(), false),
-			RevisionBounds(MinRevision, R11_Paris),
 		},
 		parameters: []Parameter{
 			ValueParameter{},


### PR DESCRIPTION
Starting with Shanghai, the init code of a create call can no longer have arbitrary size. These changes are added to the create/create2 effect implementation.

Fixes #489, can only be merged after #498 and #499 to ensure correct CT execution.