### PR TITLE
CT: Max Memory Size Check

### DIFF
--- a/go/ct/st/memory_test.go
+++ b/go/ct/st/memory_test.go
@@ -139,15 +139,19 @@ func TestMemory_MemoryExpansionCosts(t *testing.T) {
 		wantOffset uint64
 		wantSize   uint64
 	}{
-		"large size no overflow":            {NewU256(0), NewU256(math.MaxUint64), tosca.Gas(0x1800000000000000), 0, math.MaxUint64},
-		"large offset no overflow":          {NewU256(math.MaxUint64 - 1), NewU256(1), tosca.Gas(0x1800000000000000), math.MaxUint64 - 1, 1},
-		"large offset and size no overflow": {NewU256(math.MaxUint64 / 2), NewU256(math.MaxUint64 / 2), tosca.Gas(0x1800000000000000), math.MaxUint64 / 2, math.MaxUint64 / 2},
+		"large size no overflow":            {NewU256(0), NewU256(math.MaxUint64), MaxGas, 0, math.MaxUint64},
+		"large offset no overflow":          {NewU256(math.MaxUint64 - 1), NewU256(1), MaxGas, math.MaxUint64 - 1, 1},
+		"large offset and size no overflow": {NewU256(math.MaxUint64 / 2), NewU256(math.MaxUint64 / 2), MaxGas, math.MaxUint64 / 2, math.MaxUint64 / 2},
 		"size overflow":                     {NewU256(0), NewU256(1, 0), tosca.Gas(math.MaxInt64), 0, 0},
 		"offset overflow":                   {NewU256(1, 0), NewU256(1), tosca.Gas(math.MaxInt64), 0, 0},
 		"large offset and size overflow":    {NewU256(math.MaxUint64/2 + 1), NewU256(math.MaxUint64/2 + 1), tosca.Gas(math.MaxInt64), math.MaxUint64/2 + 1, math.MaxUint64/2 + 1},
 		"zero size":                         {NewU256(0), NewU256(0), tosca.Gas(0), 0, 0},
 		"zero size offset":                  {NewU256(1024), NewU256(0), tosca.Gas(0), 1024, 0},
 		"zero size offset overflow":         {NewU256(1, 0), NewU256(0), tosca.Gas(0), 0, 0},
+		"max memory size allowed":           {NewU256(0), NewU256(maxMemoryExpansionSize + 1), MaxGas, 0, maxMemoryExpansionSize + 1},
+		"acceptable size":                   {NewU256(0), NewU256(maxMemoryExpansionSize), tosca.Gas(36028809887088637), 0, maxMemoryExpansionSize},
+		"acceptable offset":                 {NewU256(maxMemoryExpansionSize - 1), NewU256(1), tosca.Gas(36028809887088637), maxMemoryExpansionSize - 1, 1},
+		"size not multiple of 32":           {NewU256(0), NewU256(31), tosca.Gas(3), 0, 31},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
Thanks to the fuzzing experiments an unchecked overflow was found and fixed in LFVM memory expansion calculation function. 

This PRs add that fix in the analogous CT function and a corresponding test case that fails without this newly introduced check.