### PR TITLE
CT: improve lfvm coverage

### DIFF
--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -374,7 +374,7 @@ func (d gasDomain) Samples(a vm.Gas) []vm.Gas {
 }
 
 func (gasDomain) SamplesForAll(as []vm.Gas) []vm.Gas {
-	res := []vm.Gas{0, st.MaxGas}
+	res := []vm.Gas{0, 100, 200, st.MaxGas}
 
 	// Test every element off by one.
 	for _, a := range as {

--- a/go/ct/rlz/parameters.go
+++ b/go/ct/rlz/parameters.go
@@ -36,6 +36,7 @@ var numericParameterSamples = []U256{
 	NewU256(1).Shl(NewU256(192)),
 	NewU256(1).Shl(NewU256(255)),
 	NewU256(0).Not(),
+	NewU256(1, 1),
 }
 
 func (NumericParameter) Samples() []U256 {
@@ -52,6 +53,11 @@ var memoryOffsetParameterSamples = []U256{
 	NewU256(31),
 	NewU256(32),
 	NewU256(1, 0),
+	// Samples stressing the max init code size introduced with Shanghai
+	NewU256(2*24576 - 1),
+	NewU256(2 * 24576),
+	NewU256(2*24576 + 1),
+	NewU256(1 << 16),
 }
 
 func (MemoryOffsetParameter) Samples() []U256 {
@@ -114,6 +120,7 @@ type GasParameter struct{}
 var gasParameterSamples = []U256{
 	NewU256(0),
 	NewU256(1),
+	NewU256(100),
 	NewU256(1 << 10),
 	NewU256(1 << 20),
 	NewU256(1 << 62),

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -563,6 +563,9 @@ func getAllRules() []Rule {
 		staticGas: 8,
 		pops:      1,
 		pushes:    0,
+		parameters: []Parameter{
+			NumericParameter{},
+		},
 		conditions: []Condition{
 			IsCode(Param(0)),
 			Eq(Op(Param(0)), JUMPDEST),
@@ -609,6 +612,10 @@ func getAllRules() []Rule {
 		staticGas: 10,
 		pops:      2,
 		pushes:    0,
+		parameters: []Parameter{
+			NumericParameter{},
+			NumericParameter{},
+		},
 		conditions: []Condition{
 			IsCode(Param(0)),
 			Eq(Op(Param(0)), JUMPDEST),


### PR DESCRIPTION
Thanks to the recent coverage command we could observe certain edge cases not being covered.
The changes in this PR enable the generation of states that would reach those edge cases however unlikely they might be in a real use case. 

In particular:
- extra values in `GasDomain` and `MemoryOffsetParameter` enable `EnsureCapacity` to fail because there is enough Gas to execute a certain rule, but not enough to expand it with reasonable size/offset. 
- `NumericParameters` is there because any instruction that pops should have a defined set of parameter values.
