### PR TITLE
CT: IsAddressWarm/Cold small refactor & benchmark

### DIFF
--- a/go/ct/common/address.go
+++ b/go/ct/common/address.go
@@ -16,7 +16,7 @@ import (
 )
 
 func NewAddress(in U256) vm.Address {
-	return in.internal.Bytes20()
+	return in.Bytes20be()
 }
 
 func NewAddressFromInt(in uint64) vm.Address {

--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -713,11 +713,8 @@ func IsAddressCold(key BindableExpression[U256]) Condition {
 }
 
 func (c *isAddressCold) Check(s *st.State) (bool, error) {
-	key, err := c.key.Eval(s)
-	if err != nil {
-		return false, err
-	}
-	return s.Accounts.IsCold(NewAddress(key)), nil
+	res, err := IsAddressWarm(c.key).Check(s)
+	return !res, err
 }
 
 func (c *isAddressCold) Restrict(generator *gen.StateGenerator) {

--- a/go/ct/rlz/conditions_test.go
+++ b/go/ct/rlz/conditions_test.go
@@ -611,6 +611,7 @@ func BenchmarkCondition_IsAddressWarmCheckWarm(b *testing.B) {
 func BenchmarkCondition_IsAddressWarmCheckCold(b *testing.B) {
 	state := st.NewState(st.NewCode([]byte{}))
 	state.Accounts.MarkWarm(NewAddress(NewU256(42)))
+	state.Stack.Push(NewU256(1))
 	condition := IsAddressWarm(Param(0))
 
 	b.ResetTimer()

--- a/go/ct/rlz/conditions_test.go
+++ b/go/ct/rlz/conditions_test.go
@@ -595,3 +595,26 @@ func TestCondition_BlobHashesProducesGetTestValues(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkCondition_IsAddressWarmCheckWarm(b *testing.B) {
+	state := st.NewState(st.NewCode([]byte{}))
+	state.Accounts.MarkWarm(NewAddress(NewU256(42)))
+	state.Stack.Push(NewU256(42))
+	condition := IsAddressWarm(Param(0))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		condition.Check(state)
+	}
+}
+
+func BenchmarkCondition_IsAddressWarmCheckCold(b *testing.B) {
+	state := st.NewState(st.NewCode([]byte{}))
+	state.Accounts.MarkWarm(NewAddress(NewU256(42)))
+	condition := IsAddressWarm(Param(0))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		condition.Check(state)
+	}
+}

--- a/go/ct/st/accounts.go
+++ b/go/ct/st/accounts.go
@@ -110,11 +110,7 @@ func (a *Accounts) IsWarm(key vm.Address) bool {
 }
 
 func (a *Accounts) IsCold(key vm.Address) bool {
-	if a.warm == nil {
-		return true
-	}
-	_, contains := a.warm[key]
-	return !contains
+	return !a.IsWarm(key)
 }
 
 func (a *Accounts) MarkWarm(key vm.Address) {


### PR DESCRIPTION
This PR is a response to the test `TestSpecification_EachRuleProducesAMatchingTestCase` taking too long for the development cycle compared to other tests. 
Running the commands
```
go test ./go/ct/spc -run ^TestSpecification_EachRuleProducesAMatchingTestCase$ -cpuprofile cpu.log
go tool pprof -http "localhost:8000" ./cpu.log
```
and a followed analysis showed  that `IsAddressWarm` and the `Cold` counterpart were taking about 21% of the whole run. 
Unfortunately the changes proposed in this PR only lowered this to 17% of the full run of the test, but this results are not shown in the benchmark comparisons. 

That said, I do think these changes do help code maintainability. 