### PR TITLE
CT: Add Makefile command for coverage

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -222,6 +222,12 @@ Ideally, pull requests targeting performance improvements should include such a 
 ## Code Coverage
 
 Code coverage of the Tosca project is a work in progress. As the different systems get integrated, more features will be added and documented here.
+Go has native support for coverage, which makes getting this metric for `lfvm` or `geth` driver runs quite simple.
+
+### CT Driver Code coverage
+
+To run the the CT driver code coverage simply run `make ct-coverage-lfvm` or `make ct-coverage-geth`, these commands will create the folder `Tosca/go/build/coverage/` and a sub folder with the corresponding interpreter's name. In this directory an instrumented version of the driver will be built and then run. The reports of the coverage of this run will also be in this directory, where lastly an HTML version of the report will be added as well. As more interpreter implementations are added to the Tosca project, they should also be added to the makefile.
+
 
 ### C++ Code coverage
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,20 @@ evmone:
 	cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_SHARED_LIBRARY_SUFFIX_CXX=.so ; \
 	cmake --build build --parallel -t evmone
 
+coverage-go: DATE=$(shell date +"%Y-%m-%d-%T")
+coverage-go: TOSCA_GO_COVERAGE_DIR=./go/build/coverage/${TOSCA_GO_COVERAGE_EVM}/${DATE}/
+coverage-go:
+	go build -cover -o ${TOSCA_GO_COVERAGE_DIR}/driver ./go/ct/driver/ ; \
+	GOCOVERDIR=${TOSCA_GO_COVERAGE_DIR} ${TOSCA_GO_COVERAGE_DIR}/driver run --max-errors 1 ${TOSCA_GO_COVERAGE_EVM} ; \
+	go tool covdata textfmt --i ${TOSCA_GO_COVERAGE_DIR} -o ${TOSCA_GO_COVERAGE_DIR}/driver_coverage_report.txt ; \
+	go tool cover -html ${TOSCA_GO_COVERAGE_DIR}/driver_coverage_report.txt -o ${TOSCA_GO_COVERAGE_DIR}/coverage_output.html
+
+ct-coverage-lfvm: TOSCA_GO_COVERAGE_EVM=lfvm
+ct-coverage-lfvm: coverage-go
+
+ct-coverage-geth: TOSCA_GO_COVERAGE_EVM=geth
+ct-coverage-geth: coverage-go
+
 test: test-go test-cpp
 
 test-go: tosca-go


### PR DESCRIPTION
This PR adds two Makefile targets:
- `coverage-lfvm`
- `coverage-geth`

This targets will build an instrumented version of the driver, and then run the the command `go run ./go/ct/driver run --max-errors 1 [evm]`, where `[evm]` is replaced by the corresponding interpreter implementation. After the run it will produce an HTML file with the name `coverage_output.html` which contains the coverage report of the run.

All the report files are created in `./go/build/coverage_report/` hence they do not need to be added in `.gitignored` and are deleted when running `make clean`

This PR fixes #404 

```
[t= 317:19] - Processing ~0 tests per second, total 495404262,
```