### PR TITLE
CT driver, print progress before exit.

### DIFF
--- a/go/ct/spc/enumeration.go
+++ b/go/ct/spc/enumeration.go
@@ -60,6 +60,18 @@ func ForEachState(
 		for {
 			select {
 			case <-done:
+				cur := testCounter.Load()
+				curTime := time.Now()
+
+				diffCounter := cur - lastTestCounter
+				diffTime := curTime.Sub(lastTime)
+
+				lastTime = curTime
+				lastTestCounter = cur
+
+				relativeTime := curTime.Sub(startTime)
+				rate := float64(diffCounter) / diffTime.Seconds()
+				printIssueCounts(relativeTime, rate, cur)
 				return
 			case curTime := <-ticker.C:
 				cur := testCounter.Load()


### PR DESCRIPTION
This commit prints enumeration status one last time before exiting. This is useful when running small filtered ct executions, to read the number of executed states.

A low-hanging fruit that improves tool usage:
- Filters resulting in an empty set will not warn about it but only report success, now the count of states can be seen.
- It is nice to see the final state count instead of the number 5 seconds before, and the completion time. 