### PR TITLE
Selfdestruct update EIP-6780

### DIFF
--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -2230,7 +2230,13 @@ func selfDestructEffect(s *st.State, destinationColdCost, accountCreationFee, re
 	}
 	// add beneficiary to list in state
 	s.HasSelfDestructed = true
-	s.SelfDestructedJournal = append(s.SelfDestructedJournal, st.NewSelfDestructEntry(s.CallContext.AccountAddress, destinationAccount, false))
+	if s.Revision < R13_Cancun {
+		s.SelfDestructedJournal = append(s.SelfDestructedJournal,
+			st.NewSelfDestructEntry(s.CallContext.AccountAddress, destinationAccount, false))
+	} else {
+		s.SelfDestructedJournal = append(s.SelfDestructedJournal,
+			st.NewSelfDestructEntry(s.CallContext.AccountAddress, destinationAccount, true))
+	}
 	s.Status = st.Stopped
 	s.GasRefund += refundGas
 }

--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -164,7 +164,8 @@ func (c *ctRunContext) Call(kind vm.CallKind, parameter vm.CallParameters) (vm.C
 }
 
 func (c *ctRunContext) SelfDestruct(address vm.Address, beneficiary vm.Address) bool {
-	c.state.SelfDestructedJournal = append(c.state.SelfDestructedJournal, st.NewSelfDestructEntry(address, beneficiary, false))
+	c.state.SelfDestructedJournal = append(c.state.SelfDestructedJournal,
+		st.NewSelfDestructEntry(address, beneficiary, false))
 	if c.state.HasSelfDestructed {
 		return false
 	}
@@ -173,10 +174,8 @@ func (c *ctRunContext) SelfDestruct(address vm.Address, beneficiary vm.Address) 
 }
 
 func (c *ctRunContext) SelfDestruct6780(address vm.Address, beneficiary vm.Address) bool {
-
 	c.state.SelfDestructedJournal = append(c.state.SelfDestructedJournal,
-		//TODO: change to true once selfdestruct is updated in the vms
-		st.NewSelfDestructEntry(address, beneficiary, false))
+		st.NewSelfDestructEntry(address, beneficiary, true))
 	if c.state.HasSelfDestructed {
 		return false
 	}

--- a/go/vm/evmc/evmc_interpreter.go
+++ b/go/vm/evmc/evmc_interpreter.go
@@ -217,8 +217,12 @@ func (ctx *hostContext) GetCode(addr evmc.Address) []byte {
 	return ctx.context.GetCode(vm.Address(addr))
 }
 
+// in order to avoid evmc interface changes, the different selfdestruct calls are handled here
 func (ctx *hostContext) Selfdestruct(addr evmc.Address, beneficiary evmc.Address) bool {
-	return ctx.context.SelfDestruct(vm.Address(addr), vm.Address(beneficiary))
+	if ctx.params.Revision < vm.R13_Cancun {
+		return ctx.context.SelfDestruct(vm.Address(addr), vm.Address(beneficiary))
+	}
+	return ctx.context.SelfDestruct6780(vm.Address(addr), vm.Address(beneficiary))
 }
 
 func (ctx *hostContext) GetTxContext() evmc.TxContext {

--- a/go/vm/evmc/evmc_interpreter_test.go
+++ b/go/vm/evmc/evmc_interpreter_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Fantom-foundation/Tosca/go/vm"
 	"github.com/ethereum/evmc/v11/bindings/go/evmc"
+	"go.uber.org/mock/gomock"
 )
 
 func TestEvmcInterpreter_RevisionConversion(t *testing.T) {
@@ -46,5 +47,42 @@ func TestEvmcInterpreter_RevisionConversionFailsOnUnknownRevision(t *testing.T) 
 	_, err := toEvmcRevision(vm.Revision(math.MaxInt))
 	if err == nil {
 		t.Errorf("expected a conversion failure, got nothing")
+	}
+}
+
+func TestEvmcInterpreter_SelfdestructCallsTheRightFunction(t *testing.T) {
+	tests := map[string]struct {
+		setup    func(*vm.MockRunContext)
+		revision vm.Revision
+	}{
+		"pre-Cancun": {
+			setup: func(runContext *vm.MockRunContext) {
+				runContext.EXPECT().SelfDestruct(gomock.Any(), gomock.Any()).Times(1)
+			},
+			revision: vm.R12_Shanghai,
+		},
+		"Cancun": {
+			setup: func(runContext *vm.MockRunContext) {
+				runContext.EXPECT().SelfDestruct6780(gomock.Any(), gomock.Any())
+			},
+			revision: vm.R13_Cancun,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			runContextCtrl := gomock.NewController(t)
+			runContext := vm.NewMockRunContext(runContextCtrl)
+			test.setup(runContext)
+
+			ctx := &hostContext{
+				context: runContext,
+				params: vm.Parameters{
+					BlockParameters: vm.BlockParameters{Revision: test.revision},
+				},
+			}
+
+			ctx.Selfdestruct(evmc.Address{}, evmc.Address{1})
+		})
 	}
 }

--- a/go/vm/lfvm/instructions.go
+++ b/go/vm/lfvm/instructions.go
@@ -733,7 +733,11 @@ func opSelfdestruct(c *context) {
 		return
 	}
 	beneficiary := vm.Address(c.stack.pop().Bytes20())
-	c.context.SelfDestruct(c.params.Recipient, beneficiary)
+	if c.isCancun() {
+		c.context.SelfDestruct6780(c.params.Recipient, beneficiary)
+	} else {
+		c.context.SelfDestruct(c.params.Recipient, beneficiary)
+	}
 	c.status = SUICIDED
 }
 


### PR DESCRIPTION
This PR is based on #556 and updates the VMs and CT specification with the changes required by EIP-6780 updating the selfdestruct instruction.
Fixes #521.