### PR TITLE
Fix race condition in EachRuleProducesAMatchingTestCase test

### DIFF
--- a/go/ct/spc/specification_test.go
+++ b/go/ct/spc/specification_test.go
@@ -69,11 +69,11 @@ func TestSpecification_SpecificationIsComplete(t *testing.T) {
 }
 
 func TestSpecification_EachRuleProducesAMatchingTestCase(t *testing.T) {
-	rnd := rand.New(0)
 	for _, rule := range Spec.GetRules() {
 		rule := rule
 		t.Run(rule.Name, func(t *testing.T) {
 			t.Parallel()
+			rnd := rand.New(0)
 			hits := 0
 			misses := 0
 			rule.EnumerateTestCases(rnd, func(state *st.State) rlz.ConsumerResult {


### PR DESCRIPTION
This issue breaks our nightly CT test run since it introduces a race condition in the unit tests. It was introduced by #540 but seems to be unrelated to the change covered by this PR.