### PR TITLE
Add Go Vet pass to build action.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -46,6 +46,9 @@ jobs:
     - name: Check Go sources formatting
       working-directory: ./
       run: diff=`gofmt -s -d ./go`; echo "$diff"; test -z "$diff"
+
+    - name: Go Vet static analysis
+      run: go vet ./go/...
 
     - name: Build
       run: make tosca-go

--- a/go/ct/driver/probe.go
+++ b/go/ct/driver/probe.go
@@ -117,9 +117,10 @@ func doProbe(context *cli.Context) error {
 	var wg sync.WaitGroup
 	wg.Add(jobCount)
 	for i := 0; i < jobCount; i++ {
+		ii := i
 		go func() {
 			defer wg.Done()
-			rnd := rand.New(seed + uint64(i))
+			rnd := rand.New(seed + uint64(ii))
 			generator := gen.NewStateGenerator()
 			condition.Restrict(generator)
 


### PR DESCRIPTION
Vet is bundled with the go installation, no need for extra setup. This pass will run fast static checks for code sanity.

More about [Vet](https://pkg.go.dev/cmd/vet)

Vet is fast and can be run along the normal build script. Although it founds some trivial errors already, there is a second linter project that finds more interesting errors, and I would like to integrate it as an action as well: #608 

The bug found is a race condition: more about it here https://eli.thegreenplace.net/2019/go-internals-capturing-loop-variables-in-closures/
The choice of naming for the new variable is deliberate, this seems to be a convention to address this issue.