### PR TITLE
CT: expand `memoryOffsetForCopyParameter`

### DIFF
--- a/go/ct/rlz/parameters.go
+++ b/go/ct/rlz/parameters.go
@@ -82,6 +82,7 @@ var memoryOffsetForCopyParameter = []U256{
 	NewU256(1),
 	NewU256(32),
 	NewU256(24576),
+	NewU256(math.MaxInt64),
 	NewU256(1, 0),
 }
 

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -1488,7 +1488,7 @@ func getAllRules() []Rule {
 		staticGas:  3,
 		pops:       1,
 		pushes:     1,
-		parameters: []Parameter{NumericParameter{}},
+		parameters: []Parameter{MemoryOffsetForCopyParameter{}},
 		effect: func(s *st.State) {
 			offsetU256 := s.Stack.Pop()
 			pushData := NewU256(0)


### PR DESCRIPTION
This PR adds `math.MaxUint64` to `memoryOffsetForCopyParameterto` trigger overflow cases, in particular in `calldataload` rule