### PR TITLE
CT: reusable sample slices

### DIFF
--- a/go/ct/rlz/parameters.go
+++ b/go/ct/rlz/parameters.go
@@ -15,81 +15,95 @@ import (
 )
 
 type Parameter interface {
+	// Samples returns a list of test values for an operation parameter.
+	// For efficiency reasons, the resulting slice may be shared among
+	// multiple calls. Thus, neither the slice itself nor its elements must
+	// be modified by users of this function.
 	Samples() []U256
 }
 
 type NumericParameter struct{}
 
+var numericParameterSamples = []U256{
+	NewU256(0),
+	NewU256(1),
+	NewU256(1 << 8),
+	NewU256(1 << 16),
+	NewU256(1 << 32),
+	NewU256(1 << 48),
+	NewU256(1).Shl(NewU256(64)),
+	NewU256(1).Shl(NewU256(128)),
+	NewU256(1).Shl(NewU256(192)),
+	NewU256(1).Shl(NewU256(255)),
+	NewU256(0).Not(),
+}
+
 func (NumericParameter) Samples() []U256 {
-	return []U256{
-		NewU256(0),
-		NewU256(1),
-		NewU256(1 << 8),
-		NewU256(1 << 16),
-		NewU256(1 << 32),
-		NewU256(1 << 48),
-		NewU256(1).Shl(NewU256(64)),
-		NewU256(1).Shl(NewU256(128)),
-		NewU256(1).Shl(NewU256(192)),
-		NewU256(1).Shl(NewU256(255)),
-		NewU256(0).Not(),
-	}
+	return numericParameterSamples
 }
 
 type StorageAccessKeyParameter = NumericParameter
 
 type MemoryOffsetParameter struct{}
 
+var memoryOffsetParameterSamples = []U256{
+	NewU256(0),
+	NewU256(1),
+	NewU256(31),
+	NewU256(32),
+	NewU256(1, 0),
+}
+
 func (MemoryOffsetParameter) Samples() []U256 {
-	return []U256{
-		NewU256(0),
-		NewU256(1),
-		NewU256(31),
-		NewU256(32),
-		NewU256(1, 0),
-	}
+	return memoryOffsetParameterSamples
 }
 
 type MemorySizeParameter struct{}
 
-func (MemorySizeParameter) Samples() []U256 {
-	return []U256{
-		NewU256(0),
-		NewU256(1),
-		NewU256(31),
-		NewU256(32),
-		NewU256(1, 0),
+var memorySizeParameterSamples = []U256{
+	NewU256(0),
+	NewU256(1),
+	NewU256(31),
+	NewU256(32),
+	NewU256(1, 0),
 
-		// Samples stressing the max init code size introduced with Shanghai
-		NewU256(2*24576 - 1),
-		NewU256(2 * 24576),
-		NewU256(2*24576 + 1),
-	}
+	// Samples stressing the max init code size introduced with Shanghai
+	NewU256(2*24576 - 1),
+	NewU256(2 * 24576),
+	NewU256(2*24576 + 1),
+}
+
+func (MemorySizeParameter) Samples() []U256 {
+	return memorySizeParameterSamples
 }
 
 type TopicParameter struct{}
 
+var topicParameterSamples = []U256{
+	// Two samples to ensure topic order is correct. Adding more samples
+	// here will create significant more test cases for LOG instructions.
+	NewU256(101),
+	NewU256(102),
+}
+
 func (TopicParameter) Samples() []U256 {
-	return []U256{
-		// Two samples to ensure topic order is correct. Adding more samples
-		// here will create significant more test cases for LOG instructions.
-		NewU256(101),
-		NewU256(102),
-	}
+	return topicParameterSamples
 }
 
 type AddressParameter struct{}
 
+var addressParameterSamples = []U256{
+	// Adding more samples here will create significantly more test cases for EXTCODECOPY.
+	// TODO: evaluate code coverage
+	NewU256(0),
+	//NewU256(1),
+	//NewU256(1).Shl(NewU256(20*8 - 1)), // < first bit of 20-byte address set
+	//NewU256(3).Shl(NewU256(20*8 - 1)), // < first bit beyond 20-byte address set as well (should be the same address as above)
+	NewU256(0).Not(),
+}
+
 func (AddressParameter) Samples() []U256 {
-	return []U256{
-		// Adding more samples here will create significantly more test cases for EXTCODECOPY.
-		// TODO: evaluate code coverage
-		NewU256(0),
-		//NewU256(1),
-		//NewU256(1).Shl(NewU256(20*8 - 1)), // < first bit of 20-byte address set
-		//NewU256(3).Shl(NewU256(20*8 - 1)), // < first bit beyond 20-byte address set as well (should be the same address as above)
-		NewU256(0).Not(),
-	}
+	return addressParameterSamples
 }
 
 type DataOffsetParameter = MemoryOffsetParameter
@@ -97,23 +111,27 @@ type DataSizeParameter = MemorySizeParameter
 
 type GasParameter struct{}
 
+var gasParameterSamples = []U256{
+	NewU256(0),
+	NewU256(1),
+	NewU256(1 << 10),
+	NewU256(1 << 20),
+	NewU256(1 << 62),
+	MaxU256(),
+}
+
 func (GasParameter) Samples() []U256 {
-	return []U256{
-		NewU256(0),
-		NewU256(1),
-		NewU256(1 << 10),
-		NewU256(1 << 20),
-		NewU256(1 << 62),
-		MaxU256(),
-	}
+	return gasParameterSamples
 }
 
 type ValueParameter struct{}
 
+var valueParameterSamples = []U256{
+	NewU256(0),
+	NewU256(1),
+	MaxU256(),
+}
+
 func (ValueParameter) Samples() []U256 {
-	return []U256{
-		NewU256(0),
-		NewU256(1),
-		MaxU256(),
-	}
+	return valueParameterSamples
 }


### PR DESCRIPTION
This PR is a response to the test `TestSpecification_EachRuleProducesAMatchingTestCase` taking too long for the development cycle compared to other tests.
Running the commands
```
go test ./go/ct/spc -run ^TestSpecification_EachRuleProducesAMatchingTestCase$ -cpuprofile cpu.log
go tool pprof -http "localhost:8000" ./cpu.log
````
and a followed analysis showed that `MemorySizeParameter.Samples()`  took about 30% of the whole run.
Making the slice a global variable to prevent multiple allocations reduced the runtime of the whole test in ~45%
Making the slice for `MemoryOffsetParameter.Samples()` reusable as well reduced another ~5%. 
The rest of the parameters are made reusable as well for consistency. 

This change is "safe" only because the `.Samples` methods are only called in a `for _, value := range param.Samples()` so the slices can not be modified. A comment is added to reflect this warning. 
