### PR TITLE
CT: Specification Soundness test

### DIFF
--- a/go/ct/common/opcodes.go
+++ b/go/ct/common/opcodes.go
@@ -494,6 +494,6 @@ func (op OpCode) String() string {
 	case SELFDESTRUCT:
 		return "SELFDESTRUCT"
 	default:
-		return fmt.Sprintf("op(%d)", op)
+		return fmt.Sprintf("op(%02X)", byte(op))
 	}
 }

--- a/go/ct/common/opcodes_test.go
+++ b/go/ct/common/opcodes_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestOpCode_ValidOpCodes(t *testing.T) {
-	noPrettyPrint := regexp.MustCompile(`^op\(\d+\)$`)
+	noPrettyPrint := regexp.MustCompile(`^op\([0-9A-F][0-9A-F]\)$`)
 	for i := 0; i < 256; i++ {
 		op := OpCode(i)
 
@@ -37,7 +37,7 @@ func TestOpCode_ValidOpCodes(t *testing.T) {
 func TestOpCode_ValidOpCodesNoPush(t *testing.T) {
 	validOps := ValidOpCodesNoPush()
 
-	noPrettyPrint := regexp.MustCompile(`^op\(\d+\)$`)
+	noPrettyPrint := regexp.MustCompile(`^op\([0-9A-F][0-9A-F]\)$`)
 	for i := 0; i < 256; i++ {
 		op := OpCode(i)
 
@@ -57,7 +57,7 @@ func TestOpCode_ValidOpCodesNoPush(t *testing.T) {
 }
 
 func TestOpCode_CanBePrinted(t *testing.T) {
-	validName := regexp.MustCompile(`^op\(\d+\)|([A-Z0-9]+)$`)
+	validName := regexp.MustCompile(`^op\([0-9A-F][0-9A-F]\)|([A-Z0-9]+)$`)
 	for i := 0; i < 256; i++ {
 		op := OpCode(i)
 		if !validName.MatchString(op.String()) {

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -84,7 +84,26 @@ func getAllRules() []Rule {
 			Condition: And(AnyKnownRevision(), Eq(Status(), st.Failed)),
 			Effect:    NoEffect(),
 		},
+
+		{
+			Name:      "pc_on_data_is_ignored",
+			Condition: IsData(Pc()),
+			Effect:    NoEffect(),
+		},
 	}...)
+
+	// --- Invalid Instructions ---
+
+	for i := 0; i < 256; i++ {
+		op := OpCode(i)
+		if !IsValid(op) {
+			rules = append(rules, Rule{
+				Name:      fmt.Sprintf("%v_invalid", op),
+				Condition: And(Eq(Status(), st.Running), Eq(Op(Pc()), op)),
+				Effect:    FailEffect(),
+			})
+		}
+	}
 
 	// --- Error States ---
 

--- a/go/ct/spc/specification_map.go
+++ b/go/ct/spc/specification_map.go
@@ -49,24 +49,26 @@ func NewSpecificationMap(rules ...Rule) Specification {
 
 func (s *specificationMap) GetRulesFor(state *st.State) []Rule {
 	result := []Rule{}
-	var opString string
+	getRules := func(opString string) {
+		for _, rule := range s.rules[opString] {
+			if valid, err := rule.Condition.Check(state); valid && err == nil {
+				result = append(result, rule)
+			}
+		}
+	}
 
-	if state.Revision == common.R99_UnknownNextRevision || state.Status != st.Running {
+	op, err := state.Code.GetOperation(int(state.Pc))
+	var opString string
+	if err != nil {
 		opString = "noOp"
 	} else {
-		op, err := state.Code.GetOperation(int(state.Pc))
-		if err != nil {
-			opString = "noOp"
-		} else {
-			opString = op.String()
+		opString = op.String()
+		if state.Revision == common.R99_UnknownNextRevision || state.Status != st.Running {
+			getRules("noOp")
 		}
 	}
 
-	for _, rule := range s.rules[opString] {
-		if valid, err := rule.Condition.Check(state); valid && err == nil {
-			result = append(result, rule)
-		}
-	}
+	getRules(opString)
 
 	return result
 }

--- a/go/ct/spc/specification_test.go
+++ b/go/ct/spc/specification_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/vm"
 )
 
-func TestSpecification_RulesCoverRandomStates(t *testing.T) {
-	const N = 10000
+func TestSpecification_SpecificationIsSound(t *testing.T) {
+	const N = 100000
 
 	rnd := rand.New(0)
 	generator := gen.NewStateGenerator()
@@ -50,6 +50,22 @@ func TestSpecification_RulesCoverRandomStates(t *testing.T) {
 					t.Fatalf("multiple conflicting rules for state %v: %v", state, rules)
 				}
 			}
+		}
+	}
+}
+
+func TestSpecification_SpecificationIsComplete(t *testing.T) {
+	const N = 100000
+	rnd := rand.New(0)
+	generator := gen.NewStateGenerator()
+	for i := 0; i < N; i++ {
+		state, err := generator.Generate(rnd)
+		if err != nil {
+			t.Errorf("failed to generate a random state: %v", err)
+		}
+		rules := Spec.GetRulesFor(state)
+		if len(rules) == 0 {
+			t.Fatalf("no rule found for \n%v", state)
 		}
 	}
 }
@@ -119,12 +135,12 @@ func TestSpecificationMap_SameRulesPerOperation(t *testing.T) {
 			t.Fatalf("failed building state: %v", err)
 		}
 
+		op, _ := state.Code.GetOperation(int(state.Pc))
 		allRulesForState := listGetRulesFor(state)
 		rulesFromMap := Spec.GetRulesFor(state)
 
 		if len(allRulesForState) != len(rulesFromMap) {
-			op, _ := state.Code.GetOperation(int(state.Pc))
-			t.Errorf("different number of rules for %s: %d vs %d", op.String(), len(allRulesForState), len(rulesFromMap))
+			t.Errorf("different number of rules for %s: %d vs %d", op, len(allRulesForState), len(rulesFromMap))
 		}
 
 		for _, rule := range allRulesForState {
@@ -145,7 +161,7 @@ func TestSpecificationMap_SameRulesPerOperation(t *testing.T) {
 func TestSpecification_OperationNotExecutedIfNotRunning(t *testing.T) {
 	// list of known no operations
 	knownNoOps := []string{"stopped_is_end", "reverted_is_end", "failed_is_end", "unknown_revision_is_end"}
-	statusFreeRules := []string{"unknown_revision_is_end"}
+	statusFreeRules := []string{"unknown_revision_is_end", "pc_on_data_is_ignored"}
 
 	rules := getAllRules()
 	for _, rule := range rules {


### PR DESCRIPTION
This PR adds:
- a test to check for specification soundness
- a rule that checks that when the PC is pointing at data, nothing gets executed
- a rule for each of the 256 available codes in the 2 byte spectrum, and checking the invalid codes are treated properly. 