### PR TITLE
Fix Flaky unittest, allocate enough space for all needed opCodes

### DIFF
--- a/go/ct/evm_test.go
+++ b/go/ct/evm_test.go
@@ -34,7 +34,7 @@ var evms = map[string]ct.Evm{
 	"evmzero": evmzero.NewConformanceTestingTarget(),
 }
 
-func Disabled_TestCt_ExplicitCases(t *testing.T) {
+func TestCt_ExplicitCases(t *testing.T) {
 
 	revisions := []Revision{}
 
@@ -101,7 +101,6 @@ func Disabled_TestCt_ExplicitCases(t *testing.T) {
 					}
 				})
 			}
-
 		})
 	}
 }

--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -31,6 +31,9 @@ type CodeGenerator struct {
 	varOps               []varOpConstraint
 	varIsCodeConstraints []varIsCodeConstraint
 	varIsDataConstraints []varIsDataConstraint
+
+	// testing only
+	codeSize *int
 }
 
 type constOpConstraint struct {
@@ -131,12 +134,17 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 		minSize = 1
 	}
 
-	// We use an exponential distribution for the code size here since long codes
-	// extend the runtime but are expected to reveal limited extra code coverage.
-	const expectedSize float64 = 200
-	size := int(rnd.ExpFloat64()/(1/expectedSize)) + minSize
-	if size > st.MaxCodeSize {
-		size = st.MaxCodeSize
+	var size int
+	if g.codeSize != nil {
+		size = *g.codeSize + minSize
+	} else {
+		// We use an exponential distribution for the code size here since long codes
+		// extend the runtime but are expected to reveal limited extra code coverage.
+		const expectedSize float64 = 200
+		size = int(rnd.ExpFloat64()/(1/expectedSize)) + minSize
+		if size > st.MaxCodeSize {
+			size = st.MaxCodeSize
+		}
 	}
 
 	// Solve variable constraints. constOpConstraints are generated, the

--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -136,7 +136,10 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 
 	var size int
 	if g.codeSize != nil {
-		size = *g.codeSize + minSize
+		if *g.codeSize < minSize {
+			return nil, fmt.Errorf("%w, fixed code size %d is too small for constraints", ErrUnsatisfiable, *g.codeSize)
+		}
+		size = *g.codeSize
 	} else {
 		// We use an exponential distribution for the code size here since long codes
 		// extend the runtime but are expected to reveal limited extra code coverage.

--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -129,7 +129,7 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 	minSize = max(minSize, len(opCount))
 
 	// If there are any variables that need to be bound to code, there must be at
-	// least on instruction in the resulting code.
+	// least one instruction in the resulting code.
 	if minSize == 0 && len(g.varIsCodeConstraints) > 0 {
 		minSize = 1
 	}

--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -104,6 +104,7 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 			minSize = constraint.pos + 1
 		}
 	}
+
 	// Make extra space for worst-case size requirements of variable operation
 	// constraints.
 	for _, constraint := range varOps {
@@ -112,6 +113,22 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 			size += int(constraint.op - PUSH1 + 1)
 		}
 		minSize += size
+	}
+
+	// Make enough space to host all the different opCodes used in condition.
+	opCount := make(map[OpCode]bool)
+	for _, constraint := range varOps {
+		opCount[constraint.op] = true
+	}
+	for _, constraint := range ops {
+		opCount[constraint.op] = true
+	}
+	minSize = max(minSize, len(opCount))
+
+	// If there are any variables that need to be bound to code, there must be at
+	// least on instruction in the resulting code.
+	if minSize == 0 && len(g.varIsCodeConstraints) > 0 {
+		minSize = 1
 	}
 
 	// We use an exponential distribution for the code size here since long codes

--- a/go/ct/gen/code_test.go
+++ b/go/ct/gen/code_test.go
@@ -386,20 +386,20 @@ func TestCodeGenerator_TooSmallCodeSizeLeadsToUnsatisfiableResult(t *testing.T) 
 
 func TestCodeGenerator_CodeIsLargeEnoughForAllConditionOps(t *testing.T) {
 
-	type constOp struct {
-		p  int
-		op OpCode
+	type constantOp struct {
+		location int
+		op       OpCode
 	}
 
-	type varOp struct {
-		v  string
-		op OpCode
+	type variableOp struct {
+		variable string
+		op       OpCode
 	}
 
 	tests := map[string]struct {
 		size         int
-		constOps     []constOp
-		varOps       []varOp
+		constantOps  []constantOp
+		variableOps  []variableOp
 		containsCode bool
 	}{
 		"Empty code": {
@@ -414,75 +414,75 @@ func TestCodeGenerator_CodeIsLargeEnoughForAllConditionOps(t *testing.T) {
 		},
 		"Single constOp": {
 			size: 1,
-			constOps: []constOp{
-				{p: 0, op: STOP},
+			constantOps: []constantOp{
+				{location: 0, op: STOP},
 			},
 		},
 		"Multiple constOps": {
 			size: 3,
-			constOps: []constOp{
-				{p: 0, op: STOP},
-				{p: 1, op: ADDMOD},
-				{p: 2, op: BALANCE},
+			constantOps: []constantOp{
+				{location: 0, op: STOP},
+				{location: 1, op: ADDMOD},
+				{location: 2, op: BALANCE},
 			},
 		},
 		"Multiple constOps with gaps": {
 			size: 9,
-			constOps: []constOp{
-				{p: 0, op: STOP},
-				{p: 4, op: ADDMOD},
-				{p: 8, op: BALANCE},
+			constantOps: []constantOp{
+				{location: 0, op: STOP},
+				{location: 4, op: ADDMOD},
+				{location: 8, op: BALANCE},
 			},
 		},
 		"Multiple constOps with containsCode": {
 			size: 3,
-			constOps: []constOp{
-				{p: 0, op: STOP},
-				{p: 1, op: ADDMOD},
-				{p: 2, op: BALANCE},
+			constantOps: []constantOp{
+				{location: 0, op: STOP},
+				{location: 1, op: ADDMOD},
+				{location: 2, op: BALANCE},
 			},
 			containsCode: true,
 		},
 		"Multiple varOps": {
 			size: 3,
-			varOps: []varOp{
-				{v: "a", op: STOP},
-				{v: "b", op: ADDMOD},
-				{v: "c", op: BALANCE},
+			variableOps: []variableOp{
+				{variable: "a", op: STOP},
+				{variable: "b", op: ADDMOD},
+				{variable: "c", op: BALANCE},
 			},
 		},
 		"Multiple varOps with identical operations": {
 			size: 3, // < this could be 2, but the solver fails on that (which it should not)
-			varOps: []varOp{
-				{v: "a", op: STOP},
-				{v: "b", op: ADDMOD},
-				{v: "c", op: STOP},
+			variableOps: []variableOp{
+				{variable: "a", op: STOP},
+				{variable: "b", op: ADDMOD},
+				{variable: "c", op: STOP},
 			},
 		},
 		"Multiple constOps and varOps": {
 			size: 6,
-			constOps: []constOp{
-				{p: 0, op: STOP},
-				{p: 1, op: ADDMOD},
-				{p: 2, op: BALANCE},
+			constantOps: []constantOp{
+				{location: 0, op: STOP},
+				{location: 1, op: ADDMOD},
+				{location: 2, op: BALANCE},
 			},
-			varOps: []varOp{
-				{v: "a", op: ADD},
-				{v: "b", op: BASEFEE},
-				{v: "c", op: BYTE},
+			variableOps: []variableOp{
+				{variable: "a", op: ADD},
+				{variable: "b", op: BASEFEE},
+				{variable: "c", op: BYTE},
 			},
 		},
 		"Multiple constOps and varOps with containsCode": {
 			size: 6,
-			constOps: []constOp{
-				{p: 0, op: STOP},
-				{p: 1, op: ADDMOD},
-				{p: 2, op: BALANCE},
+			constantOps: []constantOp{
+				{location: 0, op: STOP},
+				{location: 1, op: ADDMOD},
+				{location: 2, op: BALANCE},
 			},
-			varOps: []varOp{
-				{v: "a", op: ADD},
-				{v: "b", op: BASEFEE},
-				{v: "c", op: BYTE},
+			variableOps: []variableOp{
+				{variable: "a", op: ADD},
+				{variable: "b", op: BASEFEE},
+				{variable: "c", op: BYTE},
 			},
 			containsCode: true,
 		},
@@ -511,11 +511,11 @@ func TestCodeGenerator_CodeIsLargeEnoughForAllConditionOps(t *testing.T) {
 			if test.containsCode {
 				generator.AddIsCode(Variable("X"))
 			}
-			for _, op := range test.constOps {
-				generator.SetOperation(op.p, op.op)
+			for _, op := range test.constantOps {
+				generator.SetOperation(op.location, op.op)
 			}
-			for _, op := range test.varOps {
-				generator.AddOperation(Variable(op.v), op.op)
+			for _, op := range test.variableOps {
+				generator.AddOperation(Variable(op.variable), op.op)
 			}
 
 			code, err := generator.Generate(Assignment{}, rand.New(0))


### PR DESCRIPTION
What does this solve?  
The unit test would have failed because of creating a code buffer of size 1 to store 2 instructions.

What does this not solve: 
It is still not possible to additionally set the Pc to a constant direction, this would require to generate the Pc at a different point in time and account for it. This is not needed right now.

fixes #507 