### PR TITLE
tosca: change `ValueFromUint64` to `NewValue`

### DIFF
--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -34,23 +34,23 @@ func TestRunContextAdapter_SetBalanceHasCorrectEffect(t *testing.T) {
 	}{
 		{},
 		{
-			before: tosca.ValueFromUint64(10),
-			after:  tosca.ValueFromUint64(10),
+			before: tosca.NewValue(10),
+			after:  tosca.NewValue(10),
 		},
 		{
-			before: tosca.ValueFromUint64(0),
-			after:  tosca.ValueFromUint64(1),
-			add:    tosca.ValueFromUint64(1),
+			before: tosca.NewValue(0),
+			after:  tosca.NewValue(1),
+			add:    tosca.NewValue(1),
 		},
 		{
-			before: tosca.ValueFromUint64(1),
-			after:  tosca.ValueFromUint64(0),
-			sub:    tosca.ValueFromUint64(1),
+			before: tosca.NewValue(1),
+			after:  tosca.NewValue(0),
+			sub:    tosca.NewValue(1),
 		},
 		{
-			before: tosca.ValueFromUint64(123),
-			after:  tosca.ValueFromUint64(321),
-			add:    tosca.ValueFromUint64(321 - 123),
+			before: tosca.NewValue(123),
+			after:  tosca.NewValue(321),
+			add:    tosca.NewValue(321 - 123),
 		},
 	}
 

--- a/go/integration_test/processor/processor_test.go
+++ b/go/integration_test/processor/processor_test.go
@@ -41,18 +41,18 @@ func getScenarios() map[string]Scenario {
 	return map[string]Scenario{
 		"SuccessfulValueTransfer": {
 			Before: WorldState{
-				{1}: Account{Balance: tosca.ValueFromUint64(100), Nonce: 4},
+				{1}: Account{Balance: tosca.NewValue(100), Nonce: 4},
 			},
 			Transaction: tosca.Transaction{
 				Sender:    tosca.Address{1},
 				Recipient: &tosca.Address{2},
 				GasLimit:  21_000,
-				Value:     tosca.ValueFromUint64(3),
+				Value:     tosca.NewValue(3),
 				Nonce:     4,
 			},
 			After: WorldState{
-				{1}: Account{Balance: tosca.ValueFromUint64(97), Nonce: 5},
-				{2}: Account{Balance: tosca.ValueFromUint64(3)},
+				{1}: Account{Balance: tosca.NewValue(97), Nonce: 5},
+				{2}: Account{Balance: tosca.NewValue(3)},
 			},
 			Receipt: tosca.Receipt{
 				Success: true,
@@ -61,17 +61,17 @@ func getScenarios() map[string]Scenario {
 		},
 		"FailedValueTransfer": {
 			Before: WorldState{
-				{1}: Account{Balance: tosca.ValueFromUint64(10), Nonce: 4},
+				{1}: Account{Balance: tosca.NewValue(10), Nonce: 4},
 			},
 			Transaction: tosca.Transaction{
 				Sender:    tosca.Address{1},
 				Recipient: &tosca.Address{2},
 				GasLimit:  21_000,
-				Value:     tosca.ValueFromUint64(20),
+				Value:     tosca.NewValue(20),
 				Nonce:     4,
 			},
 			After: WorldState{
-				{1}: Account{Balance: tosca.ValueFromUint64(10), Nonce: 5},
+				{1}: Account{Balance: tosca.NewValue(10), Nonce: 5},
 			},
 			Receipt: tosca.Receipt{
 				Success: false,
@@ -80,8 +80,8 @@ func getScenarios() map[string]Scenario {
 		},
 		"SuccessfulContractCall": {
 			Before: WorldState{
-				{1}: Account{Balance: tosca.ValueFromUint64(100), Nonce: 4},
-				{2}: Account{Balance: tosca.ValueFromUint64(0),
+				{1}: Account{Balance: tosca.NewValue(100), Nonce: 4},
+				{2}: Account{Balance: tosca.NewValue(0),
 					Code: tosca.Code{
 						byte(op.PUSH1), byte(0), // < push 0
 						byte(op.PUSH1), byte(0), // < push 0
@@ -93,12 +93,12 @@ func getScenarios() map[string]Scenario {
 				Sender:    tosca.Address{1},
 				Recipient: &tosca.Address{2},
 				GasLimit:  21_000 + 2*3, // < value transfer + 2 push instructions (return is free)
-				Value:     tosca.ValueFromUint64(3),
+				Value:     tosca.NewValue(3),
 				Nonce:     4,
 			},
 			After: WorldState{
-				{1}: Account{Balance: tosca.ValueFromUint64(97), Nonce: 5},
-				{2}: Account{Balance: tosca.ValueFromUint64(3),
+				{1}: Account{Balance: tosca.NewValue(97), Nonce: 5},
+				{2}: Account{Balance: tosca.NewValue(3),
 					Code: tosca.Code{
 						byte(op.PUSH1), byte(0), // < push 0
 						byte(op.PUSH1), byte(0), // < push 0
@@ -113,8 +113,8 @@ func getScenarios() map[string]Scenario {
 		},
 		"RevertingContractCall": {
 			Before: WorldState{
-				{1}: Account{Balance: tosca.ValueFromUint64(100), Nonce: 4},
-				{2}: Account{Balance: tosca.ValueFromUint64(0),
+				{1}: Account{Balance: tosca.NewValue(100), Nonce: 4},
+				{2}: Account{Balance: tosca.NewValue(0),
 					Code: tosca.Code{
 						byte(op.PUSH1), byte(0), // < push 0
 						byte(op.PUSH1), byte(0), // < push 0
@@ -126,12 +126,12 @@ func getScenarios() map[string]Scenario {
 				Sender:    tosca.Address{1},
 				Recipient: &tosca.Address{2},
 				GasLimit:  21_000 + 2*3, // < value transfer + 2 push instructions (return is free)
-				Value:     tosca.ValueFromUint64(3),
+				Value:     tosca.NewValue(3),
 				Nonce:     4,
 			},
 			After: WorldState{
-				{1}: Account{Balance: tosca.ValueFromUint64(100), Nonce: 5},
-				{2}: Account{Balance: tosca.ValueFromUint64(0),
+				{1}: Account{Balance: tosca.NewValue(100), Nonce: 5},
+				{2}: Account{Balance: tosca.NewValue(0),
 					Code: tosca.Code{
 						byte(op.PUSH1), byte(0), // < push 0
 						byte(op.PUSH1), byte(0), // < push 0
@@ -147,18 +147,18 @@ func getScenarios() map[string]Scenario {
 
 		"SuccessfulContractCreation": {
 			Before: WorldState{
-				{1}: Account{Balance: tosca.ValueFromUint64(100), Nonce: 4},
+				{1}: Account{Balance: tosca.NewValue(100), Nonce: 4},
 			},
 			Transaction: tosca.Transaction{
 				Sender:   tosca.Address{1},
 				GasLimit: 53_000,
-				Value:    tosca.ValueFromUint64(3),
+				Value:    tosca.NewValue(3),
 				Nonce:    4,
 			},
 			After: WorldState{
-				{1}: Account{Balance: tosca.ValueFromUint64(97), Nonce: 5},
+				{1}: Account{Balance: tosca.NewValue(97), Nonce: 5},
 				createdAddress: Account{
-					Balance: tosca.ValueFromUint64(3),
+					Balance: tosca.NewValue(3),
 					Nonce:   1,
 					Code:    tosca.Code{},
 				},

--- a/go/integration_test/processor/scenario_test.go
+++ b/go/integration_test/processor/scenario_test.go
@@ -23,7 +23,7 @@ func TestScenarioContext_AccountsAreImplictilyCreated(t *testing.T) {
 	addr := tosca.Address{1}
 	tests := map[string]func(tosca.WorldState){
 		"balance": func(s tosca.WorldState) {
-			s.SetBalance(addr, tosca.ValueFromUint64(100))
+			s.SetBalance(addr, tosca.NewValue(100))
 		},
 		"nonce": func(s tosca.WorldState) {
 			s.SetNonce(addr, 12)
@@ -58,8 +58,8 @@ func TestScenarioContext_BalanceManipulation(t *testing.T) {
 
 	snapshot := context.CreateSnapshot()
 
-	context.SetBalance(addr, tosca.ValueFromUint64(100))
-	if want, got := tosca.ValueFromUint64(100), context.GetBalance(addr); got != want {
+	context.SetBalance(addr, tosca.NewValue(100))
+	if want, got := tosca.NewValue(100), context.GetBalance(addr); got != want {
 		t.Errorf("unexpected balance, want %v, got %v", want, got)
 	}
 

--- a/go/integration_test/processor/world_state_test.go
+++ b/go/integration_test/processor/world_state_test.go
@@ -63,8 +63,8 @@ func TestWorldState_Clone(t *testing.T) {
 		},
 		"multiple": {
 			a: WorldState{
-				{1}: Account{Balance: tosca.ValueFromUint64(100)},
-				{2}: Account{Balance: tosca.ValueFromUint64(200)},
+				{1}: Account{Balance: tosca.NewValue(100)},
+				{2}: Account{Balance: tosca.NewValue(200)},
 			},
 		},
 	}
@@ -107,17 +107,17 @@ func TestWorldState_Diff(t *testing.T) {
 			b: WorldState{},
 		},
 		"different_accounts": {
-			a:        WorldState{{1}: Account{Balance: tosca.ValueFromUint64(100)}},
-			b:        WorldState{{1}: Account{Balance: tosca.ValueFromUint64(200)}},
+			a:        WorldState{{1}: Account{Balance: tosca.NewValue(100)}},
+			b:        WorldState{{1}: Account{Balance: tosca.NewValue(200)}},
 			expected: []string{"0x0100000000000000000000000000000000000000/different balance: 100 != 200"},
 		},
 		"extra_accounts": {
 			a: WorldState{
-				{1}: Account{Balance: tosca.ValueFromUint64(100)},
+				{1}: Account{Balance: tosca.NewValue(100)},
 			},
 			b: WorldState{
-				{1}: Account{Balance: tosca.ValueFromUint64(100)},
-				{2}: Account{Balance: tosca.ValueFromUint64(200)},
+				{1}: Account{Balance: tosca.NewValue(100)},
+				{2}: Account{Balance: tosca.NewValue(200)},
 			},
 			expected: []string{"0x0200000000000000000000000000000000000000/different balance: 0 != 200"},
 		},
@@ -144,7 +144,7 @@ func TestAccount_Equal(t *testing.T) {
 		"both_zero": {},
 		"identical_non_zero": {
 			a: Account{
-				Balance: tosca.ValueFromUint64(100),
+				Balance: tosca.NewValue(100),
 				Nonce:   4,
 				Code:    tosca.Code{byte(op.STOP)},
 				Storage: map[tosca.Key]tosca.Word{
@@ -153,7 +153,7 @@ func TestAccount_Equal(t *testing.T) {
 				},
 			},
 			b: Account{
-				Balance: tosca.ValueFromUint64(100),
+				Balance: tosca.NewValue(100),
 				Nonce:   4,
 				Code:    tosca.Code{byte(op.STOP)},
 				Storage: map[tosca.Key]tosca.Word{
@@ -186,8 +186,8 @@ func TestAccount_NotEqual(t *testing.T) {
 		a, b Account
 	}{
 		"different_balance": {
-			a: Account{Balance: tosca.ValueFromUint64(100)},
-			b: Account{Balance: tosca.ValueFromUint64(200)},
+			a: Account{Balance: tosca.NewValue(100)},
+			b: Account{Balance: tosca.NewValue(200)},
 		},
 		"different_nonce": {
 			a: Account{Nonce: 4},
@@ -219,7 +219,7 @@ func TestAccount_Clone(t *testing.T) {
 		"empty": {},
 		"non_empty": {
 			a: Account{
-				Balance: tosca.ValueFromUint64(100),
+				Balance: tosca.NewValue(100),
 				Nonce:   4,
 				Code:    tosca.Code{byte(op.STOP)},
 				Storage: map[tosca.Key]tosca.Word{
@@ -252,8 +252,8 @@ func TestAccount_Diff(t *testing.T) {
 			b: Account{},
 		},
 		"different_balance": {
-			a:        Account{Balance: tosca.ValueFromUint64(100)},
-			b:        Account{Balance: tosca.ValueFromUint64(200)},
+			a:        Account{Balance: tosca.NewValue(100)},
+			b:        Account{Balance: tosca.NewValue(200)},
 			expected: []string{"different balance: 100 != 200"},
 		},
 		"different_nonce": {
@@ -273,8 +273,8 @@ func TestAccount_Diff(t *testing.T) {
 		},
 		"different_balance_with_prefix": {
 			prefix:   "myContext/",
-			a:        Account{Balance: tosca.ValueFromUint64(100)},
-			b:        Account{Balance: tosca.ValueFromUint64(200)},
+			a:        Account{Balance: tosca.NewValue(100)},
+			b:        Account{Balance: tosca.NewValue(200)},
 			expected: []string{"myContext/different balance: 100 != 200"},
 		},
 	}


### PR DESCRIPTION
This PR changes the old `ValueFromUint64` to `NewValue`, keeping the old representation and decimal printing, but allowing the create a new value from up to 4 `uint64` much like `NewU256` 

This PR fixes #589 