### PR TITLE
lfvm: remove geth dependency in lfvm opcodes

### DIFF
--- a/go/integration_test/interpreter/instruction_info.go
+++ b/go/integration_test/interpreter/instruction_info.go
@@ -308,7 +308,7 @@ func getBerlinInstructions() map[vm.OpCode]*InstructionInfo {
 	// Selfdestruct dynamic gas calculation has changed in Berlin
 	// Test is universal for all revisions, keeping here to know, there is change in calculation
 	// const gasSelfDestruct tosca.Gas = 5000
-	// res[evm.SELFDESTRUCT].gas = GasUsage{gasSelfDestruct, gasDynamicSelfDestruct}
+	// res[vm.SELFDESTRUCT].gas = GasUsage{gasSelfDestruct, gasDynamicSelfDestruct}
 
 	return res
 }


### PR DESCRIPTION
This PR changes the use of `geth.evm` codes for `tosca.opcodes` in `converter.go`
This PR dependes on #604 