### PR TITLE
Prepare for selfdestruct update

### DIFF
--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -2230,7 +2230,7 @@ func selfDestructEffect(s *st.State, destinationColdCost, accountCreationFee, re
 	}
 	// add beneficiary to list in state
 	s.HasSelfDestructed = true
-	s.SelfDestructedJournal = append(s.SelfDestructedJournal, st.NewSelfDestructEntry(s.CallContext.AccountAddress, destinationAccount))
+	s.SelfDestructedJournal = append(s.SelfDestructedJournal, st.NewSelfDestructEntry(s.CallContext.AccountAddress, destinationAccount, false))
 	s.Status = st.Stopped
 	s.GasRefund += refundGas
 }

--- a/go/ct/st/serialization.go
+++ b/go/ct/st/serialization.go
@@ -255,7 +255,8 @@ func (s *stateSerializable) deserialize() *State {
 	state.HasSelfDestructed = s.HasSelfDestructed
 	if s.SelfDestructedJournal != nil {
 		for _, entry := range s.SelfDestructedJournal {
-			state.SelfDestructedJournal = append(state.SelfDestructedJournal, SelfDestructEntry{entry.Account, entry.Beneficiary})
+			state.SelfDestructedJournal = append(state.SelfDestructedJournal,
+				SelfDestructEntry{entry.Account, entry.Beneficiary, s.Revision >= R13_Cancun})
 		}
 	}
 	state.RecentBlockHashes = s.RecentBlockHashes

--- a/go/ct/st/serialization_test.go
+++ b/go/ct/st/serialization_test.go
@@ -196,7 +196,7 @@ func TestSerialization_NewStateSerializableIsIndependent(t *testing.T) {
 		s.LastCallReturnData.Get(0, 1)[0] == 1 &&
 		s.HasSelfDestructed &&
 		len(s.SelfDestructedJournal) == 1 &&
-		s.SelfDestructedJournal[0] == SelfDestructEntry{vm.Address{1}, vm.Address{2}} &&
+		s.SelfDestructedJournal[0] == SelfDestructEntry{vm.Address{1}, vm.Address{2}, false} &&
 		s.RecentBlockHashes.Equal(NewImmutableHashArray(vm.Hash{0x01}))
 
 	if !ok {

--- a/go/ct/st/state.go
+++ b/go/ct/st/state.go
@@ -48,10 +48,11 @@ const (
 type SelfDestructEntry struct {
 	account     vm.Address
 	beneficiary vm.Address
+	is6780      bool
 }
 
-func NewSelfDestructEntry(account vm.Address, beneficiary vm.Address) SelfDestructEntry {
-	return SelfDestructEntry{account, beneficiary}
+func NewSelfDestructEntry(account vm.Address, beneficiary vm.Address, is6780 bool) SelfDestructEntry {
+	return SelfDestructEntry{account, beneficiary, is6780}
 }
 
 func (s StatusCode) String() string {
@@ -464,8 +465,8 @@ func (s *State) Diff(o *State) []string {
 			for index, entry1 := range s.SelfDestructedJournal {
 				entry2 := o.SelfDestructedJournal[index]
 				if entry1 != entry2 {
-					res = append(res, fmt.Sprintf("Different has-self-destructed journal entry:\n\t(%v, %v)\n\tvs\n\t(%v, %v)",
-						entry1.account, entry1.beneficiary, entry2.account, entry2.beneficiary))
+					res = append(res, fmt.Sprintf("Different has-self-destructed journal entry:\n\t(%v, %v, %t)\n\tvs\n\t(%v, %v, %t)",
+						entry1.account, entry1.beneficiary, entry1.is6780, entry2.account, entry2.beneficiary, entry2.is6780))
 				}
 			}
 		}

--- a/go/ct/st/state_test.go
+++ b/go/ct/st/state_test.go
@@ -52,7 +52,7 @@ func getNewFilledState() *State {
 	s.CallData = NewBytes([]byte{1})
 	s.LastCallReturnData = NewBytes([]byte{1})
 	s.HasSelfDestructed = true
-	s.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{1}, vm.Address{2}}}
+	s.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{1}, vm.Address{2}, false}}
 	s.RecentBlockHashes = NewImmutableHashArray(vm.Hash{0x01})
 	return s
 }
@@ -160,7 +160,7 @@ func getTestChanges() map[string]testStruct {
 			"Different has-self-destructed",
 		},
 		"self_destructed_journal": {func(state *State) {
-			state.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0x01}, vm.Address{0x04}}}
+			state.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0x01}, vm.Address{0x04}, false}}
 		},
 			"Different has-self-destructed journal entry",
 		},
@@ -484,7 +484,7 @@ func TestState_DiffMatch(t *testing.T) {
 	s1.CallData = NewBytes([]byte{1})
 	s1.LastCallReturnData = NewBytes([]byte{1})
 	s1.HasSelfDestructed = true
-	s1.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0x01}, vm.Address{0x01}}}
+	s1.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0x01}, vm.Address{0x01}, false}}
 	s1.RecentBlockHashes = NewImmutableHashArray(vm.Hash{0x01})
 
 	s2 := NewState(NewCode([]byte{byte(PUSH2), 7, 4, byte(ADD), byte(STOP)}))
@@ -503,7 +503,7 @@ func TestState_DiffMatch(t *testing.T) {
 	s2.CallData = NewBytes([]byte{1})
 	s2.LastCallReturnData = NewBytes([]byte{1})
 	s2.HasSelfDestructed = true
-	s2.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0x01}, vm.Address{0x01}}}
+	s2.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0x01}, vm.Address{0x01}, false}}
 	s2.RecentBlockHashes = NewImmutableHashArray(vm.Hash{0x01})
 
 	diffs := s1.Diff(s2)
@@ -535,7 +535,7 @@ func TestState_DiffMismatch(t *testing.T) {
 	s1.CallData = NewBytes([]byte{1})
 	s1.LastCallReturnData = NewBytes([]byte{1})
 	s1.HasSelfDestructed = true
-	s1.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0x01}, vm.Address{0x01}}}
+	s1.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0x01}, vm.Address{0x01}, false}}
 	s1.RecentBlockHashes = NewImmutableHashArray(vm.Hash{0x01})
 
 	s2 := NewState(NewCode([]byte{byte(PUSH2), 7, 5, byte(ADD)}))
@@ -554,7 +554,7 @@ func TestState_DiffMismatch(t *testing.T) {
 	s2.CallData = NewBytes([]byte{250})
 	s2.LastCallReturnData = NewBytes([]byte{249})
 	s2.HasSelfDestructed = false
-	s2.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0xf3}, vm.Address{0xf3}}}
+	s2.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0xf3}, vm.Address{0xf3}, false}}
 	s2.RecentBlockHashes = NewImmutableHashArray(vm.Hash{0xf2})
 
 	diffs := s1.Diff(s2)
@@ -783,7 +783,9 @@ func TestState_EqualityConsidersRelevantFieldsDependingOnStatus(t *testing.T) {
 			relevantFor: allButFailed,
 		},
 		"has_self_destructed_journal": {
-			modify:      func(s *State) { s.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0xf3}, vm.Address{0xf3}}} },
+			modify: func(s *State) {
+				s.SelfDestructedJournal = []SelfDestructEntry{{vm.Address{0xf3}, vm.Address{0xf3}, false}}
+			},
 			relevantFor: allButFailed,
 		},
 		"block_number_hashes": {

--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -164,7 +164,19 @@ func (c *ctRunContext) Call(kind vm.CallKind, parameter vm.CallParameters) (vm.C
 }
 
 func (c *ctRunContext) SelfDestruct(address vm.Address, beneficiary vm.Address) bool {
-	c.state.SelfDestructedJournal = append(c.state.SelfDestructedJournal, st.NewSelfDestructEntry(address, beneficiary))
+	c.state.SelfDestructedJournal = append(c.state.SelfDestructedJournal, st.NewSelfDestructEntry(address, beneficiary, false))
+	if c.state.HasSelfDestructed {
+		return false
+	}
+	c.state.HasSelfDestructed = true
+	return true
+}
+
+func (c *ctRunContext) SelfDestruct6780(address vm.Address, beneficiary vm.Address) bool {
+
+	c.state.SelfDestructedJournal = append(c.state.SelfDestructedJournal,
+		//TODO: change to true once selfdestruct is updated in the vms
+		st.NewSelfDestructEntry(address, beneficiary, false))
 	if c.state.HasSelfDestructed {
 		return false
 	}

--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -477,6 +477,22 @@ func (a *runContextAdapter) SelfDestruct(addr vm.Address, beneficiary vm.Address
 	return true
 }
 
+func (a *runContextAdapter) SelfDestruct6780(addr vm.Address, beneficiary vm.Address) bool {
+	if adapterDebug {
+		fmt.Printf("SelfDestruct called with %v, %v\n", addr, beneficiary)
+	}
+
+	stateDb := a.evm.StateDB
+	if stateDb.HasSelfDestructed(gc.Address(addr)) {
+		return false
+	}
+	balance := stateDb.GetBalance(a.contract.Address())
+	stateDb.AddBalance(gc.Address(beneficiary), balance, tracing.BalanceDecreaseSelfdestruct)
+	stateDb.SubBalance(a.contract.Address(), balance, tracing.BalanceDecreaseSelfdestruct)
+	stateDb.SelfDestruct(gc.Address(addr))
+	return true
+}
+
 func (a *runContextAdapter) CreateSnapshot() vm.Snapshot {
 	return vm.Snapshot(a.evm.StateDB.Snapshot())
 }

--- a/go/vm/geth/geth.go
+++ b/go/vm/geth/geth.go
@@ -347,9 +347,8 @@ func (s *stateDbAdapter) HasSelfDestructed(addr common.Address) bool {
 	return s.context.HasSelfDestructed(vm.Address(addr))
 }
 
-func (s *stateDbAdapter) Selfdestruct6780(common.Address) {
-	// ignored: effect not needed in test environments
-	panic("not implemented")
+func (s *stateDbAdapter) Selfdestruct6780(addr common.Address) {
+	s.context.SelfDestruct6780(vm.Address(addr), s.lastBeneficiary)
 }
 
 func (s *stateDbAdapter) Exist(addr common.Address) bool {

--- a/go/vm/interpreter_mock.go
+++ b/go/vm/interpreter_mock.go
@@ -392,6 +392,20 @@ func (mr *MockRunContextMockRecorder) SelfDestruct(addr, beneficiary any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelfDestruct", reflect.TypeOf((*MockRunContext)(nil).SelfDestruct), addr, beneficiary)
 }
 
+// SelfDestruct6780 mocks base method.
+func (m *MockRunContext) SelfDestruct6780(addr, beneficiary Address) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelfDestruct6780", addr, beneficiary)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SelfDestruct6780 indicates an expected call of SelfDestruct6780.
+func (mr *MockRunContextMockRecorder) SelfDestruct6780(addr, beneficiary any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelfDestruct6780", reflect.TypeOf((*MockRunContext)(nil).SelfDestruct6780), addr, beneficiary)
+}
+
 // SetBalance mocks base method.
 func (m *MockRunContext) SetBalance(arg0 Address, arg1 Value) {
 	m.ctrl.T.Helper()
@@ -754,6 +768,20 @@ func (m *MockTransactionContext) SelfDestruct(addr, beneficiary Address) bool {
 func (mr *MockTransactionContextMockRecorder) SelfDestruct(addr, beneficiary any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelfDestruct", reflect.TypeOf((*MockTransactionContext)(nil).SelfDestruct), addr, beneficiary)
+}
+
+// SelfDestruct6780 mocks base method.
+func (m *MockTransactionContext) SelfDestruct6780(addr, beneficiary Address) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelfDestruct6780", addr, beneficiary)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SelfDestruct6780 indicates an expected call of SelfDestruct6780.
+func (mr *MockTransactionContextMockRecorder) SelfDestruct6780(addr, beneficiary any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelfDestruct6780", reflect.TypeOf((*MockTransactionContext)(nil).SelfDestruct6780), addr, beneficiary)
 }
 
 // SetBalance mocks base method.

--- a/go/vm/test/test_evm.go
+++ b/go/vm/test/test_evm.go
@@ -214,6 +214,10 @@ func (a *runContextAdapter) SelfDestruct(address vm.Address, beneficiary vm.Addr
 	return balance != (vm.Value{})
 }
 
+func (a *runContextAdapter) SelfDestruct6780(address vm.Address, beneficiary vm.Address) bool {
+	return a.SelfDestruct(address, beneficiary)
+}
+
 func (a *runContextAdapter) CreateAccount(vm.Address, vm.Code) bool {
 	panic("should not be needed for interpreter tests")
 }

--- a/go/vm/world_state.go
+++ b/go/vm/world_state.go
@@ -33,6 +33,7 @@ type WorldState interface {
 	SetStorage(Address, Key, Word) StorageStatus
 
 	SelfDestruct(addr Address, beneficiary Address) bool
+	SelfDestruct6780(addr Address, beneficiary Address) bool
 }
 
 // Address represents the 160-bit (20 bytes) address of an account.

--- a/go/vm/world_state_mock.go
+++ b/go/vm/world_state_mock.go
@@ -174,6 +174,20 @@ func (mr *MockWorldStateMockRecorder) SelfDestruct(addr, beneficiary any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelfDestruct", reflect.TypeOf((*MockWorldState)(nil).SelfDestruct), addr, beneficiary)
 }
 
+// SelfDestruct6780 mocks base method.
+func (m *MockWorldState) SelfDestruct6780(addr, beneficiary Address) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelfDestruct6780", addr, beneficiary)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SelfDestruct6780 indicates an expected call of SelfDestruct6780.
+func (mr *MockWorldStateMockRecorder) SelfDestruct6780(addr, beneficiary any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelfDestruct6780", reflect.TypeOf((*MockWorldState)(nil).SelfDestruct6780), addr, beneficiary)
+}
+
 // SetBalance mocks base method.
 func (m *MockWorldState) SetBalance(arg0 Address, arg1 Value) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR prepares for the update of the selfdestruct introduced in Cancun with EIP-6780. The world state interface is extended with another selfdestruct6780 function. The CT selfdestruct journal is extended with a boolean member to indicate whether a updated selfdestructed has been executed. 
The specification as well as the ct/utils/adapter will be updated in a follow up PR.
Contributes to #521.  