### PR TITLE
Remove unused code as reported by golangci-lint

### DIFF
--- a/go/ct/gen/state.go
+++ b/go/ct/gen/state.go
@@ -277,19 +277,6 @@ func (g *StateGenerator) IsAbsentBlobHashIndex(variable Variable) {
 	g.transactionContextGen.IsAbsentBlobHashIndex(variable)
 }
 
-func getRandomData(rnd *rand.Rand) ([]byte, error) {
-	size := uint(rnd.ExpFloat64() * float64(200))
-	if size > st.MaxDataSize {
-		size = st.MaxDataSize
-	}
-	dataBuffer := make([]byte, size)
-	_, err := rnd.Read(dataBuffer)
-	if err != nil {
-		return nil, err
-	}
-	return dataBuffer, nil
-}
-
 // Generate produces a State instance satisfying the constraints set on this
 // generator or returns ErrUnsatisfiable on conflicting constraints. Subsequent
 // generators are invoked automatically.

--- a/go/ct/rlz/domains.go
+++ b/go/ct/rlz/domains.go
@@ -102,41 +102,6 @@ func (uint16Domain) SamplesForAll(as []uint16) []uint16 {
 }
 
 ////////////////////////////////////////////////////////////
-// uint64
-
-type uint64Domain struct{}
-
-func (uint64Domain) Equal(a uint64, b uint64) bool     { return a == b }
-func (uint64Domain) Less(a uint64, b uint64) bool      { return a < b }
-func (uint64Domain) Predecessor(a uint64) uint64       { return a - 1 }
-func (uint64Domain) Successor(a uint64) uint64         { return a + 1 }
-func (uint64Domain) SomethingNotEqual(a uint64) uint64 { return a + 1 }
-
-func (d uint64Domain) Samples(a uint64) []uint64 {
-	return d.SamplesForAll([]uint64{a})
-}
-
-func (uint64Domain) SamplesForAll(as []uint64) []uint64 {
-	res := []uint64{0, ^uint64(0)}
-
-	// Test every element off by one.
-	for _, a := range as {
-		res = append(res, a-1)
-		res = append(res, a)
-		res = append(res, a+1)
-	}
-
-	// Add all powers of 2.
-	for i := 0; i < 64; i++ {
-		res = append(res, uint64(1<<i))
-	}
-
-	res = removeDuplicatesGeneric[uint64](res)
-
-	return res
-}
-
-////////////////////////////////////////////////////////////
 // U256
 
 type u256Domain struct{}
@@ -348,40 +313,6 @@ func (stackSizeDomain) SamplesForAll(as []int) []int {
 	res = removeDuplicatesGeneric[int](res)
 
 	return res
-}
-
-////////////////////////////////////////////////////////////
-// Address
-
-type addressDomain struct{}
-
-func (addressDomain) Equal(a, b tosca.Address) bool {
-	return a == b
-}
-
-func (addressDomain) Less(tosca.Address, tosca.Address) bool  { panic("not implemented") }
-func (addressDomain) Predecessor(tosca.Address) tosca.Address { panic("not implemented") }
-func (addressDomain) Successor(tosca.Address) tosca.Address   { panic("not implemented") }
-
-func (addressDomain) SomethingNotEqual(a tosca.Address) tosca.Address {
-	return tosca.Address{a[0] + 1}
-}
-
-func (ad addressDomain) Samples(a tosca.Address) []tosca.Address {
-	return ad.SamplesForAll([]tosca.Address{a})
-}
-
-func (addressDomain) SamplesForAll(as []tosca.Address) []tosca.Address {
-	ret := []tosca.Address{}
-	ret = append(ret, as...)
-
-	zero := tosca.Address{}
-	ffs := tosca.Address{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
-
-	ret = append(ret, zero)
-	ret = append(ret, ffs)
-
-	return ret
 }
 
 ////////////////////////////////////////////////////////////

--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -570,10 +570,6 @@ func bigIntToWord(value *big.Int) (tosca.Word, error) {
 	return tosca.Word(res), err
 }
 
-func valueToBigInt(value tosca.Value) *big.Int {
-	return new(big.Int).SetBytes(value[:])
-}
-
 func isPrecompiledContract(recipient tosca.Address) bool {
 	// the addresses 1-9 are precompiled contracts
 	for i := 0; i < 18; i++ {

--- a/go/integration_test/interpreter/instruction_info.go
+++ b/go/integration_test/interpreter/instruction_info.go
@@ -293,7 +293,6 @@ func getBerlinInstructions() map[evm.OpCode]*InstructionInfo {
 	// Berlin only modifies gas computations.
 	// https://eips.ethereum.org/EIPS/eip-2929
 	const gasWarmStorageReadCostEIP2929 tosca.Gas = 100
-	const gasSelfDestruct tosca.Gas = 5000
 
 	res := getIstanbulInstructions()
 
@@ -310,6 +309,7 @@ func getBerlinInstructions() map[evm.OpCode]*InstructionInfo {
 	res[evm.DELEGATECALL].gas = GasUsage{gasWarmStorageReadCostEIP2929, gasDynamicStaticDelegateCall}
 	// Selfdestruct dynamic gas calculation has changed in Berlin
 	// Test is universal for all revisions, keeping here to know, there is change in calculation
+	// const gasSelfDestruct tosca.Gas = 5000
 	// res[evm.SELFDESTRUCT].gas = GasUsage{gasSelfDestruct, gasDynamicSelfDestruct}
 
 	return res


### PR DESCRIPTION
This is part of the effort to enable #608 
Code removed was never used. 