### PR TITLE
CT: update evmc  for blobhash support

### DIFF
--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -986,7 +986,7 @@ struct Impl<OpCode::BLOBHASH> {
 
   static OpResult Run(uint256_t* top, Context& ctx) noexcept {
     const auto tx_context = ctx.host->get_tx_context();
-    if (static_cast<size_t>(top[0]) < tx_context.blob_hashes_count) {
+    if (top[0] < tx_context.blob_hashes_count) {
       top[0] = ToUint256(tx_context.blob_hashes[static_cast<size_t>(top[0])]);
     } else {
       top[0] = 0;

--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -986,8 +986,8 @@ struct Impl<OpCode::BLOBHASH> {
 
   static OpResult Run(uint256_t* top, Context& ctx) noexcept {
     const auto tx_context = ctx.host->get_tx_context();
-    if (top[0] < tx_context.blob_hashes_count) {
-      top[0] = ToUint256(tx_context.blob_hashes[static_cast<int64_t>(top[0])]);
+    if (static_cast<size_t>(top[0]) < tx_context.blob_hashes_count) {
+      top[0] = ToUint256(tx_context.blob_hashes[static_cast<size_t>(top[0])]);
     } else {
       top[0] = 0;
     }

--- a/cpp/vm/evmzero/interpreter.cc
+++ b/cpp/vm/evmzero/interpreter.cc
@@ -987,7 +987,7 @@ struct Impl<OpCode::BLOBHASH> {
   static OpResult Run(uint256_t* top, Context& ctx) noexcept {
     const auto tx_context = ctx.host->get_tx_context();
     if (top[0] < tx_context.blob_hashes_count) {
-      top[0] = ToUint256(tx_context.blob_hashes[static_cast<size_t>(top[0])]);
+      top[0] = ToUint256(tx_context.blob_hashes[static_cast<int64_t>(top[0])]);
     } else {
       top[0] = 0;
     }

--- a/go/vm/evmc/evmc_interpreter.go
+++ b/go/vm/evmc/evmc_interpreter.go
@@ -155,8 +155,9 @@ func toEvmcRevision(revision vm.Revision) (evmc.Revision, error) {
 // context and chain state information external to the the interpreter.
 // It implements the host interface of evmc's Go bindings.
 type hostContext struct {
-	params  vm.Parameters
-	context vm.RunContext
+	params         vm.Parameters
+	context        vm.RunContext
+	EvmcBlobHashes []evmc.Hash
 }
 
 func (ctx *hostContext) AccountExists(addr evmc.Address) bool {
@@ -224,15 +225,17 @@ func (ctx *hostContext) Selfdestruct(addr evmc.Address, beneficiary evmc.Address
 func (ctx *hostContext) GetTxContext() evmc.TxContext {
 	params := ctx.params
 	return evmc.TxContext{
-		GasPrice:   evmc.Hash(params.GasPrice),
-		Origin:     evmc.Address(params.Origin),
-		Coinbase:   evmc.Address(params.Coinbase),
-		Number:     params.BlockNumber,
-		Timestamp:  params.Timestamp,
-		GasLimit:   int64(params.GasLimit),
-		PrevRandao: evmc.Hash(params.PrevRandao),
-		ChainID:    evmc.Hash(params.ChainID),
-		BaseFee:    evmc.Hash(params.BaseFee),
+		GasPrice:    evmc.Hash(params.GasPrice),
+		Origin:      evmc.Address(params.Origin),
+		Coinbase:    evmc.Address(params.Coinbase),
+		Number:      params.BlockNumber,
+		Timestamp:   params.Timestamp,
+		GasLimit:    int64(params.GasLimit),
+		PrevRandao:  evmc.Hash(params.PrevRandao),
+		ChainID:     evmc.Hash(params.ChainID),
+		BaseFee:     evmc.Hash(params.BaseFee),
+		BlobBaseFee: evmc.Hash(params.BlobBaseFee),
+		BlobHashes:  ctx.EvmcBlobHashes,
 	}
 }
 

--- a/go/vm/evmc/evmc_interpreter.go
+++ b/go/vm/evmc/evmc_interpreter.go
@@ -157,7 +157,7 @@ func toEvmcRevision(revision vm.Revision) (evmc.Revision, error) {
 type hostContext struct {
 	params         vm.Parameters
 	context        vm.RunContext
-	EvmcBlobHashes []evmc.Hash
+	evmcBlobHashes []evmc.Hash
 }
 
 func (ctx *hostContext) AccountExists(addr evmc.Address) bool {
@@ -235,7 +235,7 @@ func (ctx *hostContext) GetTxContext() evmc.TxContext {
 		ChainID:     evmc.Hash(params.ChainID),
 		BaseFee:     evmc.Hash(params.BaseFee),
 		BlobBaseFee: evmc.Hash(params.BlobBaseFee),
-		BlobHashes:  ctx.EvmcBlobHashes,
+		BlobHashes:  ctx.evmcBlobHashes,
 	}
 }
 

--- a/go/vm/evmc/evmc_interpreter.go
+++ b/go/vm/evmc/evmc_interpreter.go
@@ -53,6 +53,11 @@ func (e *EvmcInterpreter) Run(params vm.Parameters) (vm.Result, error) {
 		context: params.Context,
 	}
 
+	host_ctx.evmcBlobHashes = make([]evmc.Hash, 0, len(params.BlobHashes))
+	for _, hash := range params.BlobHashes {
+		host_ctx.evmcBlobHashes = append(host_ctx.evmcBlobHashes, evmc.Hash(hash))
+	}
+
 	revision, err := toEvmcRevision(params.Revision)
 	if err != nil {
 		return vm.Result{}, err

--- a/go/vm/evmc/evmc_steppable_interpreter.go
+++ b/go/vm/evmc/evmc_steppable_interpreter.go
@@ -46,11 +46,10 @@ func (e *SteppableEvmcInterpreter) StepN(
 		context: params.Context,
 	}
 
-	evmcBlobHashes := make([]evmc.Hash, 0, state.CallData.Length())
+	host_ctx.evmcBlobHashes = make([]evmc.Hash, 0, len(params.BlobHashes))
 	for _, hash := range params.BlobHashes {
-		evmcBlobHashes = append(evmcBlobHashes, evmc.Hash(hash))
+		host_ctx.evmcBlobHashes = append(host_ctx.evmcBlobHashes, evmc.Hash(hash))
 	}
-	host_ctx.evmcBlobHashes = evmcBlobHashes
 
 	revision, err := toEvmcRevision(params.Revision)
 	if err != nil {

--- a/go/vm/evmc/evmc_steppable_interpreter.go
+++ b/go/vm/evmc/evmc_steppable_interpreter.go
@@ -62,6 +62,12 @@ func (e *SteppableEvmcInterpreter) StepN(
 		return nil, err
 	}
 
+	evmcBlobHashes := []evmc.Hash{}
+	for _, hash := range params.BlobHashes {
+		evmcBlobHashes = append(evmcBlobHashes, evmc.Hash(hash[:]))
+	}
+	host_ctx.EvmcBlobHashes = evmcBlobHashes
+
 	result, err := e.vm.StepN(evmc.StepParameters{
 		Context:        &host_ctx,
 		Revision:       revision,

--- a/go/vm/evmc/evmc_steppable_interpreter.go
+++ b/go/vm/evmc/evmc_steppable_interpreter.go
@@ -46,6 +46,12 @@ func (e *SteppableEvmcInterpreter) StepN(
 		context: params.Context,
 	}
 
+	evmcBlobHashes := make([]evmc.Hash, 0, state.CallData.Length())
+	for _, hash := range params.BlobHashes {
+		evmcBlobHashes = append(evmcBlobHashes, evmc.Hash(hash))
+	}
+	host_ctx.evmcBlobHashes = evmcBlobHashes
+
 	revision, err := toEvmcRevision(params.Revision)
 	if err != nil {
 		return nil, err
@@ -61,12 +67,6 @@ func (e *SteppableEvmcInterpreter) StepN(
 	if err != nil {
 		return nil, err
 	}
-
-	evmcBlobHashes := []evmc.Hash{}
-	for _, hash := range params.BlobHashes {
-		evmcBlobHashes = append(evmcBlobHashes, evmc.Hash(hash[:]))
-	}
-	host_ctx.EvmcBlobHashes = evmcBlobHashes
 
 	result, err := e.vm.StepN(evmc.StepParameters{
 		Context:        &host_ctx,

--- a/go/vm/evmzero/evmzero_test.go
+++ b/go/vm/evmzero/evmzero_test.go
@@ -11,8 +11,11 @@
 package evmzero
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"github.com/Fantom-foundation/Tosca/go/examples"
 	"github.com/Fantom-foundation/Tosca/go/vm"
 )
@@ -82,4 +85,82 @@ func benchmarkFib(b *testing.B, arg int) {
 			}
 		}
 	})
+}
+
+func TestEvmcInterpreter_BlobHashCanBeRead(t *testing.T) {
+
+	// create a test state with a code push at index 0
+	code := []byte{
+		byte(common.PUSH1), 0, // add to stack index to read from blobhash
+		byte(common.BLOBHASH), // read from blobhash index 0 and push it into stack
+		byte(common.PUSH1), 0, // push to stack offset to write in memory
+		byte(common.MSTORE),    // write in memory offset 0 value returned from blobhash
+		byte(common.PUSH1), 32, // push size of hash to read
+		byte(common.PUSH1), 0, // push to stack offset to read from memory
+		byte(common.RETURN),
+	}
+
+	params := vm.Parameters{
+		Gas: 20000,
+		BlockParameters: vm.BlockParameters{
+			Revision: vm.R13_Cancun,
+		},
+		TransactionParameters: vm.TransactionParameters{
+			BlobHashes: []vm.Hash{{2}},
+		},
+		Code: code,
+	}
+
+	evm := vm.GetInterpreter("evmzero")
+	if evm == nil {
+		t.Fatalf("failed to locate evmzero")
+	}
+
+	result, err := evm.Run(params)
+	if err != nil {
+		t.Fatalf("failed to run evmzero interpreter: %v", err)
+	}
+	if result.Output == nil {
+		t.Fatalf("expected output, got nothing")
+	}
+	if !bytes.Equal(result.Output, params.BlobHashes[0][:]) {
+		t.Errorf("unexpected output, wanted %v, got %v", params.BlobHashes[0], result.Output)
+	}
+}
+
+func TestEvmcSteppableInterpreter_BlobHashCanBeRead(t *testing.T) {
+
+	code := []byte{
+		byte(common.PUSH1), 0, // add to stack index to read from blobhash
+		byte(common.BLOBHASH), // read from blobhash index 0 and push it into stack
+		byte(common.PUSH1), 0, // push to stack offset to write in memory
+		byte(common.MSTORE),    // write in memory offset 0 value returned from blobhash
+		byte(common.PUSH1), 32, // push size of hash to read
+		byte(common.PUSH1), 0, // push to stack offset to read from memory
+		byte(common.RETURN),
+	}
+
+	blobhashes := []vm.Hash{{2}}
+
+	inputState := st.NewState(st.NewCode(code))
+	inputState.Gas = 20000
+	inputState.Revision = common.R13_Cancun
+	inputState.TransactionContext = st.NewTransactionContext()
+	inputState.TransactionContext.BlobHashes = blobhashes
+
+	evm := NewConformanceTestingTarget()
+	if evm == nil {
+		t.Fatalf("failed to locate evmzero")
+	}
+
+	resultState, err := evm.StepN(inputState, 8)
+	if err != nil {
+		t.Fatalf("failed to run evmzero interpreter: %v", err)
+	}
+	if resultState.TransactionContext.BlobHashes == nil {
+		t.Fatalf("expected output, got nothing")
+	}
+	if !bytes.Equal(resultState.ReturnData.ToBytes(), blobhashes[0][:]) {
+		t.Errorf("unexpected output, wanted %v, got %v", blobhashes[0], resultState.ReturnData)
+	}
 }


### PR DESCRIPTION
This PR adds `EvmcBlobHashes []evmc.Hash` to `HostContext`  in `evmc_interpreter`.

These slice is filled in `evmc_steppable_interpreter` 
And is returned in `GetTxContext()` instead of the one in `params`

This is an ugly fix needed because:
- when passing memory from Go to C, if it's a slice, you need to pin the memory, to insure it will note moved or deleted by Go's garbage collector.
- the problem is that (because they are different types), when calling `evmc_interpter.go:GetTxContext`, in there, it needs to translate from `vm.Hash` in `vm.Params` to `evmc.hash` defined type by `evmc`
- but this means that we cannot `unpin` the `evmc.hash` slice's memory (because it is returned to the C side)
- so we need to pin the `evmcBlobHashes` before calling `C.step_n_wrapper`,
This way we can have this extra slice in `HostContext` defined in evmc_interpreter.


This is a first approach, open to suggestions on how to do this in a better way. 

Q: is it event possible to reinterpret cast the same memory without a copy ?

NOTE: unit tests will test until patch has been merged in evmc (https://github.com/Fantom-foundation/evmc/pull/1)