### PR TITLE
LFVM: merge memory set/copy with EnsureCapacity

### DIFF
--- a/go/ct/rlz/parameters.go
+++ b/go/ct/rlz/parameters.go
@@ -81,8 +81,7 @@ var memoryOffsetForCopyParameter = []U256{
 	NewU256(0),
 	NewU256(1),
 	NewU256(32),
-	NewU256(24576),
-	NewU256(math.MaxInt64),
+	NewU256(2 * 24576),
 	NewU256(1, 0),
 }
 

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -1182,7 +1182,7 @@ func getAllRules() []Rule {
 		},
 		parameters: []Parameter{
 			AddressParameter{},
-			MemoryOffsetParameter{},
+			MemoryOffsetForCopyParameter{},
 			DataOffsetParameter{},
 			DataSizeParameter{}},
 		effect: func(s *st.State) {
@@ -1203,7 +1203,7 @@ func getAllRules() []Rule {
 		},
 		parameters: []Parameter{
 			AddressParameter{},
-			MemoryOffsetParameter{},
+			MemoryOffsetForCopyParameter{},
 			DataOffsetParameter{},
 			DataSizeParameter{}},
 		effect: func(s *st.State) {
@@ -1223,7 +1223,7 @@ func getAllRules() []Rule {
 		},
 		parameters: []Parameter{
 			AddressParameter{},
-			MemoryOffsetParameter{},
+			MemoryOffsetForCopyParameter{},
 			DataOffsetParameter{},
 			DataSizeParameter{}},
 		effect: func(s *st.State) {
@@ -1438,7 +1438,7 @@ func getAllRules() []Rule {
 		pops:      3,
 		pushes:    0,
 		parameters: []Parameter{
-			MemoryOffsetParameter{},
+			MemoryOffsetForCopyParameter{},
 			DataOffsetParameter{},
 			DataSizeParameter{}},
 		effect: func(s *st.State) {

--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -189,7 +189,7 @@ func convertCtMemoryToLfvmMemory(memory *st.Memory) (*Memory, error) {
 
 	result := NewMemory()
 	result.EnsureCapacityWithoutGas(uint64(len(data)), nil)
-	err := result.Set(0, uint64(len(data)), data)
+	err := result.Set(0, uint64(len(data)), data, nil, false)
 	return result, err
 }
 

--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -188,8 +188,7 @@ func convertCtMemoryToLfvmMemory(memory *st.Memory) (*Memory, error) {
 	data := memory.Read(0, uint64(memory.Size()))
 
 	result := NewMemory()
-	result.EnsureCapacityWithoutGas(uint64(len(data)), nil)
-	err := result.Set(0, uint64(len(data)), data, nil, false)
+	err := result.SetWithCapacityCheck(0, uint64(len(data)), data)
 	return result, err
 }
 

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -114,7 +114,12 @@ func (m *Memory) Len() uint64 {
 	return uint64(len(m.store))
 }
 
-func (m *Memory) SetByte(offset uint64, value byte) error {
+func (m *Memory) SetByte(offset uint64, value byte, size uint64, c *context) error {
+	err := m.EnsureCapacity(offset, size, c)
+	if err != nil {
+		return err
+	}
+
 	if m.Len() < offset+1 {
 		return fmt.Errorf("memory too small, size %d, attempted to write at position %d", m.Len(), offset)
 	}
@@ -122,7 +127,12 @@ func (m *Memory) SetByte(offset uint64, value byte) error {
 	return nil
 }
 
-func (m *Memory) SetWord(offset uint64, value *uint256.Int) error {
+func (m *Memory) SetWord(offset uint64, value *uint256.Int, size uint64, c *context) error {
+	err := m.EnsureCapacity(offset, size, c)
+	if err != nil {
+		return err
+	}
+
 	if m.Len() < offset+32 {
 		return fmt.Errorf("memory too small, size %d, attempted to write 32 byte at position %d", m.Len(), offset)
 	}
@@ -167,7 +177,13 @@ func (m *Memory) SetWord(offset uint64, value *uint256.Int) error {
 	return nil
 }
 
-func (m *Memory) Set(offset, size uint64, value []byte) error {
+func (m *Memory) Set(offset, size uint64, value []byte, c *context, shouldEnsureCapacity bool) error {
+	if shouldEnsureCapacity {
+		err := m.EnsureCapacity(offset, size, c)
+		if err != nil {
+			return err
+		}
+	}
 	if size > 0 {
 		if offset+size < offset {
 			return errGasUintOverflow
@@ -180,7 +196,11 @@ func (m *Memory) Set(offset, size uint64, value []byte) error {
 	return nil
 }
 
-func (m *Memory) CopyWord(offset uint64, trg *uint256.Int) error {
+func (m *Memory) CopyWord(offset uint64, trg *uint256.Int, size uint64, c *context) error {
+	err := m.EnsureCapacity(offset, size, c)
+	if err != nil {
+		return err
+	}
 	if m.Len() < offset+32 {
 		return fmt.Errorf("memory too small, size %d, attempted to read 32 byte at position %d", m.Len(), offset)
 	}

--- a/go/interpreter/lfvm/super_instructions.go
+++ b/go/interpreter/lfvm/super_instructions.go
@@ -86,7 +86,7 @@ func opDup2_Mstore(c *context) {
 	var addr = c.stack.peek()
 
 	offset := addr.Uint64()
-	if err := c.memory.SetWord(offset, value, 32, c); err != nil {
+	if err := c.memory.SetWord(offset, value, c); err != nil {
 		c.SignalError(err)
 	}
 }

--- a/go/interpreter/lfvm/super_instructions.go
+++ b/go/interpreter/lfvm/super_instructions.go
@@ -86,10 +86,7 @@ func opDup2_Mstore(c *context) {
 	var addr = c.stack.peek()
 
 	offset := addr.Uint64()
-	if c.memory.EnsureCapacity(offset, 32, c) != nil {
-		return
-	}
-	if err := c.memory.SetWord(offset, value); err != nil {
+	if err := c.memory.SetWord(offset, value, 32, c); err != nil {
 		c.SignalError(err)
 	}
 }


### PR DESCRIPTION
This PR aims to improve coverage by including calls to `EnsureCapacity` in functions that need it to not fail.