### PR TITLE
CT: Fix storage generation

### DIFF
--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -215,7 +215,7 @@ func (g *StateGenerator) BindStackValue(pos int, v Variable) {
 }
 
 // BindStorageConfiguration wraps StorageGenerator.BindConfiguration.
-func (g *StateGenerator) BindStorageConfiguration(config StorageCfg, key, newValue Variable) {
+func (g *StateGenerator) BindStorageConfiguration(config vm.StorageStatus, key, newValue Variable) {
 	g.storageGen.BindConfiguration(config, key, newValue)
 }
 

--- a/go/ct/rlz/conditions.go
+++ b/go/ct/rlz/conditions.go
@@ -18,6 +18,7 @@ import (
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/gen"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
+	"github.com/Fantom-foundation/Tosca/go/vm"
 )
 
 // Condition represents a state property.
@@ -530,12 +531,12 @@ func (c *isStorageCold) String() string {
 // Storage Configuration
 
 type storageConfiguration struct {
-	config   gen.StorageCfg
+	config   vm.StorageStatus
 	key      BindableExpression[U256]
 	newValue BindableExpression[U256]
 }
 
-func StorageConfiguration(config gen.StorageCfg, key, newValue BindableExpression[U256]) Condition {
+func StorageConfiguration(config vm.StorageStatus, key, newValue BindableExpression[U256]) Condition {
 	return &storageConfiguration{config, key, newValue}
 }
 
@@ -548,7 +549,7 @@ func (c *storageConfiguration) Check(s *st.State) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return c.config.Check(s.Storage.GetOriginal(key), s.Storage.GetCurrent(key), newValue), nil
+	return gen.CheckStorageStatusConfig(c.config, s.Storage.GetOriginal(key), s.Storage.GetCurrent(key), newValue), nil
 }
 
 func (c *storageConfiguration) Restrict(generator *gen.StateGenerator) {

--- a/go/ct/rlz/conditions_test.go
+++ b/go/ct/rlz/conditions_test.go
@@ -143,31 +143,31 @@ func TestCondition_UnknownNextRevisionIsNotAnyKnownIsRevision(t *testing.T) {
 }
 
 func TestCondition_CheckStorageConfiguration(t *testing.T) {
-	allConfigs := []gen.StorageCfg{
-		gen.StorageAssigned,
-		gen.StorageAdded,
-		gen.StorageAddedDeleted,
-		gen.StorageDeletedRestored,
-		gen.StorageDeletedAdded,
-		gen.StorageDeleted,
-		gen.StorageModified,
-		gen.StorageModifiedDeleted,
-		gen.StorageModifiedRestored,
+	allConfigs := []vm.StorageStatus{
+		vm.StorageAssigned,
+		vm.StorageAdded,
+		vm.StorageAddedDeleted,
+		vm.StorageDeletedRestored,
+		vm.StorageDeletedAdded,
+		vm.StorageDeleted,
+		vm.StorageModified,
+		vm.StorageModifiedDeleted,
+		vm.StorageModifiedRestored,
 	}
 
 	tests := []struct {
-		config        gen.StorageCfg
+		config        vm.StorageStatus
 		org, cur, new U256
 	}{
-		{gen.StorageAssigned, NewU256(1), NewU256(2), NewU256(3)},
-		{gen.StorageAdded, NewU256(0), NewU256(0), NewU256(1)},
-		{gen.StorageAddedDeleted, NewU256(0), NewU256(1), NewU256(0)},
-		{gen.StorageDeletedRestored, NewU256(1), NewU256(0), NewU256(1)},
-		{gen.StorageDeletedAdded, NewU256(1), NewU256(0), NewU256(2)},
-		{gen.StorageDeleted, NewU256(1), NewU256(1), NewU256(0)},
-		{gen.StorageModified, NewU256(1), NewU256(1), NewU256(2)},
-		{gen.StorageModifiedDeleted, NewU256(1), NewU256(2), NewU256(0)},
-		{gen.StorageModifiedRestored, NewU256(1), NewU256(2), NewU256(1)},
+		{vm.StorageAssigned, NewU256(1), NewU256(2), NewU256(3)},
+		{vm.StorageAdded, NewU256(0), NewU256(0), NewU256(1)},
+		{vm.StorageAddedDeleted, NewU256(0), NewU256(1), NewU256(0)},
+		{vm.StorageDeletedRestored, NewU256(1), NewU256(0), NewU256(1)},
+		{vm.StorageDeletedAdded, NewU256(1), NewU256(0), NewU256(2)},
+		{vm.StorageDeleted, NewU256(1), NewU256(1), NewU256(0)},
+		{vm.StorageModified, NewU256(1), NewU256(1), NewU256(2)},
+		{vm.StorageModifiedDeleted, NewU256(1), NewU256(2), NewU256(0)},
+		{vm.StorageModifiedRestored, NewU256(1), NewU256(2), NewU256(1)},
 	}
 
 	for _, test := range tests {

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
-	"github.com/Fantom-foundation/Tosca/go/ct/gen"
 	. "github.com/Fantom-foundation/Tosca/go/ct/rlz"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"github.com/Fantom-foundation/Tosca/go/vm"
@@ -488,63 +487,63 @@ func getAllRules() []Rule {
 	// --- SSTORE ---
 
 	sstoreRules := []sstoreOpParams{
-		{revision: R07_Istanbul, config: gen.StorageAssigned, gasCost: 800},
-		{revision: R07_Istanbul, config: gen.StorageAdded, gasCost: 20000},
-		{revision: R07_Istanbul, config: gen.StorageAddedDeleted, gasCost: 800, gasRefund: 19200},
-		{revision: R07_Istanbul, config: gen.StorageDeletedRestored, gasCost: 800, gasRefund: -10800},
-		{revision: R07_Istanbul, config: gen.StorageDeletedAdded, gasCost: 800, gasRefund: -15000},
-		{revision: R07_Istanbul, config: gen.StorageDeleted, gasCost: 5000, gasRefund: 15000},
-		{revision: R07_Istanbul, config: gen.StorageModified, gasCost: 5000},
-		{revision: R07_Istanbul, config: gen.StorageModifiedDeleted, gasCost: 800, gasRefund: 15000},
-		{revision: R07_Istanbul, config: gen.StorageModifiedRestored, gasCost: 800, gasRefund: 4200},
+		{revision: R07_Istanbul, config: vm.StorageAssigned, gasCost: 800},
+		{revision: R07_Istanbul, config: vm.StorageAdded, gasCost: 20000},
+		{revision: R07_Istanbul, config: vm.StorageAddedDeleted, gasCost: 800, gasRefund: 19200},
+		{revision: R07_Istanbul, config: vm.StorageDeletedRestored, gasCost: 800, gasRefund: -10800},
+		{revision: R07_Istanbul, config: vm.StorageDeletedAdded, gasCost: 800, gasRefund: -15000},
+		{revision: R07_Istanbul, config: vm.StorageDeleted, gasCost: 5000, gasRefund: 15000},
+		{revision: R07_Istanbul, config: vm.StorageModified, gasCost: 5000},
+		{revision: R07_Istanbul, config: vm.StorageModifiedDeleted, gasCost: 800, gasRefund: 15000},
+		{revision: R07_Istanbul, config: vm.StorageModifiedRestored, gasCost: 800, gasRefund: 4200},
 
 		// Certain storage configurations imply warm access. Not all
 		// combinations are possible; invalid ones are marked below.
 
-		// {revision: R09_Berlin, warm: false, config: gen.StorageAssigned, gasCost: 2200}, // invalid
-		{revision: R09_Berlin, warm: false, config: gen.StorageAdded, gasCost: 22100},
-		// {revision: R09_Berlin, warm: false, config: gen.StorageAddedDeleted, gasCost: 2200, gasRefund: 19900},     // invalid
-		// {revision: R09_Berlin, warm: false, config: gen.StorageDeletedRestored, gasCost: 2200, gasRefund: -10800}, // invalid
-		// {revision: R09_Berlin, warm: false, config: gen.StorageDeletedAdded, gasCost: 2200, gasRefund: -15000},    // invalid
-		{revision: R09_Berlin, warm: false, config: gen.StorageDeleted, gasCost: 5000, gasRefund: 15000},
-		{revision: R09_Berlin, warm: false, config: gen.StorageModified, gasCost: 5000},
-		// {revision: R09_Berlin, warm: false, config: gen.StorageModifiedDeleted, gasCost: 2200, gasRefund: 15000}, // invalid
-		// {revision: R09_Berlin, warm: false, config: gen.StorageModifiedRestored, gasCost: 2200, gasRefund: 4900}, // invalid
+		// {revision: R09_Berlin, warm: false, config: vm.StorageAssigned, gasCost: 2200}, // invalid
+		{revision: R09_Berlin, warm: false, config: vm.StorageAdded, gasCost: 22100},
+		// {revision: R09_Berlin, warm: false, config: vm.StorageAddedDeleted, gasCost: 2200, gasRefund: 19900},     // invalid
+		// {revision: R09_Berlin, warm: false, config: vm.StorageDeletedRestored, gasCost: 2200, gasRefund: -10800}, // invalid
+		// {revision: R09_Berlin, warm: false, config: vm.StorageDeletedAdded, gasCost: 2200, gasRefund: -15000},    // invalid
+		{revision: R09_Berlin, warm: false, config: vm.StorageDeleted, gasCost: 5000, gasRefund: 15000},
+		{revision: R09_Berlin, warm: false, config: vm.StorageModified, gasCost: 5000},
+		// {revision: R09_Berlin, warm: false, config: vm.StorageModifiedDeleted, gasCost: 2200, gasRefund: 15000}, // invalid
+		// {revision: R09_Berlin, warm: false, config: vm.StorageModifiedRestored, gasCost: 2200, gasRefund: 4900}, // invalid
 
-		{revision: R09_Berlin, warm: true, config: gen.StorageAssigned, gasCost: 100},
-		{revision: R09_Berlin, warm: true, config: gen.StorageAdded, gasCost: 20000},
-		{revision: R09_Berlin, warm: true, config: gen.StorageAddedDeleted, gasCost: 100, gasRefund: 19900},
-		{revision: R09_Berlin, warm: true, config: gen.StorageDeletedRestored, gasCost: 100, gasRefund: -12200},
-		{revision: R09_Berlin, warm: true, config: gen.StorageDeletedAdded, gasCost: 100, gasRefund: -15000},
-		{revision: R09_Berlin, warm: true, config: gen.StorageDeleted, gasCost: 2900, gasRefund: 15000},
-		{revision: R09_Berlin, warm: true, config: gen.StorageModified, gasCost: 2900},
-		{revision: R09_Berlin, warm: true, config: gen.StorageModifiedDeleted, gasCost: 100, gasRefund: 15000},
-		{revision: R09_Berlin, warm: true, config: gen.StorageModifiedRestored, gasCost: 100, gasRefund: 2800},
+		{revision: R09_Berlin, warm: true, config: vm.StorageAssigned, gasCost: 100},
+		{revision: R09_Berlin, warm: true, config: vm.StorageAdded, gasCost: 20000},
+		{revision: R09_Berlin, warm: true, config: vm.StorageAddedDeleted, gasCost: 100, gasRefund: 19900},
+		{revision: R09_Berlin, warm: true, config: vm.StorageDeletedRestored, gasCost: 100, gasRefund: -12200},
+		{revision: R09_Berlin, warm: true, config: vm.StorageDeletedAdded, gasCost: 100, gasRefund: -15000},
+		{revision: R09_Berlin, warm: true, config: vm.StorageDeleted, gasCost: 2900, gasRefund: 15000},
+		{revision: R09_Berlin, warm: true, config: vm.StorageModified, gasCost: 2900},
+		{revision: R09_Berlin, warm: true, config: vm.StorageModifiedDeleted, gasCost: 100, gasRefund: 15000},
+		{revision: R09_Berlin, warm: true, config: vm.StorageModifiedRestored, gasCost: 100, gasRefund: 2800},
 	}
 
 	for rev := R10_London; rev <= NewestSupportedRevision; rev++ {
 		// Certain storage configurations imply warm access. Not all
 		// combinations are possible; invalid ones are marked below.
 		sstoreRules = append(sstoreRules, []sstoreOpParams{
-			// {revision: rev, warm: false, config: gen.StorageAssigned, gasCost: 2200}, // invalid
-			{revision: rev, warm: false, config: gen.StorageAdded, gasCost: 22100},
-			// {revision: rev, warm: false, config: gen.StorageAddedDeleted, gasCost: 2200, gasRefund: 19900},  // invalid
-			// {revision: rev, warm: false, config: gen.StorageDeletedRestored, gasCost: 2200, gasRefund: 100}, // invalid
-			// {revision: rev, warm: false, config: gen.StorageDeletedAdded, gasCost: 2200, gasRefund: -4800},  // invalid
-			{revision: rev, warm: false, config: gen.StorageDeleted, gasCost: 5000, gasRefund: 4800},
-			{revision: rev, warm: false, config: gen.StorageModified, gasCost: 5000},
-			// {revision: rev, warm: false, config: gen.StorageModifiedDeleted, gasCost: 2200, gasRefund: 4800},  // invalid
-			// {revision: rev, warm: false, config: gen.StorageModifiedRestored, gasCost: 2200, gasRefund: 4900}, // invalid
+			// {revision: rev, warm: false, config: vm.StorageAssigned, gasCost: 2200}, // invalid
+			{revision: rev, warm: false, config: vm.StorageAdded, gasCost: 22100},
+			// {revision: rev, warm: false, config: vm.StorageAddedDeleted, gasCost: 2200, gasRefund: 19900},  // invalid
+			// {revision: rev, warm: false, config: vm.StorageDeletedRestored, gasCost: 2200, gasRefund: 100}, // invalid
+			// {revision: rev, warm: false, config: vm.StorageDeletedAdded, gasCost: 2200, gasRefund: -4800},  // invalid
+			{revision: rev, warm: false, config: vm.StorageDeleted, gasCost: 5000, gasRefund: 4800},
+			{revision: rev, warm: false, config: vm.StorageModified, gasCost: 5000},
+			// {revision: rev, warm: false, config: vm.StorageModifiedDeleted, gasCost: 2200, gasRefund: 4800},  // invalid
+			// {revision: rev, warm: false, config: vm.StorageModifiedRestored, gasCost: 2200, gasRefund: 4900}, // invalid
 
-			{revision: rev, warm: true, config: gen.StorageAssigned, gasCost: 100},
-			{revision: rev, warm: true, config: gen.StorageAdded, gasCost: 20000},
-			{revision: rev, warm: true, config: gen.StorageAddedDeleted, gasCost: 100, gasRefund: 19900},
-			{revision: rev, warm: true, config: gen.StorageDeletedRestored, gasCost: 100, gasRefund: -2000},
-			{revision: rev, warm: true, config: gen.StorageDeletedAdded, gasCost: 100, gasRefund: -4800},
-			{revision: rev, warm: true, config: gen.StorageDeleted, gasCost: 2900, gasRefund: 4800},
-			{revision: rev, warm: true, config: gen.StorageModified, gasCost: 2900},
-			{revision: rev, warm: true, config: gen.StorageModifiedDeleted, gasCost: 100, gasRefund: 4800},
-			{revision: rev, warm: true, config: gen.StorageModifiedRestored, gasCost: 100, gasRefund: 2800},
+			{revision: rev, warm: true, config: vm.StorageAssigned, gasCost: 100},
+			{revision: rev, warm: true, config: vm.StorageAdded, gasCost: 20000},
+			{revision: rev, warm: true, config: vm.StorageAddedDeleted, gasCost: 100, gasRefund: 19900},
+			{revision: rev, warm: true, config: vm.StorageDeletedRestored, gasCost: 100, gasRefund: -2000},
+			{revision: rev, warm: true, config: vm.StorageDeletedAdded, gasCost: 100, gasRefund: -4800},
+			{revision: rev, warm: true, config: vm.StorageDeleted, gasCost: 2900, gasRefund: 4800},
+			{revision: rev, warm: true, config: vm.StorageModified, gasCost: 2900},
+			{revision: rev, warm: true, config: vm.StorageModifiedDeleted, gasCost: 100, gasRefund: 4800},
+			{revision: rev, warm: true, config: vm.StorageModifiedRestored, gasCost: 100, gasRefund: 2800},
 		}...)
 	}
 
@@ -1967,7 +1966,7 @@ func extCodeCopyEffect(s *st.State, markWarm bool) {
 type sstoreOpParams struct {
 	revision  Revision
 	warm      bool
-	config    gen.StorageCfg
+	config    vm.StorageStatus
 	gasCost   vm.Gas
 	gasRefund vm.Gas
 }

--- a/go/ct/spc/specification_test.go
+++ b/go/ct/spc/specification_test.go
@@ -101,6 +101,33 @@ func TestSpecification_EachRuleProducesAMatchingTestCase(t *testing.T) {
 	}
 }
 
+func TestSpecification_SstoreWithTooLittleGasProducesMatchingTestCases(t *testing.T) {
+	rnd := rand.New(0)
+	rules := Spec.GetRules()
+	filter := regexp.MustCompile("sstore_with_too_little_gas_")
+	rules = FilterRules(rules, filter)
+	if len(rules) == 0 {
+		t.Fatalf("no rule found for filter %v", filter)
+	}
+
+	rule := rules[0]
+	gen := gen.NewStateGenerator()
+	rule.Condition.Restrict(gen)
+	for i := 0; i < 1000; i++ {
+		state, err := gen.Generate(rnd)
+		if err != nil {
+			t.Fatalf("failed to generate a random state: %v", err)
+		}
+		pass, err := rule.Condition.Check(state)
+		if err != nil {
+			t.Fatalf("failed to check rule condition for %v: %v", rule.Name, err)
+		}
+		if !pass {
+			t.Fatalf("State %v \nFailed for conditions: %v\n", state, rule.Condition)
+		}
+	}
+}
+
 func TestSpecificationMap_NumberOfTests(t *testing.T) {
 	rulesMap := Spec.GetRules()
 	rules := getAllRules()

--- a/go/vm/world_state.go
+++ b/go/vm/world_state.go
@@ -10,6 +10,8 @@
 
 package vm
 
+import "fmt"
+
 //go:generate mockgen -source world_state.go -destination world_state_mock.go -package vm
 
 // WorldState is an interface to access and manipulate the state of the block chain.
@@ -62,13 +64,42 @@ type StorageStatus int
 
 // See t.ly/b5HPf for the definition of these values.
 const (
-	StorageAssigned StorageStatus = iota
-	StorageAdded
-	StorageDeleted
-	StorageModified
-	StorageDeletedAdded
-	StorageModifiedDeleted
-	StorageDeletedRestored
-	StorageAddedDeleted
-	StorageModifiedRestored
+	// The comment indicates the storage values for the corresponding
+	// configuration. X, Y, Z are non-zero numbers, distinct from each other,
+	// while 0 is zero.
+	//
+	// <original> -> <current> -> <new>
+	StorageAssigned         StorageStatus = iota
+	StorageAdded                          // 0 -> 0 -> Z
+	StorageDeleted                        // X -> X -> 0
+	StorageModified                       // X -> X -> Z
+	StorageDeletedAdded                   // X -> 0 -> Z
+	StorageModifiedDeleted                // X -> Y -> 0
+	StorageDeletedRestored                // X -> 0 -> X
+	StorageAddedDeleted                   // 0 -> Y -> 0
+	StorageModifiedRestored               // X -> Y -> X
 )
+
+func (config StorageStatus) String() string {
+	switch config {
+	case StorageAssigned:
+		return "StorageAssigned"
+	case StorageAdded:
+		return "StorageAdded"
+	case StorageAddedDeleted:
+		return "StorageAddedDeleted"
+	case StorageDeletedRestored:
+		return "StorageDeletedRestored"
+	case StorageDeletedAdded:
+		return "StorageDeletedAdded"
+	case StorageDeleted:
+		return "StorageDeleted"
+	case StorageModified:
+		return "StorageModified"
+	case StorageModifiedDeleted:
+		return "StorageModifiedDeleted"
+	case StorageModifiedRestored:
+		return "StorageModifiedRestored"
+	}
+	return fmt.Sprintf("StorageStatus(%d)", config)
+}


### PR DESCRIPTION
This PR fixes the storage generation, in particular when using `StorageAssigned` config.
it also changes:
- use vm.StorageStatus, moves print of `StorageCfg`  to `world_state.go`
- add tests for missing StorageAssigned config
- add tests for triggering status 

This should fix the flakiness of the test `TestSpecification_EachRuleProducesAMatchingTestCase`