### PR TITLE
CT: fix jump/i explicit test and evmzero adapter

### DIFF
--- a/go/ct/evm_test.go
+++ b/go/ct/evm_test.go
@@ -35,24 +35,34 @@ var evms = map[string]ct.Evm{
 }
 
 func TestCt_ExplicitCases(t *testing.T) {
-	tests := map[string]Condition{
-		"jump_to_2^32": And(
-			RevisionBounds(R07_Istanbul, NewestSupportedRevision),
-			Eq(Status(), st.Running),
-			Eq(Op(Pc()), JUMP),
-			Eq(Op(Constant(NewU256(0))), JUMPDEST),
-			Eq(Param(0), NewU256(1<<32)),
-			Ge(Gas(), vm.Gas(8)),
-		),
-		"jumpi_to_2^32": And(
-			RevisionBounds(R07_Istanbul, NewestSupportedRevision),
-			Eq(Status(), st.Running),
-			Eq(Op(Pc()), JUMPI),
-			Eq(Op(Constant(NewU256(0))), JUMPDEST),
-			Eq(Param(0), NewU256(1<<32)),
-			Ne(Param(1), NewU256(0)),
-			Ge(Gas(), vm.Gas(10)),
-		),
+
+	revisions := []Revision{}
+
+	for i := R07_Istanbul; i <= NewestSupportedRevision; i++ {
+		revisions = append(revisions, i)
+	}
+
+	tests := map[string]Condition{}
+	for _, revision := range revisions {
+		tests["jump_to_2^32_"+revision.String()] =
+			And(
+				IsRevision(revision),
+				Eq(Status(), st.Running),
+				Eq(Op(Pc()), JUMP),
+				Eq(Op(Constant(NewU256(0))), JUMPDEST),
+				Eq(Param(0), NewU256(1<<32)),
+				Ge(Gas(), vm.Gas(8)),
+			)
+		tests["jumpi_to_2^32"+revision.String()] =
+			And(
+				IsRevision(revision),
+				Eq(Status(), st.Running),
+				Eq(Op(Pc()), JUMPI),
+				Eq(Op(Constant(NewU256(0))), JUMPDEST),
+				Eq(Param(0), NewU256(1<<32)),
+				Ne(Param(1), NewU256(0)),
+				Ge(Gas(), vm.Gas(10)),
+			)
 	}
 
 	random := rand.New(0)

--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -42,6 +42,8 @@ func ToVmParameters(state *st.State) vm.Parameters {
 		revision = vm.R10_London
 	case cc.R11_Paris:
 		revision = vm.R11_Paris
+	case cc.R12_Shanghai:
+		revision = vm.R12_Shanghai
 	default:
 		revision = vm.Revision(state.Revision)
 	}

--- a/go/vm/evmzero/evmzero.go
+++ b/go/vm/evmzero/evmzero.go
@@ -106,7 +106,7 @@ type evmzeroInstance struct {
 	e *evmc.EvmcInterpreter
 }
 
-const newestSupportedRevision = vm.R11_Paris
+const newestSupportedRevision = vm.R12_Shanghai
 
 func (e *evmzeroInstance) Run(params vm.Parameters) (vm.Result, error) {
 	if params.Revision > newestSupportedRevision {


### PR DESCRIPTION
This PR fixes the `ExplicitCases` test for `JUMP` and `JUMPI` instructions by forcing it to run with all the supported revisions, and updates the evmzero adapter to support Shangai as well.

This problem was hidden by the random number generator only generating revisions older than Shangai