### PR TITLE
CT: Add rules for jump over int32

### DIFF
--- a/go/ct/rlz/parameters.go
+++ b/go/ct/rlz/parameters.go
@@ -11,6 +11,8 @@
 package rlz
 
 import (
+	"math"
+
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 )
 
@@ -49,6 +51,7 @@ var jumpTargetParameterSamples = []U256{
 	NewU256(0),
 	NewU256(1),
 	NewU256(1 << 8),
+	NewU256(math.MaxInt32 + 1),
 	NewU256(1, 1),
 }
 

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -592,6 +592,9 @@ func getAllRules() []Rule {
 
 		{
 			Name: "jump_to_invalid_destination",
+			Parameter: []Parameter{
+				JumpTargetParameter{},
+			},
 			Condition: And(
 				AnyKnownRevision(),
 				Eq(Status(), st.Running),
@@ -663,6 +666,10 @@ func getAllRules() []Rule {
 
 		{
 			Name: "jumpi_to_invalid_destination",
+			Parameter: []Parameter{
+				JumpTargetParameter{},
+				JumpTargetParameter{},
+			},
 			Condition: And(
 				AnyKnownRevision(),
 				Eq(Status(), st.Running),

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -617,7 +617,7 @@ func getAllRules() []Rule {
 		pushes:    0,
 		parameters: []Parameter{
 			JumpTargetParameter{},
-			JumpTargetParameter{},
+			NumericParameter{},
 		},
 		conditions: []Condition{
 			IsCode(Param(0)),
@@ -668,7 +668,7 @@ func getAllRules() []Rule {
 			Name: "jumpi_to_invalid_destination",
 			Parameter: []Parameter{
 				JumpTargetParameter{},
-				JumpTargetParameter{},
+				NumericParameter{},
 			},
 			Condition: And(
 				AnyKnownRevision(),


### PR DESCRIPTION
Coverage reported that there was no hit for the checks of jump/jumpi's destination overflow. 
This PR adds rules testing exactly that case. 