### PR TITLE
Improve processor testing infrastructure

### DIFF
--- a/go/integration_test/processor/processor_test.go
+++ b/go/integration_test/processor/processor_test.go
@@ -1,3 +1,13 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
 package processor
 
 import (

--- a/go/integration_test/processor/processor_test.go
+++ b/go/integration_test/processor/processor_test.go
@@ -1,14 +1,16 @@
-// Copyright (c) 2024 Fantom Foundation
-//
-// Use of this software is governed by the Business Source License included
-// in the LICENSE file and at fantom.foundation/bsl11.
-//
-// Change Date: 2028-4-16
-//
-// On the date above, in accordance with the Business Source License, use of
-// this software will be governed by the GNU Lesser General Public License v3.
+package processor
 
-package interpreter_test
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+	"github.com/ethereum/go-ethereum/common"
+	op "github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	_ "github.com/Fantom-foundation/Tosca/go/processor/opera" // < registers opera processor for testing
+)
 
 // This file contains a few initial shake-down tests or a Processor implementation.
 // Right now, the tested features are minimal. Follow-up work is needed to systematically
@@ -20,262 +22,158 @@ package interpreter_test
 // - test left-over gas refunding
 // - test recursive calls
 // - test roll-back on revert
-// - improve test setup
-// - find better place for those tests
 
-import (
-	"fmt"
-	"testing"
+func getScenarios() map[string]Scenario {
 
-	"github.com/Fantom-foundation/Tosca/go/integration_test"
-	"github.com/Fantom-foundation/Tosca/go/tosca"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
-	"go.uber.org/mock/gomock"
+	// TODO: improve organization of test scenarios
 
-	_ "github.com/Fantom-foundation/Tosca/go/processor/opera"
+	createdAddress := tosca.Address(crypto.CreateAddress(common.Address{1}, 4))
+	return map[string]Scenario{
+		"SuccessfulValueTransfer": {
+			Before: WorldState{
+				{1}: Account{Balance: tosca.ValueFromUint64(100), Nonce: 4},
+			},
+			Transaction: tosca.Transaction{
+				Sender:    tosca.Address{1},
+				Recipient: &tosca.Address{2},
+				GasLimit:  21_000,
+				Value:     tosca.ValueFromUint64(3),
+				Nonce:     4,
+			},
+			After: WorldState{
+				{1}: Account{Balance: tosca.ValueFromUint64(97), Nonce: 5},
+				{2}: Account{Balance: tosca.ValueFromUint64(3)},
+			},
+			Receipt: tosca.Receipt{
+				Success: true,
+				GasUsed: 21_000,
+			},
+		},
+		"FailedValueTransfer": {
+			Before: WorldState{
+				{1}: Account{Balance: tosca.ValueFromUint64(10), Nonce: 4},
+			},
+			Transaction: tosca.Transaction{
+				Sender:    tosca.Address{1},
+				Recipient: &tosca.Address{2},
+				GasLimit:  21_000,
+				Value:     tosca.ValueFromUint64(20),
+				Nonce:     4,
+			},
+			After: WorldState{
+				{1}: Account{Balance: tosca.ValueFromUint64(10), Nonce: 5},
+			},
+			Receipt: tosca.Receipt{
+				Success: false,
+				GasUsed: 21_000,
+			},
+		},
+		"SuccessfulContractCall": {
+			Before: WorldState{
+				{1}: Account{Balance: tosca.ValueFromUint64(100), Nonce: 4},
+				{2}: Account{Balance: tosca.ValueFromUint64(0),
+					Code: tosca.Code{
+						byte(op.PUSH1), byte(0), // < push 0
+						byte(op.PUSH1), byte(0), // < push 0
+						byte(op.RETURN),
+					},
+				},
+			},
+			Transaction: tosca.Transaction{
+				Sender:    tosca.Address{1},
+				Recipient: &tosca.Address{2},
+				GasLimit:  21_000 + 2*3, // < value transfer + 2 push instructions (return is free)
+				Value:     tosca.ValueFromUint64(3),
+				Nonce:     4,
+			},
+			After: WorldState{
+				{1}: Account{Balance: tosca.ValueFromUint64(97), Nonce: 5},
+				{2}: Account{Balance: tosca.ValueFromUint64(3),
+					Code: tosca.Code{
+						byte(op.PUSH1), byte(0), // < push 0
+						byte(op.PUSH1), byte(0), // < push 0
+						byte(op.RETURN),
+					},
+				},
+			},
+			Receipt: tosca.Receipt{
+				Success: true,
+				GasUsed: 21_000 + 2*3,
+			},
+		},
+		"RevertingContractCall": {
+			Before: WorldState{
+				{1}: Account{Balance: tosca.ValueFromUint64(100), Nonce: 4},
+				{2}: Account{Balance: tosca.ValueFromUint64(0),
+					Code: tosca.Code{
+						byte(op.PUSH1), byte(0), // < push 0
+						byte(op.PUSH1), byte(0), // < push 0
+						byte(op.REVERT),
+					},
+				},
+			},
+			Transaction: tosca.Transaction{
+				Sender:    tosca.Address{1},
+				Recipient: &tosca.Address{2},
+				GasLimit:  21_000 + 2*3, // < value transfer + 2 push instructions (return is free)
+				Value:     tosca.ValueFromUint64(3),
+				Nonce:     4,
+			},
+			After: WorldState{
+				{1}: Account{Balance: tosca.ValueFromUint64(100), Nonce: 5},
+				{2}: Account{Balance: tosca.ValueFromUint64(0),
+					Code: tosca.Code{
+						byte(op.PUSH1), byte(0), // < push 0
+						byte(op.PUSH1), byte(0), // < push 0
+						byte(op.REVERT),
+					},
+				},
+			},
+			Receipt: tosca.Receipt{
+				Success: false,
+				GasUsed: 21_000 + 2*3,
+			},
+		},
 
-	// This is only imported to get the EVM opcode definitions.
-	// TODO: write up our own op-code definition and remove this dependency.
-	op "github.com/ethereum/go-ethereum/core/vm"
-)
-
-func TestProcessor_SimpleValueTransfer(t *testing.T) {
-	const transferCosts = tosca.Gas(21_000)
-
-	// Transfer 3 tokens from account 1 to account 2.
-	transaction := tosca.Transaction{
-		Sender:    tosca.Address{1},
-		Recipient: &tosca.Address{2},
-		Value:     tosca.ValueFromUint64(3),
-		Nonce:     4,
-		GasLimit:  transferCosts,
+		"SuccessfulContractCreation": {
+			Before: WorldState{
+				{1}: Account{Balance: tosca.ValueFromUint64(100), Nonce: 4},
+			},
+			Transaction: tosca.Transaction{
+				Sender:   tosca.Address{1},
+				GasLimit: 53_000,
+				Value:    tosca.ValueFromUint64(3),
+				Nonce:    4,
+			},
+			After: WorldState{
+				{1}: Account{Balance: tosca.ValueFromUint64(97), Nonce: 5},
+				createdAddress: Account{
+					Balance: tosca.ValueFromUint64(3),
+					Nonce:   1,
+					Code:    tosca.Code{},
+				},
+			},
+			Receipt: tosca.Receipt{
+				Success:         true,
+				GasUsed:         53_000,
+				ContractAddress: &createdAddress,
+			},
+		},
 	}
+}
 
-	for name, processor := range getProcessors() {
+func RunProcessorTests(t *testing.T, processor tosca.Processor) {
+	for name, s := range getScenarios() {
 		t.Run(name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			blockParams := tosca.BlockParameters{}
-
-			// TODO: clean up expectations
-			// TODO: provide a better way to define expectations that is less
-			// sensitive to implementation details; focus on effects
-			// - use a before/after pattern
-			context := tosca.NewMockTransactionContext(ctrl)
-
-			context.EXPECT().CreateSnapshot()
-			context.EXPECT().GetBalance(tosca.Address{1}).Return(tosca.ValueFromUint64(10)).AnyTimes()
-			context.EXPECT().GetBalance(tosca.Address{2}).Return(tosca.ValueFromUint64(5)).AnyTimes()
-
-			context.EXPECT().AccountExists(tosca.Address{2}).Return(true)
-			context.EXPECT().GetCode(tosca.Address{2}).Return([]byte{})
-			context.EXPECT().GetNonce(tosca.Address{1}).Return(uint64(4)).Times(2)
-			context.EXPECT().SetNonce(tosca.Address{1}, uint64(5)).Return()
-			context.EXPECT().GetCodeHash(tosca.Address{1}).Return(tosca.Hash{})
-
-			context.EXPECT().SetBalance(tosca.Address{1}, tosca.ValueFromUint64(10)).MinTimes(1) // < charging gas, but price is zero
-			context.EXPECT().SetBalance(tosca.Address{1}, tosca.ValueFromUint64(7))              // < withdraw 3 tokens
-			context.EXPECT().SetBalance(tosca.Address{2}, tosca.ValueFromUint64(8))              // < deposit 3 tokens
-
-			context.EXPECT().GetLogs()
-
-			// Execute the transaction.
-			receipt, err := processor.Run(blockParams, transaction, context)
-			if err != nil {
-				t.Errorf("error: %v", err)
-			}
-
-			// Check the result.
-			if got, want := receipt.Success, true; got != want {
-				t.Errorf("unexpected success: got %v, want %v", got, want)
-			}
-			if want, got := transferCosts, receipt.GasUsed; want != got {
-				t.Errorf("unexpected gas costs: want %d, got %d", want, got)
-			}
+			s.Run(t, processor)
 		})
 	}
 }
 
-func TestProcessor_ContractCallThatSucceeds(t *testing.T) {
-	const gasCosts = tosca.Gas(21_000 + 2*3)
-
-	// A call to the contract at address 2 paid by account 1.
-	transaction := tosca.Transaction{
-		Sender:    tosca.Address{1},
-		Recipient: &tosca.Address{2},
-		Nonce:     4,
-		GasLimit:  gasCosts,
-	}
-
+func TestProcessor_Scenarios(t *testing.T) {
 	for name, processor := range getProcessors() {
 		t.Run(name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			blockParams := tosca.BlockParameters{}
-
-			context := tosca.NewMockTransactionContext(ctrl)
-
-			context.EXPECT().CreateSnapshot()
-			context.EXPECT().GetBalance(tosca.Address{1}).Return(tosca.ValueFromUint64(10)).AnyTimes()
-			context.EXPECT().GetBalance(tosca.Address{2}).Return(tosca.ValueFromUint64(5)).AnyTimes()
-
-			context.EXPECT().GetNonce(tosca.Address{1}).Return(uint64(4)).Times(2)
-			context.EXPECT().SetNonce(tosca.Address{1}, uint64(5)).Return()
-			context.EXPECT().GetCodeHash(tosca.Address{1}).Return(tosca.Hash{})
-
-			context.EXPECT().AccountExists(tosca.Address{2}).Return(true)
-
-			code := []byte{
-				byte(op.PUSH1), byte(0), // < push 0
-				byte(op.PUSH1), byte(0), // < push 0
-				byte(op.RETURN),
-			}
-			context.EXPECT().GetCode(tosca.Address{2}).Return(code)
-			context.EXPECT().GetCodeHash(tosca.Address{2}).Return(integration_test.Keccak256Hash(code))
-
-			context.EXPECT().SetBalance(tosca.Address{1}, tosca.ValueFromUint64(10)).MinTimes(1) // < charging gas, but price is zero
-
-			context.EXPECT().GetLogs()
-
-			// Execute the transaction.
-			receipt, err := processor.Run(blockParams, transaction, context)
-			if err != nil {
-				t.Errorf("error: %v", err)
-			}
-
-			// Check the result.
-			if got, want := receipt.Success, true; got != want {
-				t.Errorf("unexpected success: got %v, want %v", got, want)
-			}
-			if want, got := gasCosts, receipt.GasUsed; want != got {
-				t.Errorf("unexpected gas costs: want %d, got %d", want, got)
-			}
-		})
-	}
-}
-
-func TestProcessor_ContractCallThatReverts(t *testing.T) {
-	const gasCosts = tosca.Gas(21_000 + 2*3)
-
-	// A call to the contract at address 2 paid by account 1.
-	transaction := tosca.Transaction{
-		Sender:    tosca.Address{1},
-		Recipient: &tosca.Address{2},
-		Nonce:     4,
-		GasLimit:  gasCosts,
-	}
-
-	for name, processor := range getProcessors() {
-		t.Run(name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			blockParams := tosca.BlockParameters{}
-
-			context := tosca.NewMockTransactionContext(ctrl)
-
-			context.EXPECT().CreateSnapshot().Return(tosca.Snapshot(12))
-			context.EXPECT().RestoreSnapshot(tosca.Snapshot(12))
-
-			context.EXPECT().GetBalance(tosca.Address{1}).Return(tosca.ValueFromUint64(10)).AnyTimes()
-			context.EXPECT().GetBalance(tosca.Address{2}).Return(tosca.ValueFromUint64(5)).AnyTimes()
-
-			context.EXPECT().GetNonce(tosca.Address{1}).Return(uint64(4)).Times(2)
-			context.EXPECT().SetNonce(tosca.Address{1}, uint64(5)).Return()
-
-			context.EXPECT().GetCodeHash(tosca.Address{1}).Return(tosca.Hash{})
-
-			context.EXPECT().AccountExists(tosca.Address{2}).Return(true)
-
-			code := []byte{
-				byte(op.PUSH1), byte(0), // < push 0
-				byte(op.PUSH1), byte(0), // < push 0
-				byte(op.REVERT),
-			}
-			context.EXPECT().GetCode(tosca.Address{2}).Return(code)
-			context.EXPECT().GetCodeHash(tosca.Address{2}).Return(integration_test.Keccak256Hash(code))
-
-			context.EXPECT().SetBalance(tosca.Address{1}, tosca.ValueFromUint64(10)).MinTimes(1) // < charging gas, but price is zero
-
-			context.EXPECT().GetLogs()
-
-			// Execute the transaction.
-			receipt, err := processor.Run(blockParams, transaction, context)
-			if err != nil {
-				t.Errorf("error: %v", err)
-			}
-
-			// Check the result.
-			if got, want := receipt.Success, false; got != want {
-				t.Errorf("unexpected success: got %v, want %v", got, want)
-			}
-
-			if want, got := gasCosts, receipt.GasUsed; want != got {
-				t.Errorf("unexpected gas costs: want %d, got %d", want, got)
-			}
-		})
-	}
-}
-
-func TestProcessor_ContractCreation(t *testing.T) {
-	const gasCosts = tosca.Gas(53_000)
-
-	// Transfer 3*2^(31*8) tokens from account 1 to account 2.
-	transaction := tosca.Transaction{
-		Sender:   tosca.Address{1},
-		Nonce:    4,
-		GasLimit: gasCosts,
-	}
-
-	// The new contract address is derived from the sender's address and the nonce.
-	newContractAddress := tosca.Address(crypto.CreateAddress(common.Address{1}, 4))
-
-	for name, processor := range getProcessors() {
-		t.Run(name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			blockParams := tosca.BlockParameters{}
-
-			context := tosca.NewMockTransactionContext(ctrl)
-
-			context.EXPECT().CreateSnapshot()
-			context.EXPECT().GetBalance(tosca.Address{1}).Return(tosca.ValueFromUint64(10)).AnyTimes()
-			context.EXPECT().SetBalance(tosca.Address{1}, tosca.ValueFromUint64(10)).MinTimes(1) // < charging gas, but price is zero
-
-			context.EXPECT().GetNonce(tosca.Address{1}).Return(uint64(4)).Times(3)
-			context.EXPECT().SetNonce(tosca.Address{1}, uint64(5)).Return()
-
-			context.EXPECT().AccountExists(newContractAddress).Return(false)
-			context.EXPECT().GetNonce(newContractAddress).Return(uint64(0))
-			context.EXPECT().SetNonce(newContractAddress, uint64(1)).Return()
-
-			context.EXPECT().GetCodeHash(tosca.Address{1}).Return(tosca.Hash{})
-			context.EXPECT().GetCodeHash(newContractAddress).Return(tosca.Hash{})
-
-			context.EXPECT().SetCode(newContractAddress, gomock.Any()).Do(func(address tosca.Address, code []byte) {
-				if len(code) != 0 {
-					t.Fatalf("unexpected code: %x", code)
-				}
-			})
-
-			context.EXPECT().GetLogs()
-
-			// Execute the transaction.
-			receipt, err := processor.Run(blockParams, transaction, context)
-			if err != nil {
-				t.Errorf("error: %v", err)
-			}
-
-			// Check the result.
-			if got, want := receipt.Success, true; got != want {
-				t.Errorf("unexpected success: got %v, want %v", got, want)
-			}
-
-			if want, got := gasCosts, receipt.GasUsed; want != got {
-				t.Errorf("unexpected gas costs: want %d, got %d", want, got)
-			}
-			if receipt.ContractAddress == nil {
-				t.Fatalf("created contract address not set in result")
-			}
-			if *receipt.ContractAddress != newContractAddress {
-				t.Errorf("unexpected result for created contract address, wanted %v, got %v", newContractAddress, *receipt.ContractAddress)
-			}
+			RunProcessorTests(t, processor)
 		})
 	}
 }

--- a/go/integration_test/processor/scenario.go
+++ b/go/integration_test/processor/scenario.go
@@ -1,3 +1,13 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
 package processor
 
 import (

--- a/go/integration_test/processor/scenario.go
+++ b/go/integration_test/processor/scenario.go
@@ -26,7 +26,7 @@ import (
 type Scenario struct {
 	Before      WorldState
 	After       WorldState
-	Parameter   tosca.BlockParameters
+	Parameters  tosca.BlockParameters
 	Transaction tosca.Transaction
 	Receipt     tosca.Receipt
 }
@@ -34,7 +34,7 @@ type Scenario struct {
 func (s *Scenario) Run(t *testing.T, processor tosca.Processor) {
 
 	context := newScenarioContext(s.Before)
-	receipt, err := processor.Run(s.Parameter, s.Transaction, context)
+	receipt, err := processor.Run(s.Parameters, s.Transaction, context)
 	if err != nil {
 		t.Fatalf("failed to run transaction: %v", err)
 	}

--- a/go/integration_test/processor/scenario.go
+++ b/go/integration_test/processor/scenario.go
@@ -1,0 +1,228 @@
+package processor
+
+import (
+	"bytes"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/integration_test"
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+)
+
+// Scenario represents a test scenario for a transaction processor. A scenario
+// consists of a world state before and after the operation, a transaction to
+// be executed, block chain parameters, and the expected receipt.
+type Scenario struct {
+	Before      WorldState
+	After       WorldState
+	Parameter   tosca.BlockParameters
+	Transaction tosca.Transaction
+	Receipt     tosca.Receipt
+}
+
+func (s *Scenario) Run(t *testing.T, processor tosca.Processor) {
+
+	context := newScenarioContext(s.Before)
+	receipt, err := processor.Run(s.Parameter, s.Transaction, context)
+	if err != nil {
+		t.Fatalf("failed to run transaction: %v", err)
+	}
+
+	// check the world state after the operation
+	if want, got := s.After, context.current; !want.Equal(got) {
+		diff := strings.Join(got.Diff(want), "\n\t")
+		t.Fatalf("unexpected world state after the operation: \n\t%v", diff)
+	}
+
+	// check the receipt
+	if want, got := s.Receipt.Success, receipt.Success; want != got {
+		t.Errorf("unexpected success, want %v, got %v", want, got)
+	}
+	if want, got := s.Receipt.GasUsed, receipt.GasUsed; want != got {
+		t.Errorf("unexpected gas used, want %v, got %v", want, got)
+	}
+	if want, got := s.Receipt.BlobGasUsed, receipt.BlobGasUsed; want != got {
+		t.Errorf("unexpected blob gas used, want %v, got %v", want, got)
+	}
+	if want, got := s.Receipt.Output, receipt.Output; !bytes.Equal(want, got) {
+		t.Errorf("unexpected output used, want %x, got %x", want, got)
+	}
+
+	wantedCreatedContract := s.Receipt.ContractAddress
+	gotCreatedContract := receipt.ContractAddress
+	if wantedCreatedContract == nil && gotCreatedContract != nil {
+		t.Errorf("unexpected created contract address, want nil, got %v", gotCreatedContract)
+	}
+	if wantedCreatedContract != nil && gotCreatedContract == nil {
+		t.Errorf("unexpected created contract address, want %v, got nil", wantedCreatedContract)
+	}
+	if wantedCreatedContract != nil && gotCreatedContract != nil {
+		if want, got := *wantedCreatedContract, *gotCreatedContract; want != got {
+			t.Errorf("unexpected created contract address, want %v, got %v", want, got)
+		}
+	}
+
+	if len(receipt.Logs) != len(s.Receipt.Logs) {
+		t.Fatalf("unexpected receipt logs: %v", receipt.Logs)
+	} else {
+		for i, want := range s.Receipt.Logs {
+			got := receipt.Logs[i]
+			if want, got := want.Address, got.Address; want != got {
+				t.Errorf("unexpected receipt log address, want %v, got %v", want, got)
+			}
+			if want, got := want.Topics, got.Topics; !slices.Equal(want, got) {
+				t.Errorf("unexpected receipt log topics, want %v, got %v", want, got)
+			}
+			if want, got := want.Data, got.Data; !bytes.Equal(want, got) {
+				t.Errorf("unexpected receipt data, want %x, got %x", want, got)
+			}
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+
+// scenarioContext implements the tosca.WorldState interface facilitating the
+// interaction with a test-case specific context.
+type scenarioContext struct {
+	original WorldState
+	current  WorldState
+	logs     []tosca.Log
+	undo     []func()
+}
+
+func newScenarioContext(initial WorldState) *scenarioContext {
+	return &scenarioContext{
+		original: initial,
+		current:  initial.Clone(),
+	}
+}
+
+func (c *scenarioContext) AccountExists(addr tosca.Address) bool {
+	return c.GetBalance(addr) != tosca.Value{} || c.GetNonce(addr) != 0 || c.GetCodeSize(addr) != 0
+}
+
+func (c *scenarioContext) GetBalance(addr tosca.Address) tosca.Value {
+	return c.current[addr].Balance
+}
+
+func (c *scenarioContext) SetBalance(addr tosca.Address, value tosca.Value) {
+	original := c.current[addr]
+	modified := original
+	modified.Balance = value
+	c.current[addr] = modified
+	c.undo = append(c.undo, func() { c.current[addr] = original })
+}
+
+func (c *scenarioContext) GetNonce(addr tosca.Address) uint64 {
+	return c.current[addr].Nonce
+}
+
+func (c *scenarioContext) SetNonce(addr tosca.Address, value uint64) {
+	original := c.current[addr]
+	modified := original
+	modified.Nonce = value
+	c.current[addr] = modified
+	c.undo = append(c.undo, func() { c.current[addr] = original })
+}
+
+func (c *scenarioContext) GetCode(addr tosca.Address) tosca.Code {
+	return tosca.Code(bytes.Clone(c.current[addr].Code))
+}
+
+func (c *scenarioContext) GetCodeHash(addr tosca.Address) tosca.Hash {
+	return integration_test.Keccak256Hash(c.GetCode(addr))
+}
+
+func (c *scenarioContext) GetCodeSize(addr tosca.Address) int {
+	return len(c.GetCode(addr))
+}
+
+func (c *scenarioContext) SetCode(addr tosca.Address, code tosca.Code) {
+	original := c.current[addr]
+	modified := original
+	modified.Code = tosca.Code(bytes.Clone(code))
+	c.current[addr] = modified
+	c.undo = append(c.undo, func() { c.current[addr] = original })
+}
+
+func (c *scenarioContext) GetStorage(addr tosca.Address, key tosca.Key) tosca.Word {
+	return c.current[addr].Storage[key]
+}
+
+func (c *scenarioContext) SetStorage(addr tosca.Address, key tosca.Key, new tosca.Word) tosca.StorageStatus {
+	original := c.original[addr].Storage[key]
+	current := c.current[addr].Storage[key]
+
+	account := c.current[addr]
+	if account.Storage == nil {
+		account.Storage = Storage{}
+		c.current[addr] = account
+	}
+
+	c.current[addr].Storage[key] = new
+	c.undo = append(c.undo, func() { c.current[addr].Storage[key] = current })
+	return tosca.GetStorageStatus(original, current, new)
+}
+
+func (c *scenarioContext) SelfDestruct(addr tosca.Address, beneficiary tosca.Address) bool {
+	panic("implement me")
+}
+
+func (c *scenarioContext) CreateSnapshot() tosca.Snapshot {
+	return tosca.Snapshot(len(c.undo))
+}
+
+func (c *scenarioContext) RestoreSnapshot(snapshot tosca.Snapshot) {
+	for len(c.undo) > int(snapshot) {
+		c.undo[len(c.undo)-1]()
+		c.undo = c.undo[:len(c.undo)-1]
+	}
+}
+
+func (c *scenarioContext) GetTransientStorage(tosca.Address, tosca.Key) tosca.Word {
+	panic("implement me")
+}
+
+func (c *scenarioContext) SetTransientStorage(tosca.Address, tosca.Key, tosca.Word) {
+	panic("implement me")
+}
+
+func (c *scenarioContext) AccessAccount(tosca.Address) tosca.AccessStatus {
+	panic("implement me")
+}
+
+func (c *scenarioContext) AccessStorage(tosca.Address, tosca.Key) tosca.AccessStatus {
+	panic("implement me")
+}
+
+func (c *scenarioContext) EmitLog(log tosca.Log) {
+	len := len(c.logs)
+	c.logs = append(c.logs, log)
+	c.undo = append(c.undo, func() { c.logs = c.logs[:len] })
+}
+
+func (c *scenarioContext) GetLogs() []tosca.Log {
+	return slices.Clone(c.logs)
+}
+
+func (c *scenarioContext) GetBlockHash(number int64) tosca.Hash {
+	panic("implement me")
+}
+
+func (c *scenarioContext) GetCommittedStorage(addr tosca.Address, key tosca.Key) tosca.Word {
+	panic("implement me")
+}
+
+func (c *scenarioContext) IsAddressInAccessList(addr tosca.Address) bool {
+	panic("implement me")
+}
+
+func (c *scenarioContext) IsSlotInAccessList(addr tosca.Address, key tosca.Key) (addressPresent, slotPresent bool) {
+	panic("implement me")
+}
+
+func (c *scenarioContext) HasSelfDestructed(addr tosca.Address) bool {
+	panic("implement me")
+}

--- a/go/integration_test/processor/scenario_test.go
+++ b/go/integration_test/processor/scenario_test.go
@@ -1,0 +1,195 @@
+package processor
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/integration_test"
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+)
+
+func TestScenarioContext_AccountsAreImplictilyCreated(t *testing.T) {
+	addr := tosca.Address{1}
+	tests := map[string]func(tosca.WorldState){
+		"balance": func(s tosca.WorldState) {
+			s.SetBalance(addr, tosca.ValueFromUint64(100))
+		},
+		"nonce": func(s tosca.WorldState) {
+			s.SetNonce(addr, 12)
+		},
+		"code": func(s tosca.WorldState) {
+			s.SetCode(addr, tosca.Code{1, 2, 3})
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			context := newScenarioContext(WorldState{})
+
+			if context.AccountExists(addr) {
+				t.Errorf("test account should not exist")
+			}
+			test(context)
+			if !context.AccountExists(addr) {
+				t.Errorf("account should exist")
+			}
+		})
+	}
+}
+
+func TestScenarioContext_BalanceManipulation(t *testing.T) {
+	context := newScenarioContext(WorldState{})
+
+	addr := tosca.Address{1}
+	if want, got := (tosca.Value{}), context.GetBalance(addr); got != want {
+		t.Errorf("unexpected balance, want %v, got %v", want, got)
+	}
+
+	snapshot := context.CreateSnapshot()
+
+	context.SetBalance(addr, tosca.ValueFromUint64(100))
+	if want, got := tosca.ValueFromUint64(100), context.GetBalance(addr); got != want {
+		t.Errorf("unexpected balance, want %v, got %v", want, got)
+	}
+
+	context.RestoreSnapshot(snapshot)
+
+	if want, got := (tosca.Value{}), context.GetBalance(addr); got != want {
+		t.Errorf("unexpected balance, want %v, got %v", want, got)
+	}
+}
+
+func TestScenarioContext_NonceManipulation(t *testing.T) {
+	context := newScenarioContext(WorldState{})
+
+	addr := tosca.Address{1}
+	if want, got := uint64(0), context.GetNonce(addr); got != want {
+		t.Errorf("unexpected nonce, want %v, got %v", want, got)
+	}
+
+	snapshot := context.CreateSnapshot()
+
+	context.SetNonce(addr, 12)
+	if want, got := uint64(12), context.GetNonce(addr); got != want {
+		t.Errorf("unexpected nonce, want %v, got %v", want, got)
+	}
+
+	context.RestoreSnapshot(snapshot)
+
+	if want, got := uint64(0), context.GetNonce(addr); got != want {
+		t.Errorf("unexpected nonce, want %v, got %v", want, got)
+	}
+}
+
+func TestScenarioContext_CodeManipulation(t *testing.T) {
+	context := newScenarioContext(WorldState{})
+
+	addr := tosca.Address{1}
+	if want, got := (tosca.Code{}), context.GetCode(addr); !bytes.Equal(want, got) {
+		t.Errorf("unexpected code, want %x, got %x", want, got)
+	}
+
+	snapshot := context.CreateSnapshot()
+
+	context.SetCode(addr, tosca.Code{1, 2, 3})
+	if want, got := (tosca.Code{1, 2, 3}), context.GetCode(addr); !bytes.Equal(want, got) {
+		t.Errorf("unexpected code, want %x, got %x", want, got)
+	}
+
+	context.RestoreSnapshot(snapshot)
+
+	if want, got := (tosca.Code{}), context.GetCode(addr); !bytes.Equal(want, got) {
+		t.Errorf("unexpected code, want %x, got %x", want, got)
+	}
+}
+
+func TestScenarioContext_StorageManipulation(t *testing.T) {
+	context := newScenarioContext(WorldState{})
+
+	addr := tosca.Address{1}
+	key := tosca.Key{2}
+	if want, got := (tosca.Word{}), context.GetStorage(addr, key); got != want {
+		t.Errorf("unexpected storage, want %v, got %v", want, got)
+	}
+
+	snapshot := context.CreateSnapshot()
+
+	if want, got := tosca.StorageAdded, context.SetStorage(addr, key, tosca.Word{12}); want != got {
+		t.Errorf("unexpected storage change, want %v, got %v", want, got)
+	}
+
+	if want, got := (tosca.Word{12}), context.GetStorage(addr, key); got != want {
+		t.Errorf("unexpected storage, want %v, got %v", want, got)
+	}
+
+	context.RestoreSnapshot(snapshot)
+
+	if want, got := (tosca.Word{}), context.GetStorage(addr, key); got != want {
+		t.Errorf("unexpected storage, want %v, got %v", want, got)
+	}
+}
+
+func TestScenarioContext_CodeQuery(t *testing.T) {
+	context := newScenarioContext(WorldState{})
+
+	addr := tosca.Address{1}
+
+	emptyHash := integration_test.Keccak256Hash(tosca.Code{})
+
+	if want, got := emptyHash, context.GetCodeHash(addr); want != got {
+		t.Errorf("unexpected code hash, want %x, got %x", want, got)
+	}
+	if want, got := 0, context.GetCodeSize(addr); want != got {
+		t.Errorf("unexpected code length, want %x, got %x", want, got)
+	}
+
+	code := tosca.Code{1, 2, 3}
+	codeHash := integration_test.Keccak256Hash(code)
+	context.SetCode(addr, code)
+
+	if want, got := codeHash, context.GetCodeHash(addr); want != got {
+		t.Errorf("unexpected code hash, want %x, got %x", want, got)
+	}
+	if want, got := len(code), context.GetCodeSize(addr); want != got {
+		t.Errorf("unexpected code length, want %x, got %x", want, got)
+	}
+}
+
+func TestScenarioContext_LogManipulation(t *testing.T) {
+	context := newScenarioContext(WorldState{})
+
+	l1 := tosca.Log{Address: tosca.Address{1}}
+	l2 := tosca.Log{Address: tosca.Address{2}}
+	if want, got := 0, len(context.GetLogs()); want != got {
+		t.Errorf("unexpected length of logs, want %v, got %v", want, got)
+	}
+
+	s1 := context.CreateSnapshot()
+
+	context.EmitLog(l1)
+
+	if want, got := []tosca.Log{l1}, context.GetLogs(); !reflect.DeepEqual(want, got) {
+		t.Errorf("unexpected logs, want %v, got %v", want, got)
+	}
+
+	s2 := context.CreateSnapshot()
+
+	context.EmitLog(l2)
+
+	if want, got := []tosca.Log{l1, l2}, context.GetLogs(); !reflect.DeepEqual(want, got) {
+		t.Errorf("unexpected logs, want %v, got %v", want, got)
+	}
+
+	context.RestoreSnapshot(s2)
+
+	if want, got := []tosca.Log{l1}, context.GetLogs(); !reflect.DeepEqual(want, got) {
+		t.Errorf("unexpected logs, want %v, got %v", want, got)
+	}
+
+	context.RestoreSnapshot(s1)
+
+	if want, got := 0, len(context.GetLogs()); want != got {
+		t.Errorf("unexpected length of logs, want %v, got %v", want, got)
+	}
+}

--- a/go/integration_test/processor/scenario_test.go
+++ b/go/integration_test/processor/scenario_test.go
@@ -1,3 +1,13 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
 package processor
 
 import (

--- a/go/integration_test/processor/world_state.go
+++ b/go/integration_test/processor/world_state.go
@@ -1,3 +1,13 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
 package processor
 
 import (

--- a/go/integration_test/processor/world_state.go
+++ b/go/integration_test/processor/world_state.go
@@ -1,0 +1,156 @@
+package processor
+
+import (
+	"bytes"
+	"fmt"
+	"maps"
+
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+)
+
+// ----------------------------------------------------------------------------
+// WorldState
+// ----------------------------------------------------------------------------
+
+// WorldState provides a utility function to model the world state of a chain
+// for testing. It is mainly intended to be used to define pre/post states of
+// test scenarios for transaction processors.
+type WorldState map[tosca.Address]Account
+
+func (s WorldState) Equal(other WorldState) bool {
+	return equalMapsIgnoringZero(s, other, func(a, b Account) bool {
+		return a.Equal(&b)
+	})
+}
+
+func (s WorldState) Clone() WorldState {
+	if s == nil {
+		return nil
+	}
+	res := make(WorldState, len(s))
+	for k, v := range s {
+		res[k] = v.Clone()
+	}
+	return res
+}
+
+func (s WorldState) Diff(other WorldState) []string {
+	return diffMaps("", s, other, func(address tosca.Address, a, b Account) []string {
+		if a.Equal(&b) {
+			return nil
+		}
+		return a.Diff(fmt.Sprintf("%v/", address), &b)
+	})
+}
+
+// ----------------------------------------------------------------------------
+// Account
+// ----------------------------------------------------------------------------
+
+// Account represents an account in the world state. The default account is
+// an empty account, that is ignored by the world state.
+type Account struct {
+	Balance tosca.Value
+	Nonce   uint64
+	Code    tosca.Code
+	Storage Storage
+}
+
+func (a *Account) Equal(other *Account) bool {
+	return a.Balance == other.Balance &&
+		a.Nonce == other.Nonce &&
+		bytes.Equal(a.Code, other.Code) &&
+		a.Storage.Equal(other.Storage)
+}
+
+func (a *Account) Clone() Account {
+	return Account{
+		Balance: a.Balance,
+		Nonce:   a.Nonce,
+		Code:    append(tosca.Code(nil), a.Code...),
+		Storage: a.Storage.Clone(),
+	}
+}
+
+func (a *Account) Diff(prefix string, other *Account) []string {
+	var res []string
+	if a.Balance != other.Balance {
+		res = append(res, fmt.Sprintf("different balance: %v != %v", a.Balance, other.Balance))
+	}
+	if a.Nonce != other.Nonce {
+		res = append(res, fmt.Sprintf("different nonce: %v != %v", a.Nonce, other.Nonce))
+	}
+	if !bytes.Equal(a.Code, other.Code) {
+		res = append(res, fmt.Sprintf("different code: 0x%x != 0x%x", a.Code, other.Code))
+	}
+	res = append(res, a.Storage.Diff(prefix+"Storage/", other.Storage)...)
+	for i, diff := range res {
+		res[i] = prefix + diff
+	}
+	return res
+}
+
+// ----------------------------------------------------------------------------
+// Storage
+// ----------------------------------------------------------------------------
+
+// Storage represents the storage of an account in the world state. Zero-valued
+// entries are ignored in the storage.
+type Storage map[tosca.Key]tosca.Word
+
+func (s Storage) Equal(other Storage) bool {
+	return equalMapsIgnoringZero(s, other, func(a, b tosca.Word) bool {
+		return a == b
+	})
+}
+
+func (s Storage) Clone() Storage {
+	return maps.Clone(s)
+}
+
+func (s Storage) Diff(prefix string, other Storage) []string {
+	return diffMaps(prefix, s, other, func(k tosca.Key, a, b tosca.Word) []string {
+		if a == b {
+			return nil
+		}
+		return []string{
+			fmt.Sprintf("different value for key %v: %v != %v", k, a, b),
+		}
+	})
+}
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+// equalMapsIgnoringZero compares two maps, ignoring zero-valued entries.
+func equalMapsIgnoringZero[K comparable, V any](a, b map[K]V, equal func(V, V) bool) bool {
+	for k, v := range a {
+		if !equal(v, b[k]) {
+			return false
+		}
+	}
+	for k, v := range b {
+		if !equal(v, a[k]) {
+			return false
+		}
+	}
+	return true
+}
+
+// diffMaps compares two maps and returns a list of differences.
+func diffMaps[K comparable, V any](prefix string, a, b map[K]V, diff func(K, V, V) []string) []string {
+	var diffs []string
+	for k, v := range a {
+		diffs = append(diffs, diff(k, v, b[k])...)
+	}
+	for k, v := range b {
+		if _, overlap := a[k]; !overlap {
+			diffs = append(diffs, diff(k, a[k], v)...)
+		}
+	}
+	for i, diff := range diffs {
+		diffs[i] = prefix + diff
+	}
+	return diffs
+}

--- a/go/integration_test/processor/world_state_test.go
+++ b/go/integration_test/processor/world_state_test.go
@@ -1,3 +1,13 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
 package processor
 
 import (

--- a/go/integration_test/processor/world_state_test.go
+++ b/go/integration_test/processor/world_state_test.go
@@ -1,0 +1,555 @@
+package processor
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+
+	// This is only imported to get the EVM opcode definitions.
+	// TODO: write up our own op-code definition and remove this dependency.
+	op "github.com/ethereum/go-ethereum/core/vm"
+)
+
+func TestWorldState_Equal(t *testing.T) {
+
+	tests := map[string]struct {
+		a, b WorldState
+	}{
+		"both_nil": {},
+		"left_hand_side_nil": {
+			b: WorldState{},
+		},
+		"zero_accounts_are_ignored": {
+			a: WorldState{
+				{1}: Account{},
+			},
+			b: WorldState{
+				{2}: Account{},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if !test.a.Equal(test.b) {
+				t.Errorf("world states %v and %v are expected to be equivalent, but they are not", test.a, test.b)
+			}
+		})
+	}
+}
+
+func TestWorldState_Clone(t *testing.T) {
+	tests := map[string]struct {
+		a WorldState
+	}{
+		"empty": {},
+		"singleton": {
+			a: WorldState{
+				{1}: Account{},
+			},
+		},
+		"multiple": {
+			a: WorldState{
+				{1}: Account{Balance: tosca.ValueFromUint64(100)},
+				{2}: Account{Balance: tosca.ValueFromUint64(200)},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			clone := test.a.Clone()
+			if !test.a.Equal(clone) {
+				t.Errorf("expected world state %v and its clone %v to be equal", test.a, clone)
+			}
+		})
+	}
+}
+
+func TestWorldState_ClonesAreIndependent(t *testing.T) {
+	addr := tosca.Address{1}
+	key := tosca.Key{1}
+	original := WorldState{
+		addr: Account{Storage: Storage{
+			key: {0x01},
+		}},
+	}
+
+	clone := original.Clone()
+	clone[addr].Storage[key] = tosca.Word{0x02}
+
+	if original[addr].Storage[key] != (tosca.Word{0x01}) {
+		t.Errorf("expected the original account to be independent from its clone")
+	}
+}
+
+func TestWorldState_Diff(t *testing.T) {
+	tests := map[string]struct {
+		a, b     WorldState
+		expected []string
+	}{
+		"both_nil": {},
+		"identical": {
+			a: WorldState{},
+			b: WorldState{},
+		},
+		"different_accounts": {
+			a:        WorldState{{1}: Account{Balance: tosca.ValueFromUint64(100)}},
+			b:        WorldState{{1}: Account{Balance: tosca.ValueFromUint64(200)}},
+			expected: []string{"0x0100000000000000000000000000000000000000/different balance: 100 != 200"},
+		},
+		"extra_accounts": {
+			a: WorldState{
+				{1}: Account{Balance: tosca.ValueFromUint64(100)},
+			},
+			b: WorldState{
+				{1}: Account{Balance: tosca.ValueFromUint64(100)},
+				{2}: Account{Balance: tosca.ValueFromUint64(200)},
+			},
+			expected: []string{"0x0200000000000000000000000000000000000000/different balance: 0 != 200"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			diffs := test.a.Diff(test.b)
+			slices.Sort(test.expected)
+			want := strings.Join(test.expected, ",")
+			slices.Sort(diffs)
+			got := strings.Join(diffs, ",")
+
+			if want != got {
+				t.Errorf("expected diffs [%v], but got [%v]", want, got)
+			}
+		})
+	}
+}
+
+func TestAccount_Equal(t *testing.T) {
+	tests := map[string]struct {
+		a, b Account
+	}{
+		"both_zero": {},
+		"identical_non_zero": {
+			a: Account{
+				Balance: tosca.ValueFromUint64(100),
+				Nonce:   4,
+				Code:    tosca.Code{byte(op.STOP)},
+				Storage: map[tosca.Key]tosca.Word{
+					{1}: {0x01},
+					{4}: {0x0F},
+				},
+			},
+			b: Account{
+				Balance: tosca.ValueFromUint64(100),
+				Nonce:   4,
+				Code:    tosca.Code{byte(op.STOP)},
+				Storage: map[tosca.Key]tosca.Word{
+					{1}: {0x01},
+					{4}: {0x0F},
+				},
+			},
+		},
+		"zero_storage_in_left_hand_side_is_ignored": {
+			a: Account{Storage: map[tosca.Key]tosca.Word{{1}: {}}},
+			b: Account{Storage: map[tosca.Key]tosca.Word{}},
+		},
+		"zero_storage_in_right_hand_side_is_ignored": {
+			a: Account{Storage: map[tosca.Key]tosca.Word{}},
+			b: Account{Storage: map[tosca.Key]tosca.Word{{1}: {}}},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if !test.a.Equal(&test.b) {
+				t.Errorf("expected accounts %v and %v to be equal", test.a, test.b)
+			}
+		})
+	}
+}
+
+func TestAccount_NotEqual(t *testing.T) {
+	tests := map[string]struct {
+		a, b Account
+	}{
+		"different_balance": {
+			a: Account{Balance: tosca.ValueFromUint64(100)},
+			b: Account{Balance: tosca.ValueFromUint64(200)},
+		},
+		"different_nonce": {
+			a: Account{Nonce: 4},
+			b: Account{Nonce: 5},
+		},
+		"different_code": {
+			a: Account{Code: tosca.Code{byte(op.STOP)}},
+			b: Account{Code: tosca.Code{byte(op.ADD)}},
+		},
+		"different_storage": {
+			a: Account{Storage: map[tosca.Key]tosca.Word{{1}: {0x01}}},
+			b: Account{Storage: map[tosca.Key]tosca.Word{{1}: {0x02}}},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if test.a.Equal(&test.b) {
+				t.Errorf("expected accounts %v and %v to be not equal", test.a, test.b)
+			}
+		})
+	}
+}
+
+func TestAccount_Clone(t *testing.T) {
+	tests := map[string]struct {
+		a Account
+	}{
+		"empty": {},
+		"non_empty": {
+			a: Account{
+				Balance: tosca.ValueFromUint64(100),
+				Nonce:   4,
+				Code:    tosca.Code{byte(op.STOP)},
+				Storage: map[tosca.Key]tosca.Word{
+					{1}: {0x01},
+					{4}: {0x0F},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			clone := test.a.Clone()
+			if !test.a.Equal(&clone) {
+				t.Errorf("expected account %v and its clone %v to be equal", test.a, clone)
+			}
+		})
+	}
+}
+
+func TestAccount_Diff(t *testing.T) {
+	tests := map[string]struct {
+		prefix   string
+		a, b     Account
+		expected []string
+	}{
+		"both_nil": {},
+		"identical": {
+			a: Account{},
+			b: Account{},
+		},
+		"different_balance": {
+			a:        Account{Balance: tosca.ValueFromUint64(100)},
+			b:        Account{Balance: tosca.ValueFromUint64(200)},
+			expected: []string{"different balance: 100 != 200"},
+		},
+		"different_nonce": {
+			a:        Account{Nonce: 4},
+			b:        Account{Nonce: 5},
+			expected: []string{"different nonce: 4 != 5"},
+		},
+		"different_code": {
+			a:        Account{Code: tosca.Code{byte(op.STOP)}},
+			b:        Account{Code: tosca.Code{byte(op.ADD), byte(op.MUL)}},
+			expected: []string{"different code: 0x00 != 0x0102"},
+		},
+		"different_storage": {
+			a:        Account{Storage: map[tosca.Key]tosca.Word{{1}: {0x01}}},
+			b:        Account{Storage: map[tosca.Key]tosca.Word{{1}: {0x02}}},
+			expected: []string{"Storage/different value for key 0x0100000000000000000000000000000000000000000000000000000000000000: 0x0100000000000000000000000000000000000000000000000000000000000000 != 0x0200000000000000000000000000000000000000000000000000000000000000"},
+		},
+		"different_balance_with_prefix": {
+			prefix:   "myContext/",
+			a:        Account{Balance: tosca.ValueFromUint64(100)},
+			b:        Account{Balance: tosca.ValueFromUint64(200)},
+			expected: []string{"myContext/different balance: 100 != 200"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			diffs := test.a.Diff(test.prefix, &test.b)
+			slices.Sort(test.expected)
+			want := strings.Join(test.expected, ",")
+			slices.Sort(diffs)
+			got := strings.Join(diffs, ",")
+
+			if want != got {
+				t.Errorf("expected diffs [%v], but got [%v]", want, got)
+			}
+		})
+	}
+}
+
+func TestStorage_Equal(t *testing.T) {
+	tests := map[string]struct {
+		a, b Storage
+	}{
+		"both_nil": {},
+		"left_hand_side_nil": {
+			b: Storage{},
+		},
+		"right_hand_side_nil": {
+			b: Storage{},
+		},
+		"singleton": {
+			a: Storage{{1}: {0x01}},
+			b: Storage{{1}: {0x01}},
+		},
+		"multiple": {
+			a: Storage{
+				{1}: {0x01},
+				{2}: {0x02},
+			},
+			b: Storage{
+				{1}: {0x01},
+				{2}: {0x02},
+			},
+		},
+		"zero_values_are_ignored": {
+			a: Storage{{1}: {0x00}},
+			b: Storage{{2}: {0x00}},
+		},
+		"zero_values_in_left_hand_side_is_ignored": {
+			a: Storage{{1}: {0x00}},
+			b: Storage{},
+		},
+		"zero_values_in_right_hand_side_is_ignored": {
+			a: Storage{},
+			b: Storage{{1}: {0x00}},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if !test.a.Equal(test.b) {
+				t.Errorf("expected storages %v and %v to be equal", test.a, test.b)
+			}
+		})
+	}
+}
+
+func TestStorage_NotEqual(t *testing.T) {
+	tests := map[string]struct {
+		a, b Storage
+	}{
+		"different_value_for_same_key": {
+			a: Storage{{1}: {0x01}},
+			b: Storage{{1}: {0x02}},
+		},
+		"extra_non_zero_entry_in_left_hand_side": {
+			a: Storage{{1}: {0x01}, {2}: {0x02}},
+			b: Storage{{1}: {0x01}},
+		},
+		"extra_non_zero_entry_in_right_hand_side": {
+			a: Storage{{1}: {0x01}},
+			b: Storage{{1}: {0x01}, {2}: {0x02}},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if test.a.Equal(test.b) {
+				t.Errorf("expected storages %v and %v to be not equal", test.a, test.b)
+			}
+		})
+	}
+}
+
+func TestStorage_Clone(t *testing.T) {
+	tests := map[string]struct {
+		a Storage
+	}{
+		"empty": {},
+		"singleton": {
+			a: Storage{{1}: {0x01}},
+		},
+		"multiple": {
+			a: Storage{
+				{1}: {0x01},
+				{2}: {0x02},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			clone := test.a.Clone()
+			if !test.a.Equal(clone) {
+				t.Errorf("expected storage %v and its clone %v to be equal", test.a, clone)
+			}
+		})
+	}
+}
+
+func TestStorage_Diff(t *testing.T) {
+	tests := map[string]struct {
+		prefix   string
+		a, b     Storage
+		expected []string
+	}{
+		"both_nil": {},
+		"identical": {
+			a: Storage{{1}: {0x01}},
+			b: Storage{{1}: {0x01}},
+		},
+		"different_value": {
+			a:        Storage{{1}: {0x01}},
+			b:        Storage{{1}: {0x02}},
+			expected: []string{"different value for key 0x0100000000000000000000000000000000000000000000000000000000000000: 0x0100000000000000000000000000000000000000000000000000000000000000 != 0x0200000000000000000000000000000000000000000000000000000000000000"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			diffs := test.a.Diff(test.prefix, test.b)
+			slices.Sort(test.expected)
+			want := strings.Join(test.expected, ",")
+			slices.Sort(diffs)
+			got := strings.Join(diffs, ",")
+
+			if want != got {
+				t.Errorf("expected diffs [%v], but got [%v]", want, got)
+			}
+		})
+	}
+}
+
+func TestEqualMapsIgnoringZero_Equal(t *testing.T) {
+	tests := map[string]struct {
+		a, b map[int]int
+	}{
+		"both_nil": {},
+		"left_hand_side_nil": {
+			b: map[int]int{},
+		},
+		"right_hand_side_nil": {
+			b: map[int]int{},
+		},
+		"singleton": {
+			a: map[int]int{1: 2},
+			b: map[int]int{1: 2},
+		},
+		"multiple": {
+			a: map[int]int{
+				1: 2,
+				3: 4,
+			},
+			b: map[int]int{
+				1: 2,
+				3: 4,
+			},
+		},
+		"zero_values_are_ignored": {
+			a: map[int]int{1: 0},
+			b: map[int]int{2: 0},
+		},
+		"zero_values_in_left_hand_side_is_ignored": {
+			a: map[int]int{1: 0},
+			b: map[int]int{},
+		},
+		"zero_values_in_right_hand_side_is_ignored": {
+			a: map[int]int{},
+			b: map[int]int{1: 0},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if !equalMapsIgnoringZero(test.a, test.b, func(a, b int) bool { return a == b }) {
+				t.Errorf("expected maps %v and %v to be equal", test.a, test.b)
+			}
+		})
+	}
+}
+
+func TestEqualMapsIgnoringZero_NonEqual(t *testing.T) {
+	tests := map[string]struct {
+		a, b map[int]int
+	}{
+		"different_value_for_same_key": {
+			a: map[int]int{1: 2},
+			b: map[int]int{1: 3},
+		},
+		"extra_non_zero_entry_in_left_hand_side": {
+			a: map[int]int{1: 2, 3: 4},
+			b: map[int]int{1: 2},
+		},
+		"extra_non_zero_entry_in_right_hand_side": {
+			a: map[int]int{1: 2},
+			b: map[int]int{1: 2, 3: 4},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if equalMapsIgnoringZero(test.a, test.b, func(a, b int) bool { return a == b }) {
+				t.Errorf("expected maps %v and %v to be not equal", test.a, test.b)
+			}
+		})
+	}
+}
+
+func TestDiffMaps(t *testing.T) {
+	tests := map[string]struct {
+		prefix   string
+		a, b     map[int]int
+		expected []string
+	}{
+		"both nil": {},
+		"identical": {
+			a: map[int]int{1: 2},
+			b: map[int]int{1: 2},
+		},
+		"different value": {
+			a:        map[int]int{1: 1},
+			b:        map[int]int{1: 2},
+			expected: []string{"different value for 1: 1 != 2"},
+		},
+		"additional key in first map": {
+			a:        map[int]int{1: 2, 2: 4},
+			b:        map[int]int{1: 2},
+			expected: []string{"different value for 2: 4 != 0"},
+		},
+		"additional key in second map": {
+			a:        map[int]int{1: 2},
+			b:        map[int]int{1: 2, 2: 4},
+			expected: []string{"different value for 2: 0 != 4"},
+		},
+		"different keys": {
+			a: map[int]int{1: 3},
+			b: map[int]int{2: 3},
+			expected: []string{
+				"different value for 1: 3 != 0",
+				"different value for 2: 0 != 3",
+			},
+		},
+		"different value with prefix": {
+			prefix:   "myContext/",
+			a:        map[int]int{1: 1},
+			b:        map[int]int{1: 2},
+			expected: []string{"myContext/different value for 1: 1 != 2"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			diffs := diffMaps(test.prefix, test.a, test.b, func(k int, a, b int) []string {
+				if a == b {
+					return nil
+				}
+				return []string{
+					fmt.Sprintf("different value for %d: %d != %d", k, a, b),
+				}
+			})
+
+			slices.Sort(test.expected)
+			want := strings.Join(test.expected, ",")
+			slices.Sort(diffs)
+			got := strings.Join(diffs, ",")
+
+			if want != got {
+				t.Errorf("expected diffs [%v], but got [%v]", want, got)
+			}
+		})
+	}
+}

--- a/go/tosca/interpreter_mock.go
+++ b/go/tosca/interpreter_mock.go
@@ -16,7 +16,7 @@
 //	mockgen -source interpreter.go -destination interpreter_mock.go -package tosca
 //
 
-// Package vm is a generated GoMock package.
+// Package tosca is a generated GoMock package.
 package tosca
 
 import (
@@ -141,20 +141,6 @@ func (m *MockRunContext) Call(kind CallKind, parameter CallParameters) (CallResu
 func (mr *MockRunContextMockRecorder) Call(kind, parameter any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Call", reflect.TypeOf((*MockRunContext)(nil).Call), kind, parameter)
-}
-
-// CreateAccount mocks base method.
-func (m *MockRunContext) CreateAccount(arg0 Address, arg1 Code) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAccount", arg0, arg1)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// CreateAccount indicates an expected call of CreateAccount.
-func (mr *MockRunContextMockRecorder) CreateAccount(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccount", reflect.TypeOf((*MockRunContext)(nil).CreateAccount), arg0, arg1)
 }
 
 // CreateSnapshot mocks base method.
@@ -517,20 +503,6 @@ func (m *MockTransactionContext) AccountExists(arg0 Address) bool {
 func (mr *MockTransactionContextMockRecorder) AccountExists(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccountExists", reflect.TypeOf((*MockTransactionContext)(nil).AccountExists), arg0)
-}
-
-// CreateAccount mocks base method.
-func (m *MockTransactionContext) CreateAccount(arg0 Address, arg1 Code) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAccount", arg0, arg1)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// CreateAccount indicates an expected call of CreateAccount.
-func (mr *MockTransactionContextMockRecorder) CreateAccount(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccount", reflect.TypeOf((*MockTransactionContext)(nil).CreateAccount), arg0, arg1)
 }
 
 // CreateSnapshot mocks base method.

--- a/go/tosca/processor_mock.go
+++ b/go/tosca/processor_mock.go
@@ -16,7 +16,7 @@
 //	mockgen -source processor.go -destination processor_mock.go -package tosca
 //
 
-// Package vm is a generated GoMock package.
+// Package tosca is a generated GoMock package.
 package tosca
 
 import (

--- a/go/tosca/types.go
+++ b/go/tosca/types.go
@@ -33,6 +33,14 @@ func (a *Address) UnmarshalText(data []byte) error {
 	return textToBytes(a[:], data)
 }
 
+func (k Key) String() string {
+	return fmt.Sprintf("0x%x", k[:])
+}
+
+func (w Word) String() string {
+	return fmt.Sprintf("0x%x", w[:])
+}
+
 func (v Value) ToBig() *big.Int {
 	return new(big.Int).SetBytes(v[:])
 }

--- a/go/tosca/world_state.go
+++ b/go/tosca/world_state.go
@@ -19,7 +19,6 @@ import "fmt"
 // optional code and storage.
 type WorldState interface {
 	AccountExists(Address) bool
-	CreateAccount(Address, Code) bool
 
 	GetBalance(Address) Value
 	SetBalance(Address, Value)

--- a/go/tosca/world_state_mock.go
+++ b/go/tosca/world_state_mock.go
@@ -16,7 +16,7 @@
 //	mockgen -source world_state.go -destination world_state_mock.go -package tosca
 //
 
-// Package vm is a generated GoMock package.
+// Package tosca is a generated GoMock package.
 package tosca
 
 import (
@@ -60,20 +60,6 @@ func (m *MockWorldState) AccountExists(arg0 Address) bool {
 func (mr *MockWorldStateMockRecorder) AccountExists(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccountExists", reflect.TypeOf((*MockWorldState)(nil).AccountExists), arg0)
-}
-
-// CreateAccount mocks base method.
-func (m *MockWorldState) CreateAccount(arg0 Address, arg1 Code) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAccount", arg0, arg1)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// CreateAccount indicates an expected call of CreateAccount.
-func (mr *MockWorldStateMockRecorder) CreateAccount(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccount", reflect.TypeOf((*MockWorldState)(nil).CreateAccount), arg0, arg1)
 }
 
 // GetBalance mocks base method.


### PR DESCRIPTION
This PR introduces some infrastructure to simplify the definition of integration tests for [Processor](https://github.com/Fantom-foundation/Tosca/blob/93de631ba0e66082b1bb912c564fcb6637cfaa16/go/tosca/processor.go#L20) implementations.

In particular, the provided infrastructure enables the definition of test scenarios based on pre/post states and a transaction definition. During the test execution, the following steps are carried out:
- a transaction context containing the pre state is created
- the transaction is executed using the provided `Processor` implementation; state manipulations are tracked
- the final state after the transaction has been completed is compared with the expected state
- the receipt produced by the transaction is compared with the expected result

**Note to reviewers**: during the implementation it was realized that the [CreateAccount](https://github.com/Fantom-foundation/Tosca/blob/93de631ba0e66082b1bb912c564fcb6637cfaa16/go/tosca/world_state.go#L22) function of Tosca's [WorldState](https://github.com/Fantom-foundation/Tosca/blob/93de631ba0e66082b1bb912c564fcb6637cfaa16/go/tosca/world_state.go#L20) interface is unnecessary since accounts are created implicitly when setting a balance, nonce, or code. Thus, this function is not used anywhere right now. We might have to re-add it when dealing with Cancun's new Self-Destruct semantic, yet likely in a different shape. Accounts need to be created before the code can be set.