### PR TITLE
Handle ignored error results discovered by static linter

### DIFF
--- a/go/ct/common/address.go
+++ b/go/ct/common/address.go
@@ -34,6 +34,6 @@ func RandAddress(rnd *rand.Rand) (tosca.Address, error) {
 
 func RandomAddress(rnd *rand.Rand) tosca.Address {
 	address := tosca.Address{}
-	rnd.Read(address[:]) // never returns an error
+	_, _ = rnd.Read(address[:]) // rnd.Read never returns an error
 	return address
 }

--- a/go/ct/common/bytes.go
+++ b/go/ct/common/bytes.go
@@ -39,7 +39,7 @@ func RandomBytes(rnd *rand.Rand, maxSize int) Bytes {
 
 func RandomBytesOfSize(rnd *rand.Rand, size int) Bytes {
 	data := make([]byte, size)
-	rnd.Read(data)
+	_, _ = rnd.Read(data) // rnd.Read never returns an error
 	return NewBytes(data)
 }
 

--- a/go/ct/common/hash.go
+++ b/go/ct/common/hash.go
@@ -17,6 +17,6 @@ import (
 
 func GetRandomHash(rnd *rand.Rand) tosca.Hash {
 	var res tosca.Hash
-	rnd.Read(res[:])
+	_, _ = rnd.Read(res[:]) // rnd.Read never returns an error
 	return res
 }

--- a/go/ct/evm_fuzz_test.go
+++ b/go/ct/evm_fuzz_test.go
@@ -163,7 +163,7 @@ func prepareFuzzingSeeds(f *testing.F) {
 
 				// generate a code segment with the operation followed by 6 random values
 				ops := make([]byte, fuzzMaximumCodeSegment)
-				rand.Read(ops[:])
+				_, _ = rand.Read(ops[:]) // rnd.Read never returns an error
 				ops[0] = byte(op)
 
 				// generate a stack: the stack contains a mixture of values
@@ -199,10 +199,10 @@ func prepareFuzzingSeeds(f *testing.F) {
 
 	// add one more with a full stack
 	ops := make([]byte, fuzzMaximumCodeSegment)
-	rnd.Read(ops[:])
+	_, _ = rnd.Read(ops[:]) // rnd.Read never returns an error
 	ops[0] = byte(0x00)
 	fullStack := make([]byte, 1024*32)
-	rnd.Read(fullStack[:])
+	_, _ = rnd.Read(fullStack[:]) // rnd.Read never returns an error
 	f.Add(
 		ops,                      // opCodes
 		int64(0),                 // gas

--- a/go/ct/gen/accounts_test.go
+++ b/go/ct/gen/accounts_test.go
@@ -109,7 +109,10 @@ func BenchmarkAccountGenWithConstraint(b *testing.B) {
 	generator.BindWarm(v1)
 	generator.BindCold(v2)
 	for i := 0; i < b.N; i++ {
-		generator.Generate(assignment, rnd, NewAddressFromInt(8))
+		_, err := generator.Generate(assignment, rnd, NewAddressFromInt(8))
+		if err != nil {
+			b.Fatalf("Invalid benchmark, Unexpected error during balance generation %v", err)
+		}
 	}
 }
 
@@ -119,6 +122,9 @@ func BenchmarkAccountGenWithOutConstraint(b *testing.B) {
 	generator := NewAccountGenerator()
 
 	for i := 0; i < b.N; i++ {
-		generator.Generate(assignment, rnd, NewAddressFromInt(8))
+		_, err := generator.Generate(assignment, rnd, NewAddressFromInt(8))
+		if err != nil {
+			b.Fatalf("Invalid benchmark, Unexpected error during balance generation %v", err)
+		}
 	}
 }

--- a/go/ct/gen/code.go
+++ b/go/ct/gen/code.go
@@ -170,7 +170,7 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 
 	// If there are no operation constraints producing random code is sufficient.
 	if len(ops) == 0 {
-		rnd.Read(code)
+		_, _ = rnd.Read(code) // rnd.Read never returns an error
 		return st.NewCode(code), nil
 	}
 
@@ -215,7 +215,7 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 
 		// If this was the last, fill the rest randomly.
 		if len(ops) == 0 {
-			rnd.Read(code[i+1:])
+			_, _ = rnd.Read(code[i+1:]) // rnd.Read never returns an error
 			break
 		}
 
@@ -226,7 +226,7 @@ func (g *CodeGenerator) Generate(assignment Assignment, rnd *rand.Rand) (*st.Cod
 			if end > len(code) {
 				end = len(code)
 			}
-			rnd.Read(code[i+1 : end])
+			_, _ = rnd.Read(code[i+1 : end]) // rnd.Read never returns an error
 			i += width
 		}
 	}

--- a/go/ct/gen/memory.go
+++ b/go/ct/gen/memory.go
@@ -29,10 +29,7 @@ func (g *MemoryGenerator) Generate(rnd *rand.Rand) (*st.Memory, error) {
 	size := 32 * rnd.Intn(10)
 
 	data := make([]byte, size)
-	_, err := rnd.Read(data)
-	if err != nil {
-		return nil, err
-	}
+	_, _ = rnd.Read(data) // rnd.Read never returns an error
 
 	return st.NewMemory(data...), nil
 }

--- a/go/ct/rlz/conditions_test.go
+++ b/go/ct/rlz/conditions_test.go
@@ -640,7 +640,10 @@ func BenchmarkCondition_IsAddressWarmCheckWarm(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		condition.Check(state)
+		_, err := condition.Check(state)
+		if err != nil {
+			b.Fatalf("invalid benchmark, check returned error %v", err)
+		}
 	}
 }
 
@@ -652,6 +655,9 @@ func BenchmarkCondition_IsAddressWarmCheckCold(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		condition.Check(state)
+		_, err := condition.Check(state)
+		if err != nil {
+			b.Fatalf("invalid benchmark, check returned error %v", err)
+		}
 	}
 }

--- a/go/ct/spc/enumeration_test.go
+++ b/go/ct/spc/enumeration_test.go
@@ -239,7 +239,7 @@ func TestEnumeration_RightNumberOfGoroutinesIsStarted(t *testing.T) {
 	printFunction := func(time time.Duration, rate float64, current int64) {}
 	err := ForEachState(Spec.GetRules(), opFunction, printFunction, numJobs, uint64(seed), fullMode)
 	if err != nil {
-		t.Errorf("Unexpected in ForEachState %v", err)
+		t.Errorf("Unexpected error in ForEachState %v", err)
 	}
 
 	if activeJobs != numJobs {

--- a/go/ct/spc/enumeration_test.go
+++ b/go/ct/spc/enumeration_test.go
@@ -237,7 +237,10 @@ func TestEnumeration_RightNumberOfGoroutinesIsStarted(t *testing.T) {
 	}
 
 	printFunction := func(time time.Duration, rate float64, current int64) {}
-	ForEachState(Spec.GetRules(), opFunction, printFunction, numJobs, uint64(seed), fullMode)
+	err := ForEachState(Spec.GetRules(), opFunction, printFunction, numJobs, uint64(seed), fullMode)
+	if err != nil {
+		t.Errorf("Unexpected in ForEachState %v", err)
+	}
 
 	if activeJobs != numJobs {
 		t.Errorf("unexpected number of active jobs, wanted %d, got %d", numJobs, activeJobs)

--- a/go/ct/st/accounts.go
+++ b/go/ct/st/accounts.go
@@ -32,7 +32,7 @@ func NewAccounts() *Accounts {
 
 func (a *Accounts) GetCodeHash(address tosca.Address) (hash [32]byte) {
 	hasher := sha3.NewLegacyKeccak256()
-	hasher.Write(a.code[address].ToBytes())
+	_, _ = hasher.Write(a.code[address].ToBytes())
 	hasher.Sum(hash[:])
 	return
 }

--- a/go/ct/st/accounts.go
+++ b/go/ct/st/accounts.go
@@ -32,7 +32,7 @@ func NewAccounts() *Accounts {
 
 func (a *Accounts) GetCodeHash(address tosca.Address) (hash [32]byte) {
 	hasher := sha3.NewLegacyKeccak256()
-	_, _ = hasher.Write(a.code[address].ToBytes())
+	_, _ = hasher.Write(a.code[address].ToBytes()) // Hash.Write never returns an error
 	hasher.Sum(hash[:])
 	return
 }

--- a/go/interpreter/evmzero/evmzero_test.go
+++ b/go/interpreter/evmzero/evmzero_test.go
@@ -46,7 +46,10 @@ func TestEvmzero_DumpProfile(t *testing.T) {
 		t.Fatalf("profiling evmzero configuration does not support profiling")
 	}
 	for i := 0; i < 10; i++ {
-		example.RunOn(interpreter, 10)
+		_, err := example.RunOn(interpreter, 10)
+		if err != nil {
+			t.Fatalf("running the fib example failed: %v", err)
+		}
 		interpreter.DumpProfile()
 		if i == 5 {
 			interpreter.ResetProfile()

--- a/go/interpreter/lfvm/hash_cache.go
+++ b/go/interpreter/lfvm/hash_cache.go
@@ -78,9 +78,9 @@ func newHashCache(capacity32 int, capacity64 int) *HashCache {
 
 	hasher.Reset()
 	var data32 [32]byte
-	hasher.Write(data32[:])
+	_, _ = hasher.Write(data32[:]) // hash.Hash.Write() never returns an error
 	var hash32 tosca.Hash
-	hasher.Read(hash32[:])
+	_, _ = hasher.Read(hash32[:]) // sha3.state.Read() never returns an error
 	res.head32.hash = hash32
 
 	res.index32[data32] = res.head32
@@ -91,9 +91,9 @@ func newHashCache(capacity32 int, capacity64 int) *HashCache {
 
 	hasher.Reset()
 	var data64 [64]byte
-	hasher.Write(data64[:])
+	_, _ = hasher.Write(data64[:]) // hash.Hash.Write() never returns an error
 	var hash64 tosca.Hash
-	hasher.Read(hash64[:])
+	_, _ = hasher.Read(hash64[:]) // sha3.state.Read() never returns an error
 	res.head64.hash = hash64
 
 	res.index64[data64] = res.head64
@@ -251,6 +251,6 @@ func getHash(c *context, data []byte) tosca.Hash {
 	}
 
 	c.hasher.Write(data)
-	c.hasher.Read(res[:])
+	_, _ = c.hasher.Read(res[:]) // sha3.state.Read() never returns an error
 	return res
 }

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -606,8 +606,8 @@ func opSha3(c *context) {
 		} else {
 			c.hasher.Reset()
 		}
-		c.hasher.Write(data)
-		c.hasher.Read(c.hasherBuf[:])
+		_, _ = c.hasher.Write(data)          // hash.Hash.Write() never returns an error
+		_, _ = c.hasher.Read(c.hasherBuf[:]) // sha3.state.Read() never returns an error
 	}
 
 	size.SetBytes32(c.hasherBuf[:])


### PR DESCRIPTION
The PR here either ignores or does error handling for the previously ignored functions, potentially returning errors.

- Rand (and hash), implement the read (and write) interfaces which are error typed, nevertheless these operations do not fail.
- Error handling is done in unit tests and benchmarks, benchmarks add a negligible constant overhead, and it is better to not benchmark failing functions. 