### PR TITLE
ignore build folders when checking for license

### DIFF
--- a/scripts/license/add_license_header.sh
+++ b/scripts/license/add_license_header.sh
@@ -27,7 +27,7 @@ root_dir=$(readlink -f "$script_dir/../..")
 
 # list of files/directories to ignore
 # paths must be in single quotes to prevent shell expansion (will be expanded later)
-ignore_files=('third_party/*')
+ignore_files=('third_party/*' '*/build/*')
 
 ## extract the flag if the script should only check the license headers
 check_only=false


### PR DESCRIPTION
This PRs modifies the add license script to ignore the `*/build/*` folders, which should anyways never be committed and should also be in the `.gitignore` file. 