### PR TITLE
CT: EachRuleProducesAMatchingTestCase flaky test

### DIFF
--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -143,6 +143,9 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 		// extend the runtime but are expected to reveal limited extra code coverage.
 		const expectedSize float64 = 200
 		size = int(rnd.ExpFloat64()/(1/expectedSize)) + minSize
+		if len(g.varIsDataConstraints) > 0 && size < 2 {
+			size = 2
+		}
 		if size > st.MaxCodeSize {
 			size = st.MaxCodeSize
 		}
@@ -375,7 +378,7 @@ func (s *varCodeConstraintSolver) fits(pos int, op OpCode) bool {
 // maximum is 33 since this is the largest instruction we have.
 func (s *varCodeConstraintSolver) largestFit(pos int) int {
 	n := 0
-	for ; n <= 33 && pos+n < s.codeSize; n++ {
+	for ; n < 33 && pos+n < s.codeSize; n++ {
 		if s.usedPositions[pos+n] != isUnused {
 			break
 		}

--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -143,6 +143,8 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 		// extend the runtime but are expected to reveal limited extra code coverage.
 		const expectedSize float64 = 200
 		size = int(rnd.ExpFloat64()/(1/expectedSize)) + minSize
+		// if there are data constraints, we need at least 2 bytes,
+		// one for an op, and the other for data.
 		if len(g.varIsDataConstraints) > 0 && size < 2 {
 			size = 2
 		}

--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -132,6 +132,12 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 		minSize = 1
 	}
 
+	// if there are data constraints, we need at least 2 bytes,
+	// one for an op, and the other for data.
+	if len(g.varIsDataConstraints) > 0 && minSize < 2 {
+		minSize = 2
+	}
+
 	var size int
 	if g.codeSize != nil {
 		if *g.codeSize < minSize {
@@ -143,11 +149,6 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 		// extend the runtime but are expected to reveal limited extra code coverage.
 		const expectedSize float64 = 200
 		size = int(rnd.ExpFloat64()/(1/expectedSize)) + minSize
-		// if there are data constraints, we need at least 2 bytes,
-		// one for an op, and the other for data.
-		if len(g.varIsDataConstraints) > 0 && size < 2 {
-			size = 2
-		}
 		if size > st.MaxCodeSize {
 			size = st.MaxCodeSize
 		}

--- a/go/ct/gen/storage.go
+++ b/go/ct/gen/storage.go
@@ -225,7 +225,6 @@ func (g *StorageGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.
 
 		builder.SetOriginal(key, orgValue)
 		builder.SetCurrent(key, curValue)
-		builder.SetWarm(key, rnd.Intn(2) == 1)
 	}
 
 	// Process warm/cold constraints.

--- a/go/ct/gen/storage_test.go
+++ b/go/ct/gen/storage_test.go
@@ -345,3 +345,27 @@ func TestStorageGenerator_NewValueMustBeZeroMustNotBeZero(t *testing.T) {
 		})
 	}
 }
+
+func TestStorageGenerator_UnspecifiedVariableIsNotWarm(t *testing.T) {
+
+	vKey := Variable("key")
+	vNewValue := Variable("newValue")
+
+	generator := NewStorageGenerator()
+	generator.BindConfiguration(vm.StorageModified, vKey, vNewValue)
+
+	assignment := Assignment{}
+	rnd := rand.New(0)
+
+	for i := 0; i < 1000; i++ {
+		storage, err := generator.Generate(assignment, rnd)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if storage.IsWarm(assignment[vKey]) {
+			t.Fatalf("unexpected variable %v is warm at iteration %v", vKey, i)
+		}
+	}
+
+}

--- a/go/ct/spc/specification_test.go
+++ b/go/ct/spc/specification_test.go
@@ -101,10 +101,14 @@ func TestSpecification_EachRuleProducesAMatchingTestCase(t *testing.T) {
 	}
 }
 
-func TestSpecification_SstoreWithTooLittleGasProducesMatchingTestCases(t *testing.T) {
+// the following test has been used to verify stability of a specific rule.
+// so far it has been used for:
+// - sstore_with_too_little_gas_
+// - pc_on_data_is_ignored
+func TestSpecification_SpecifiedRuleProducesMatchingTestCases(t *testing.T) {
 	rnd := rand.New(0)
 	rules := Spec.GetRules()
-	filter := regexp.MustCompile("sstore_with_too_little_gas_")
+	filter := regexp.MustCompile("sstore_with_too_little_gas_Berlin_StorageDeleted_cold")
 	rules = FilterRules(rules, filter)
 	if len(rules) == 0 {
 		t.Fatalf("no rule found for filter %v", filter)
@@ -113,17 +117,17 @@ func TestSpecification_SstoreWithTooLittleGasProducesMatchingTestCases(t *testin
 	rule := rules[0]
 	gen := gen.NewStateGenerator()
 	rule.Condition.Restrict(gen)
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 10000; i++ {
 		state, err := gen.Generate(rnd)
 		if err != nil {
-			t.Fatalf("failed to generate a random state: %v", err)
+			t.Fatalf("failed to generate a random state at iteration %v: %v", i, err)
 		}
 		pass, err := rule.Condition.Check(state)
 		if err != nil {
-			t.Fatalf("failed to check rule condition for %v: %v", rule.Name, err)
+			t.Fatalf("at iteration %v failed to check rule condition for %v: %v", i, rule.Name, err)
 		}
 		if !pass {
-			t.Fatalf("State %v \nFailed for conditions: %v\n", state, rule.Condition)
+			t.Fatalf("at iteration %v State %v \nFailed for conditions: %v\n", i, state, rule.Condition)
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes some of the state generation issues that made the `TestSpecification_EachRuleProducesAMatchingTestCase` test randomly fail (depending on the state of the RNG). 

Also the `TestSpecification_SpecifiedRuleProducesMatchingTestCases` test is there to use iteratively in case any other rule fails as well, and to debug the generation. 

The 2 specific issues thar are solved in this changes are:
- limiting code size to be bigger than 2 if we are restrained by `isData` condition (if we need data there has to be at least one op followed by data)
- randomly setting an address as warm, but not "cleaning" it when "isStorageCold" condition is also present.

This PR fixes #550 