### PR TITLE
CT: Reduce number of produced test cases

### DIFF
--- a/go/ct/common/revisions.go
+++ b/go/ct/common/revisions.go
@@ -18,7 +18,7 @@ import (
 
 // Newest tosca.Revision currently supported by the CT specification
 const NewestSupportedRevision = tosca.R13_Cancun
-const NewestFullySupportedRevision = tosca.R12_Shanghai
+const NewestFullySupportedRevision = tosca.R13_Cancun
 
 const R99_UnknownNextRevision = tosca.Revision(99)
 const MinRevision = tosca.R07_Istanbul

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -52,6 +52,21 @@ func (boolDomain) SamplesForAll(_ []bool) []bool {
 }
 
 ////////////////////////////////////////////////////////////
+// readOnlyDomain
+
+type readOnlyDomain struct {
+	boolDomain
+}
+
+func (readOnlyDomain) Samples(value bool) []bool {
+	return []bool{value}
+}
+
+func (readOnlyDomain) SamplesForAll(values []bool) []bool {
+	return values
+}
+
+////////////////////////////////////////////////////////////
 // uint16
 
 type uint16Domain struct{}

--- a/go/ct/rlz/expressions.go
+++ b/go/ct/rlz/expressions.go
@@ -205,7 +205,7 @@ func ReadOnly() Expression[bool] {
 
 func (readOnly) Property() Property { return Property("readOnly") }
 
-func (readOnly) Domain() Domain[bool] { return boolDomain{} }
+func (readOnly) Domain() Domain[bool] { return readOnlyDomain{} }
 
 func (readOnly) Eval(s *st.State) (bool, error) {
 	return s.ReadOnly, nil


### PR DESCRIPTION
By adding the support for new revisions the number of generated test cases during a CT run increased to an unmanageable number. By evaluating the specification, conditions on read only mode, warm accounts and revisions could be changed. The number of test cases is reduced from 510.530.430.373 to 18.288.391.943 by these changes. 