### PR TITLE
Update Selfdestruct EIP-6780

### DIFF
--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -473,7 +473,14 @@ func (a *runContextAdapter) SelfDestruct(addr vm.Address, beneficiary vm.Address
 	}
 	balance := stateDb.GetBalance(a.contract.Address())
 	stateDb.AddBalance(gc.Address(beneficiary), balance, tracing.BalanceDecreaseSelfdestruct)
-	stateDb.SelfDestruct(gc.Address(addr))
+
+	if a.evm.ChainConfig().IsCancun(a.evm.Context.BlockNumber, a.evm.Context.Time) {
+		stateDb.SubBalance(a.contract.Address(), balance, tracing.BalanceDecreaseSelfdestruct)
+		stateDb.Selfdestruct6780(gc.Address(addr))
+	} else {
+		stateDb.SelfDestruct(gc.Address(addr))
+	}
+
 	return true
 }
 

--- a/go/vm/geth/geth.go
+++ b/go/vm/geth/geth.go
@@ -347,9 +347,8 @@ func (s *stateDbAdapter) HasSelfDestructed(addr common.Address) bool {
 	return s.context.HasSelfDestructed(vm.Address(addr))
 }
 
-func (s *stateDbAdapter) Selfdestruct6780(common.Address) {
-	// ignored: effect not needed in test environments
-	panic("not implemented")
+func (s *stateDbAdapter) Selfdestruct6780(addr common.Address) {
+	s.context.SelfDestruct(vm.Address(addr), s.lastBeneficiary)
 }
 
 func (s *stateDbAdapter) Exist(addr common.Address) bool {


### PR DESCRIPTION
After the implementation of changes to Selfdestruct in Cancun in #556 and #557, it was decided that these changes should happen in the database. The right function is simply selected by checking the revision.