### PR TITLE
Containerize build environment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ build/
 
 # Jenkinsfile linter config
 .groovylintrc.json
+
+.devcontainer/

--- a/BUILD.md
+++ b/BUILD.md
@@ -274,11 +274,6 @@ The ct Evm.StepN interface is used to evaluate N instructions in different EVM i
    - FuzzDifferentialLfvmVsGeth: ```make fuzz-lfvm-diff```
    - FuzzDifferentialEvmzeroVsGeth: ```make fuzz-evmzero-diff``` (disabled, issue #549)
 
-
-## Static analysis
-
-Tosca project uses static analysis to improve code quality.
-
 ### Go
 
 Currently, two different static analysis tools are used:
@@ -290,3 +285,32 @@ Lints can be disabled as described [here](https://golangci-lint.run/usage/false-
 ### C++
 
 There is currently no infrastructure to run static analysis for C++ code in this project.
+
+## Containerized Build
+
+This feature allows to use different platforms and toolchains to compile the project, at this stage, an initial Dockerfile is provided in the CI folder to describe an environment capable of building and running tests for this project codebase. 
+The workflow is purely optional.
+Using this feature enables: 
+- Containerized Jenkins Builds. Where the development environment is described in the git repository and does not depend from any particular server setup.
+- Multiple simultaneous platform definitions.
+- Different branches with different toolchains, all of them building correctly the CI. This is important to prevent loosing CI support during toolchain migrations. 
+- Containerized development, using a number of IDEs that support them: https://containers.dev/
+
+Build the image:
+```bash
+docker build CI -t tosca_build:latest
+```
+To start an interactive container from the image, run this command in the Tosca root folder.
+```bash
+docker run -it --rm -v$(pwd):$(pwd) -u$(id -u):$(id -g) -w$(pwd) tosca_build:latest
+```
+- `-it` interactive terminal
+- `--rm` transient container, changes to the image will be deleted when existing the interactive session
+- `-v` mount Tosca source code in the same path inside the image (build will be persistent in the host filesystem after exiting the container)
+- `-u` use same user id as in the host, to prevent build folder permissions mismatch 
+- `-w` working directory is the mounted source code directory
+
+Once inside the container, build can be triggered as usual:
+```bash
+make test
+```

--- a/CI/Dockerfile.build
+++ b/CI/Dockerfile.build
@@ -8,15 +8,11 @@ RUN apt-get update && apt-get install -y \
   cmake \
   lcov \
   clang-format \
-  wget \
+  curl \
   && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update ;\
-  wget https://go.dev/dl/go1.21.0.linux-amd64.tar.gz;\
-  tar xf go1.21.0.linux-amd64.tar.gz;\
-  mv go /usr/local;\
-  rm -r go1.21.0.linux-amd64.tar.gz 
 
+# Install Go:
 # Because of user id forwarding, the home directory may not exist in the container
 # Go would fall back to / (root) in this case, which is not writable
 RUN mkdir -p /tmp/cache && chmod 777 /tmp/cache && \
@@ -24,4 +20,15 @@ RUN mkdir -p /tmp/cache && chmod 777 /tmp/cache && \
 ENV GOCACHE=/tmp/cache
 ENV GOPATH=/tmp/gopath
 ENV GOROOT=/usr/local/go
-ENV PATH="$PATH:$GOROOT/bin"
+RUN curl -OL https://go.dev/dl/go1.22.8.linux-amd64.tar.gz && \
+  tar -xf go1.22.8.linux-amd64.tar.gz && \
+  mv go /usr/local && \
+  rm -f go1.22.8.linux-amd64.tar.gz
+
+# Install Rust:
+ENV RUSTUP_HOME=/tmp/rust/rustup 
+ENV CARGO_HOME=/tmp/rust/cargo
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+
+
+ENV PATH="$PATH:$GOROOT/bin:${GOPATH}/bin:${CARGO_HOME}/bin"

--- a/CI/Dockerfile.build
+++ b/CI/Dockerfile.build
@@ -12,9 +12,9 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update ;\
-  wget https://go.dev/dl/go1.21.0.linux-amd64.tar.gz ;\
-  tar xf go1.21.0.linux-amd64.tar.gz ;\
-  mv go /usr/local ;\
+  wget https://go.dev/dl/go1.21.0.linux-amd64.tar.gz;\
+  tar xf go1.21.0.linux-amd64.tar.gz;\
+  mv go /usr/local;\
   rm -r go1.21.0.linux-amd64.tar.gz 
 
 # Because of user id forwarding, the home directory may not exist in the container
@@ -23,5 +23,5 @@ RUN mkdir -p /tmp/cache && chmod 777 /tmp/cache && \
   mkdir -p /tmp/gopath && chmod 777 /tmp/gopath
 ENV GOCACHE=/tmp/cache
 ENV GOPATH=/tmp/gopath
-ENV GOROOT=/usr/local/go 
-ENV PATH="$PATH:$GOPATH/bin"
+ENV GOROOT=/usr/local/go
+ENV PATH="$PATH:$GOROOT/bin"

--- a/CI/Dockerfile.build
+++ b/CI/Dockerfile.build
@@ -1,0 +1,22 @@
+FROM ubuntu:24.04
+
+# Install dependencies and keep image small as described in best practices
+# https://docs.docker.com/build/building/best-practices/
+RUN apt-get update && apt-get install -y \
+  clang-16 \
+  g++-11 \
+  git \
+  cmake \
+  golang-go \
+  lcov \
+  clang-format \
+  && rm -rf /var/lib/apt/lists/*
+    
+# Because of user id forwarding, the home directory may not exist in the container
+# Go would fall back to / (root) in this case, which is not writable
+RUN mkdir -p /tmp/cache && chmod 777 /tmp/cache && \
+    mkdir -p /tmp/gopath && chmod 777 /tmp/gopath
+ENV GOCACHE=/tmp/cache
+ENV GOPATH=/tmp/gopath
+
+ENV PATH="$PATH:$GOPATH/bin"

--- a/CI/Dockerfile.build
+++ b/CI/Dockerfile.build
@@ -3,20 +3,25 @@ FROM ubuntu:24.04
 # Install dependencies and keep image small as described in best practices
 # https://docs.docker.com/build/building/best-practices/
 RUN apt-get update && apt-get install -y \
-  clang-16 \
   g++-11 \
   git \
   cmake \
-  golang-go \
   lcov \
   clang-format \
+  wget \
   && rm -rf /var/lib/apt/lists/*
-    
+
+RUN apt-get update ;\
+  wget https://go.dev/dl/go1.21.0.linux-amd64.tar.gz ;\
+  tar xf go1.21.0.linux-amd64.tar.gz ;\
+  mv go /usr/local ;\
+  rm -r go1.21.0.linux-amd64.tar.gz 
+
 # Because of user id forwarding, the home directory may not exist in the container
 # Go would fall back to / (root) in this case, which is not writable
 RUN mkdir -p /tmp/cache && chmod 777 /tmp/cache && \
-    mkdir -p /tmp/gopath && chmod 777 /tmp/gopath
+  mkdir -p /tmp/gopath && chmod 777 /tmp/gopath
 ENV GOCACHE=/tmp/cache
 ENV GOPATH=/tmp/gopath
-
+ENV GOROOT=/usr/local/go 
 ENV PATH="$PATH:$GOPATH/bin"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,12 @@
 // this software will be governed by the GNU Lesser General Public License v3.
 
 pipeline {
-    agent { label 'quick' }
+    agent {
+        dockerfile {
+            filename 'CI/Dockerfile.build'
+            label 'quick'
+        }
+    }
 
     options {
         timestamps()
@@ -50,7 +55,7 @@ pipeline {
 
         stage('Check Go sources formatting') {
             steps {
-                sh "gofmt -s -d go"
+                sh 'gofmt -s -d go'
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,16 @@ pipeline {
             }
         }
 
+        stage('check environment') {
+            steps {
+                sh 'echo $PATH'
+                sh 'echo $GOPATH'
+                sh 'echo $GOCACHE'
+                sh 'echo $GOTMPDIR'
+                sh 'go version'
+                sh 'whereis gofmt'
+            }
+        }
         stage('Checkout code') {
             steps {
                 sh 'git submodule update --init --recursive'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,12 +21,6 @@ pipeline {
         timeout(time: 2, unit: 'HOURS')
     }
 
-    environment {
-        CC = 'gcc'
-        CXX = 'g++'
-        PATH = "${env.HOME}/.cargo/bin:${env.PATH}"
-    }
-
     stages {
         stage('Validate commit') {
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     agent {
         dockerfile {
             filename 'CI/Dockerfile.build'
-            label 'norma'
+            label 'quick'
         }
     }
 
@@ -61,6 +61,11 @@ pipeline {
 
         stage('Lint Go sources') {
             steps {
+                sh 'echo $PATH'
+                sh 'echo $GOPATH'
+                sh 'echo $GOCACHE'
+                sh 'echo $GOTMPDIR'
+                sh 'ls /tmp'
                 withEnv(["PATH+GOPATH=${env.HOME}/go/bin"]) {
                     sh 'make lint-go'
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     agent {
         dockerfile {
             filename 'CI/Dockerfile.build'
-            label 'quick'
+            label 'norma'
         }
     }
 


### PR DESCRIPTION
tl;dr:  This PR adds tools to prevent the famous "but it works in my machine".


This feature allows using different platforms and Toolchains to compile the project. At this stage, an initial Dockerfile is provided in the CI folder to describe an environment capable of building and running tests for the Tosca project. 
The workflow is purely optional.

Using this feature enables: 
- Containerized Jenkins Builds. Where the development environment is described in the git repository and does not depend on any particular server setup.
- Multiple simultaneous platform definitions.
- Different branches with different Toolchains, all of them building correctly the CI. This is important to prevent loosing CI support during Toolchain migrations. 
- Containerized development, using a number of IDEs that support them: https://containers.de
