### PR TITLE
Handle errors discovered by static linter, staticcheck and ineffassign

### DIFF
--- a/go/ct/common/address.go
+++ b/go/ct/common/address.go
@@ -27,11 +27,6 @@ func AddressToU256(a tosca.Address) U256 {
 	return NewU256FromBytes(a[:]...)
 }
 
-// Deprecated: use RandomAddress instead
-func RandAddress(rnd *rand.Rand) (tosca.Address, error) {
-	return RandomAddress(rnd), nil
-}
-
 func RandomAddress(rnd *rand.Rand) tosca.Address {
 	address := tosca.Address{}
 	_, _ = rnd.Read(address[:]) // rnd.Read never returns an error

--- a/go/ct/common/address_test.go
+++ b/go/ct/common/address_test.go
@@ -43,14 +43,10 @@ func TestAddress_ToU256(t *testing.T) {
 	}
 }
 
-func TestAddress_RandAddress(t *testing.T) {
+func TestAddress_RandomAddress(t *testing.T) {
 	address1 := tosca.Address{}
 	rnd := rand.New(0)
-	address2, err := RandAddress(rnd)
-
-	if err != nil {
-		t.Errorf("Error generating random %v", err)
-	}
+	address2 := RandomAddress(rnd)
 
 	if address1 == address2 {
 		t.Errorf("Random Address is same as default value")

--- a/go/ct/gen/accounts.go
+++ b/go/ct/gen/accounts.go
@@ -93,7 +93,7 @@ func (g *AccountsGenerator) Generate(assignment Assignment, rnd *rand.Rand, acco
 	}
 	getUnusedAddress := func() tosca.Address {
 		for {
-			address, _ := RandAddress(rnd)
+			address := RandomAddress(rnd)
 
 			if _, isPresent := addressesInUse[address]; !isPresent {
 				addressesInUse[address] = true

--- a/go/ct/gen/accounts_test.go
+++ b/go/ct/gen/accounts_test.go
@@ -21,10 +21,7 @@ import (
 func TestAccountsGenerator_UnconstrainedGeneratorCanProduceBalance(t *testing.T) {
 	rnd := rand.New(0)
 	generator := NewAccountGenerator()
-	accountAddress, err := RandAddress(rnd)
-	if err != nil {
-		t.Errorf("Unexpected random address generation error: %v", err)
-	}
+	accountAddress := RandomAddress(rnd)
 	if _, err := generator.Generate(nil, rnd, accountAddress); err != nil {
 		t.Errorf("Unexpected error during generation: %v", err)
 	}
@@ -37,10 +34,7 @@ func TestAccountsGenerator_WarmConstraintIsEnforced(t *testing.T) {
 
 	rnd := rand.New(0)
 	generator := NewAccountGenerator()
-	accountAddress, err := RandAddress(rnd)
-	if err != nil {
-		t.Errorf("Unexpected random address generation error: %v", err)
-	}
+	accountAddress := RandomAddress(rnd)
 	generator.BindWarm(v1)
 	accounts, err := generator.Generate(assignment, rnd, accountAddress)
 	if err != nil {

--- a/go/ct/gen/block_context.go
+++ b/go/ct/gen/block_context.go
@@ -19,6 +19,7 @@ import (
 
 	"pgregory.net/rand"
 
+	"github.com/Fantom-foundation/Tosca/go/ct/common"
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"github.com/Fantom-foundation/Tosca/go/tosca"
@@ -197,10 +198,7 @@ func (b *BlockContextGenerator) Generate(assignment Assignment, rnd *rand.Rand) 
 	}
 
 	chainId := RandU256(rnd)
-	coinbase, err := RandAddress(rnd)
-	if err != nil {
-		return st.BlockContext{}, err
-	}
+	coinbase := common.RandomAddress(rnd)
 
 	baseFee := RandU256(rnd)
 	blobBaseFee := RandU256(rnd)

--- a/go/ct/gen/block_context.go
+++ b/go/ct/gen/block_context.go
@@ -19,7 +19,6 @@ import (
 
 	"pgregory.net/rand"
 
-	"github.com/Fantom-foundation/Tosca/go/ct/common"
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"github.com/Fantom-foundation/Tosca/go/tosca"
@@ -198,7 +197,7 @@ func (b *BlockContextGenerator) Generate(assignment Assignment, rnd *rand.Rand) 
 	}
 
 	chainId := RandU256(rnd)
-	coinbase := common.RandomAddress(rnd)
+	coinbase := RandomAddress(rnd)
 
 	baseFee := RandU256(rnd)
 	blobBaseFee := RandU256(rnd)

--- a/go/ct/gen/call_context.go
+++ b/go/ct/gen/call_context.go
@@ -26,10 +26,7 @@ func NewCallContextGenerator() *CallContextGenerator {
 }
 
 func (*CallContextGenerator) Generate(rnd *rand.Rand, accountAddress tosca.Address) (st.CallContext, error) {
-	callerAddress, err := common.RandAddress(rnd)
-	if err != nil {
-		return st.CallContext{}, err
-	}
+	callerAddress := common.RandomAddress(rnd)
 
 	return st.CallContext{
 		AccountAddress: accountAddress,

--- a/go/ct/gen/call_context_test.go
+++ b/go/ct/gen/call_context_test.go
@@ -21,10 +21,7 @@ import (
 func TestCallContextGen_Generate(t *testing.T) {
 	rnd := rand.New(0)
 	callCtxGen := NewCallContextGenerator()
-	accountAddress, err := common.RandAddress(rnd)
-	if err != nil {
-		t.Errorf("Unexpected random address generation error: %v", err)
-	}
+	accountAddress := common.RandomAddress(rnd)
 	callCtx, err := callCtxGen.Generate(rnd, accountAddress)
 	if err != nil {
 		t.Errorf("Error generating call context: %v", err)

--- a/go/ct/gen/interval_solver_test.go
+++ b/go/ct/gen/interval_solver_test.go
@@ -279,7 +279,7 @@ func TestInterval_isEmpty(t *testing.T) {
 	}
 }
 
-func TestIntervalSolver_uint64fullrangeAndEdges(t *testing.T) {
+func TestIntervalSolver_uint64FullRangeAndEdges(t *testing.T) {
 
 	tests := map[string]struct {
 		setup func(*IntervalSolver[uint64])
@@ -287,13 +287,13 @@ func TestIntervalSolver_uint64fullrangeAndEdges(t *testing.T) {
 	}{
 		"full-range": {
 			setup: func(s *IntervalSolver[uint64]) {},
-			check: func(v uint64) bool { return v >= 0 && v <= math.MaxUint64 }},
+			check: func(v uint64) bool { return true }}, // this tests that does not return err
 		"remove-zero": {
 			setup: func(s *IntervalSolver[uint64]) { s.Exclude(0, 0) },
 			check: func(v uint64) bool { return v > 0 && v < math.MaxUint64 }},
 		"remove-max": {
 			setup: func(s *IntervalSolver[uint64]) { s.Exclude(math.MaxUint64, math.MaxUint64) },
-			check: func(v uint64) bool { return v >= 0 && v < math.MaxUint64-1 }},
+			check: func(v uint64) bool { return v != math.MaxUint64 }},
 		"fix-max": {
 			setup: func(s *IntervalSolver[uint64]) { s.AddEqualityConstraint(math.MaxUint64) },
 			check: func(v uint64) bool { return v == math.MaxUint64 }},
@@ -321,7 +321,7 @@ func TestIntervalSolver_uint64fullrangeAndEdges(t *testing.T) {
 	}
 }
 
-func TestIntervalSolver_int64fullrangeAndEdges(t *testing.T) {
+func TestIntervalSolver_int64FullRangeAndEdges(t *testing.T) {
 
 	tests := map[string]struct {
 		setup func(*IntervalSolver[int64])
@@ -329,10 +329,13 @@ func TestIntervalSolver_int64fullrangeAndEdges(t *testing.T) {
 	}{
 		"full-range": {
 			setup: func(s *IntervalSolver[int64]) {},
-			check: func(v int64) bool { return v >= math.MinInt64 && v <= math.MaxInt64 }},
+			check: func(v int64) bool { return true }}, // this tests that does not return err
 		"remove-min": {
 			setup: func(s *IntervalSolver[int64]) { s.Exclude(math.MinInt64, math.MinInt64) },
 			check: func(v int64) bool { return v != math.MaxInt64 }},
+		"remove-zero": {
+			setup: func(s *IntervalSolver[int64]) { s.Exclude(0, 0) },
+			check: func(v int64) bool { return v != 0 }},
 		"remove-max": {
 			setup: func(s *IntervalSolver[int64]) { s.Exclude(math.MaxInt64, math.MaxInt64) },
 			check: func(v int64) bool { return v != math.MaxInt64 }},
@@ -342,9 +345,6 @@ func TestIntervalSolver_int64fullrangeAndEdges(t *testing.T) {
 		"remove-all-negative": {
 			setup: func(s *IntervalSolver[int64]) { s.Exclude(math.MinInt64, 0) },
 			check: func(v int64) bool { return v > 0 }},
-		"remove-zero": {
-			setup: func(s *IntervalSolver[int64]) { s.Exclude(0, 0) },
-			check: func(v int64) bool { return v != 0 }},
 		"fix-max": {
 			setup: func(s *IntervalSolver[int64]) { s.AddEqualityConstraint(math.MaxInt64) },
 			check: func(v int64) bool { return v == math.MaxInt64 }},

--- a/go/ct/utils/adapter_test.go
+++ b/go/ct/utils/adapter_test.go
@@ -163,7 +163,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 			},
 			func(p tosca.Parameters) (any, any) {
 				ctxt := p.Context
-				return tosca.Word{}, ctxt.GetCommittedStorage(tosca.Address{}, tosca.Key{})
+				return tosca.Word{}, ctxt.GetCommittedStorage(tosca.Address{}, tosca.Key{}) //nolint:staticcheck
 			},
 		},
 		"storage-original-specified": {
@@ -176,7 +176,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 				ctxt := p.Context
 				key1 := tosca.Key(cc.NewU256(1).Bytes32be())
 				val2 := tosca.Word(cc.NewU256(2).Bytes32be())
-				return val2, ctxt.GetCommittedStorage(tosca.Address{}, key1)
+				return val2, ctxt.GetCommittedStorage(tosca.Address{}, key1) //nolint:staticcheck
 			},
 		},
 		"cold-slot": {
@@ -185,7 +185,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 			},
 			func(p tosca.Parameters) (any, any) {
 				ctxt := p.Context
-				_, res := ctxt.IsSlotInAccessList(tosca.Address{}, tosca.Key{})
+				_, res := ctxt.IsSlotInAccessList(tosca.Address{}, tosca.Key{}) //nolint:staticcheck
 				return false, res
 			},
 		},
@@ -197,7 +197,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 			},
 			func(p tosca.Parameters) (any, any) {
 				ctxt := p.Context
-				_, res := ctxt.IsSlotInAccessList(tosca.Address{}, tosca.Key{})
+				_, res := ctxt.IsSlotInAccessList(tosca.Address{}, tosca.Key{}) //nolint:staticcheck
 				return true, res
 			},
 		},
@@ -311,7 +311,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 			},
 			func(p tosca.Parameters) (any, any) {
 				ctxt := p.Context
-				return false, ctxt.IsAddressInAccessList(tosca.Address{})
+				return false, ctxt.IsAddressInAccessList(tosca.Address{}) //nolint:staticcheck
 			},
 		},
 		"warm-account-legacy": {
@@ -321,7 +321,7 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 			},
 			func(p tosca.Parameters) (any, any) {
 				ctxt := p.Context
-				return true, ctxt.IsAddressInAccessList(tosca.Address{})
+				return true, ctxt.IsAddressInAccessList(tosca.Address{}) //nolint:staticcheck
 			},
 		},
 	}

--- a/go/ct/utils/adapter_test.go
+++ b/go/ct/utils/adapter_test.go
@@ -163,7 +163,8 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 			},
 			func(p tosca.Parameters) (any, any) {
 				ctxt := p.Context
-				return tosca.Word{}, ctxt.GetCommittedStorage(tosca.Address{}, tosca.Key{}) //nolint:staticcheck
+				//lint:ignore SA1019 deprecated functions to be migrated in #616
+				return tosca.Word{}, ctxt.GetCommittedStorage(tosca.Address{}, tosca.Key{})
 			},
 		},
 		"storage-original-specified": {
@@ -176,7 +177,8 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 				ctxt := p.Context
 				key1 := tosca.Key(cc.NewU256(1).Bytes32be())
 				val2 := tosca.Word(cc.NewU256(2).Bytes32be())
-				return val2, ctxt.GetCommittedStorage(tosca.Address{}, key1) //nolint:staticcheck
+				//lint:ignore SA1019 deprecated functions to be migrated in #616
+				return val2, ctxt.GetCommittedStorage(tosca.Address{}, key1)
 			},
 		},
 		"cold-slot": {
@@ -185,7 +187,8 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 			},
 			func(p tosca.Parameters) (any, any) {
 				ctxt := p.Context
-				_, res := ctxt.IsSlotInAccessList(tosca.Address{}, tosca.Key{}) //nolint:staticcheck
+				//lint:ignore SA1019 deprecated functions to be migrated in #616
+				_, res := ctxt.IsSlotInAccessList(tosca.Address{}, tosca.Key{})
 				return false, res
 			},
 		},
@@ -197,7 +200,8 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 			},
 			func(p tosca.Parameters) (any, any) {
 				ctxt := p.Context
-				_, res := ctxt.IsSlotInAccessList(tosca.Address{}, tosca.Key{}) //nolint:staticcheck
+				//lint:ignore SA1019 deprecated functions to be migrated in #616
+				_, res := ctxt.IsSlotInAccessList(tosca.Address{}, tosca.Key{})
 				return true, res
 			},
 		},
@@ -311,7 +315,8 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 			},
 			func(p tosca.Parameters) (any, any) {
 				ctxt := p.Context
-				return false, ctxt.IsAddressInAccessList(tosca.Address{}) //nolint:staticcheck
+				//lint:ignore SA1019 deprecated functions to be migrated in #616
+				return false, ctxt.IsAddressInAccessList(tosca.Address{})
 			},
 		},
 		"warm-account-legacy": {
@@ -321,7 +326,8 @@ func TestAdapter_ParameterConversion(t *testing.T) {
 			},
 			func(p tosca.Parameters) (any, any) {
 				ctxt := p.Context
-				return true, ctxt.IsAddressInAccessList(tosca.Address{}) //nolint:staticcheck
+				//lint:ignore SA1019 deprecated functions to be migrated in #616
+				return true, ctxt.IsAddressInAccessList(tosca.Address{})
 			},
 		},
 	}

--- a/go/interpreter/geth/geth.go
+++ b/go/interpreter/geth/geth.go
@@ -300,7 +300,7 @@ func (s *stateDbAdapter) GetRefund() uint64 {
 }
 
 func (s *stateDbAdapter) GetCommittedState(addr common.Address, key common.Hash) common.Hash {
-	return common.Hash(s.context.GetCommittedStorage(tosca.Address(addr), tosca.Key(key)))
+	return common.Hash(s.context.GetCommittedStorage(tosca.Address(addr), tosca.Key(key))) //nolint:staticcheck
 }
 
 func (s *stateDbAdapter) GetState(addr common.Address, key common.Hash) common.Hash {
@@ -329,7 +329,7 @@ func (s *stateDbAdapter) SelfDestruct(addr common.Address) {
 }
 
 func (s *stateDbAdapter) HasSelfDestructed(addr common.Address) bool {
-	return s.context.HasSelfDestructed(tosca.Address(addr))
+	return s.context.HasSelfDestructed(tosca.Address(addr)) //nolint:staticcheck
 }
 
 func (s *stateDbAdapter) Selfdestruct6780(addr common.Address) {
@@ -361,11 +361,11 @@ func (s *stateDbAdapter) PrepareAccessList(sender common.Address, dest *common.A
 }
 
 func (s *stateDbAdapter) AddressInAccessList(addr common.Address) bool {
-	return s.context.IsAddressInAccessList(tosca.Address(addr))
+	return s.context.IsAddressInAccessList(tosca.Address(addr)) //nolint:staticcheck
 }
 
 func (s *stateDbAdapter) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
-	return s.context.IsSlotInAccessList(tosca.Address(addr), tosca.Key(slot))
+	return s.context.IsSlotInAccessList(tosca.Address(addr), tosca.Key(slot)) //nolint:staticcheck
 }
 
 func (s *stateDbAdapter) AddAddressToAccessList(addr common.Address) {

--- a/go/interpreter/geth/geth.go
+++ b/go/interpreter/geth/geth.go
@@ -300,7 +300,8 @@ func (s *stateDbAdapter) GetRefund() uint64 {
 }
 
 func (s *stateDbAdapter) GetCommittedState(addr common.Address, key common.Hash) common.Hash {
-	return common.Hash(s.context.GetCommittedStorage(tosca.Address(addr), tosca.Key(key))) //nolint:staticcheck
+	//lint:ignore SA1019 deprecated functions to be migrated in #616
+	return common.Hash(s.context.GetCommittedStorage(tosca.Address(addr), tosca.Key(key)))
 }
 
 func (s *stateDbAdapter) GetState(addr common.Address, key common.Hash) common.Hash {
@@ -329,7 +330,8 @@ func (s *stateDbAdapter) SelfDestruct(addr common.Address) {
 }
 
 func (s *stateDbAdapter) HasSelfDestructed(addr common.Address) bool {
-	return s.context.HasSelfDestructed(tosca.Address(addr)) //nolint:staticcheck
+	//lint:ignore SA1019 deprecated functions to be migrated in #616
+	return s.context.HasSelfDestructed(tosca.Address(addr))
 }
 
 func (s *stateDbAdapter) Selfdestruct6780(addr common.Address) {
@@ -361,11 +363,13 @@ func (s *stateDbAdapter) PrepareAccessList(sender common.Address, dest *common.A
 }
 
 func (s *stateDbAdapter) AddressInAccessList(addr common.Address) bool {
-	return s.context.IsAddressInAccessList(tosca.Address(addr)) //nolint:staticcheck
+	//lint:ignore SA1019 deprecated functions to be migrated in #616
+	return s.context.IsAddressInAccessList(tosca.Address(addr))
 }
 
 func (s *stateDbAdapter) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
-	return s.context.IsSlotInAccessList(tosca.Address(addr), tosca.Key(slot)) //nolint:staticcheck
+	//lint:ignore SA1019 deprecated functions to be migrated in #616
+	return s.context.IsSlotInAccessList(tosca.Address(addr), tosca.Key(slot))
 }
 
 func (s *stateDbAdapter) AddAddressToAccessList(addr common.Address) {

--- a/go/interpreter/lfvm/gas.go
+++ b/go/interpreter/lfvm/gas.go
@@ -312,7 +312,7 @@ func gasSStoreEIP2200(c *context) (tosca.Gas, error) {
 	if current == value { // noop (1)
 		return tosca.Gas(params.SloadGasEIP2200), nil
 	}
-	original := c.context.GetCommittedStorage(c.params.Recipient, key)
+	original := c.context.GetCommittedStorage(c.params.Recipient, key) //nolint:staticcheck
 	if original == current {
 		if original == zero { // create slot (2.1.1)
 			return tosca.Gas(params.SstoreSetGasEIP2200), nil
@@ -360,7 +360,7 @@ func gasSStoreEIP2929(c *context) (tosca.Gas, error) {
 		cost    = tosca.Gas(0)
 	)
 	// Check slot presence in the access list
-	if addrPresent, slotPresent := c.context.IsSlotInAccessList(c.params.Recipient, slot); !slotPresent {
+	if addrPresent, slotPresent := c.context.IsSlotInAccessList(c.params.Recipient, slot); !slotPresent { //nolint:staticcheck
 		if !addrPresent {
 			c.status = ERROR
 			return 0, errors.New("address was not present in access list during sstore op")
@@ -374,7 +374,7 @@ func gasSStoreEIP2929(c *context) (tosca.Gas, error) {
 	if current == value { // noop (1)
 		return cost + tosca.Gas(params.WarmStorageReadCostEIP2929), nil // SLOAD_GAS
 	}
-	original := c.context.GetCommittedStorage(c.params.Recipient, slot)
+	original := c.context.GetCommittedStorage(c.params.Recipient, slot) //nolint:staticcheck
 	if original == current {
 		if original == zero { // create slot (2.1.1)
 			return cost + tosca.Gas(params.SstoreSetGasEIP2200), nil
@@ -404,7 +404,7 @@ func gasSStoreEIP2929(c *context) (tosca.Gas, error) {
 func gasEip2929AccountCheck(c *context, address tosca.Address) error {
 	if c.isBerlin() {
 		// Charge extra for cold locations.
-		if !c.context.IsAddressInAccessList(address) {
+		if !c.context.IsAddressInAccessList(address) { //nolint:staticcheck
 			if !c.UseGas(tosca.Gas(params.ColdAccountAccessCostEIP2929 - params.WarmStorageReadCostEIP2929)) {
 				return errOutOfGas
 			}
@@ -419,7 +419,7 @@ func addressInAccessList(c *context) (warmAccess bool, coldCost tosca.Gas, err e
 	if c.isBerlin() {
 		addr := tosca.Address(c.stack.Back(1).Bytes20())
 		// Check slot presence in the access list
-		warmAccess = c.context.IsAddressInAccessList(addr)
+		warmAccess = c.context.IsAddressInAccessList(addr) //nolint:staticcheck
 		// The WarmStorageReadCostEIP2929 (100) is already deducted in the form of a constant cost, so
 		// the cost to charge for cold access, if any, is Cold - Warm
 		coldCost = tosca.Gas(params.ColdAccountAccessCostEIP2929 - params.WarmStorageReadCostEIP2929)
@@ -443,7 +443,7 @@ func gasSelfdestruct(c *context) tosca.Gas {
 	if !c.context.AccountExists(address) && c.context.GetBalance(c.params.Recipient) != (tosca.Value{}) {
 		gas += tosca.Gas(params.CreateBySelfdestructGas)
 	}
-	if !c.context.HasSelfDestructed(c.params.Recipient) {
+	if !c.context.HasSelfDestructed(c.params.Recipient) { //nolint:staticcheck
 		c.refund += tosca.Gas(params.SelfdestructRefundGas)
 	}
 	return gas
@@ -454,7 +454,7 @@ func gasSelfdestructEIP2929(c *context) tosca.Gas {
 		gas     tosca.Gas
 		address = tosca.Address(c.stack.Back(0).Bytes20())
 	)
-	if !c.context.IsAddressInAccessList(address) {
+	if !c.context.IsAddressInAccessList(address) { //nolint:staticcheck
 		// If the caller cannot afford the cost, this change will be rolled back
 		c.context.AccessAccount(address)
 		gas = tosca.Gas(params.ColdAccountAccessCostEIP2929)
@@ -465,7 +465,7 @@ func gasSelfdestructEIP2929(c *context) tosca.Gas {
 	}
 	// do this only for Berlin and not after London fork
 	if c.isBerlin() && !c.isLondon() {
-		if !c.context.HasSelfDestructed(c.params.Recipient) {
+		if !c.context.HasSelfDestructed(c.params.Recipient) { //nolint:staticcheck
 			c.refund += tosca.Gas(params.SelfdestructRefundGas)
 		}
 	}

--- a/go/interpreter/lfvm/gas.go
+++ b/go/interpreter/lfvm/gas.go
@@ -312,7 +312,8 @@ func gasSStoreEIP2200(c *context) (tosca.Gas, error) {
 	if current == value { // noop (1)
 		return tosca.Gas(params.SloadGasEIP2200), nil
 	}
-	original := c.context.GetCommittedStorage(c.params.Recipient, key) //nolint:staticcheck
+	//lint:ignore SA1019 deprecated functions to be migrated in #616
+	original := c.context.GetCommittedStorage(c.params.Recipient, key)
 	if original == current {
 		if original == zero { // create slot (2.1.1)
 			return tosca.Gas(params.SstoreSetGasEIP2200), nil
@@ -360,7 +361,8 @@ func gasSStoreEIP2929(c *context) (tosca.Gas, error) {
 		cost    = tosca.Gas(0)
 	)
 	// Check slot presence in the access list
-	if addrPresent, slotPresent := c.context.IsSlotInAccessList(c.params.Recipient, slot); !slotPresent { //nolint:staticcheck
+	//lint:ignore SA1019 deprecated functions to be migrated in #616
+	if addrPresent, slotPresent := c.context.IsSlotInAccessList(c.params.Recipient, slot); !slotPresent {
 		if !addrPresent {
 			c.status = ERROR
 			return 0, errors.New("address was not present in access list during sstore op")
@@ -374,7 +376,8 @@ func gasSStoreEIP2929(c *context) (tosca.Gas, error) {
 	if current == value { // noop (1)
 		return cost + tosca.Gas(params.WarmStorageReadCostEIP2929), nil // SLOAD_GAS
 	}
-	original := c.context.GetCommittedStorage(c.params.Recipient, slot) //nolint:staticcheck
+	//lint:ignore SA1019 deprecated functions to be migrated in #616
+	original := c.context.GetCommittedStorage(c.params.Recipient, slot)
 	if original == current {
 		if original == zero { // create slot (2.1.1)
 			return cost + tosca.Gas(params.SstoreSetGasEIP2200), nil
@@ -404,7 +407,8 @@ func gasSStoreEIP2929(c *context) (tosca.Gas, error) {
 func gasEip2929AccountCheck(c *context, address tosca.Address) error {
 	if c.isBerlin() {
 		// Charge extra for cold locations.
-		if !c.context.IsAddressInAccessList(address) { //nolint:staticcheck
+		//lint:ignore SA1019 deprecated functions to be migrated in #616
+		if !c.context.IsAddressInAccessList(address) {
 			if !c.UseGas(tosca.Gas(params.ColdAccountAccessCostEIP2929 - params.WarmStorageReadCostEIP2929)) {
 				return errOutOfGas
 			}
@@ -419,7 +423,8 @@ func addressInAccessList(c *context) (warmAccess bool, coldCost tosca.Gas, err e
 	if c.isBerlin() {
 		addr := tosca.Address(c.stack.Back(1).Bytes20())
 		// Check slot presence in the access list
-		warmAccess = c.context.IsAddressInAccessList(addr) //nolint:staticcheck
+		//lint:ignore SA1019 deprecated functions to be migrated in #616
+		warmAccess = c.context.IsAddressInAccessList(addr)
 		// The WarmStorageReadCostEIP2929 (100) is already deducted in the form of a constant cost, so
 		// the cost to charge for cold access, if any, is Cold - Warm
 		coldCost = tosca.Gas(params.ColdAccountAccessCostEIP2929 - params.WarmStorageReadCostEIP2929)
@@ -443,7 +448,8 @@ func gasSelfdestruct(c *context) tosca.Gas {
 	if !c.context.AccountExists(address) && c.context.GetBalance(c.params.Recipient) != (tosca.Value{}) {
 		gas += tosca.Gas(params.CreateBySelfdestructGas)
 	}
-	if !c.context.HasSelfDestructed(c.params.Recipient) { //nolint:staticcheck
+	//lint:ignore SA1019 deprecated functions to be migrated in #616
+	if !c.context.HasSelfDestructed(c.params.Recipient) {
 		c.refund += tosca.Gas(params.SelfdestructRefundGas)
 	}
 	return gas
@@ -454,7 +460,8 @@ func gasSelfdestructEIP2929(c *context) tosca.Gas {
 		gas     tosca.Gas
 		address = tosca.Address(c.stack.Back(0).Bytes20())
 	)
-	if !c.context.IsAddressInAccessList(address) { //nolint:staticcheck
+	//lint:ignore SA1019 deprecated functions to be migrated in #616
+	if !c.context.IsAddressInAccessList(address) {
 		// If the caller cannot afford the cost, this change will be rolled back
 		c.context.AccessAccount(address)
 		gas = tosca.Gas(params.ColdAccountAccessCostEIP2929)
@@ -465,7 +472,8 @@ func gasSelfdestructEIP2929(c *context) tosca.Gas {
 	}
 	// do this only for Berlin and not after London fork
 	if c.isBerlin() && !c.isLondon() {
-		if !c.context.HasSelfDestructed(c.params.Recipient) { //nolint:staticcheck
+		//lint:ignore SA1019 deprecated functions to be migrated in #616
+		if !c.context.HasSelfDestructed(c.params.Recipient) {
 			c.refund += tosca.Gas(params.SelfdestructRefundGas)
 		}
 	}

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -270,7 +270,8 @@ func opSload(c *context) {
 	slot := tosca.Key(top.Bytes32())
 	if c.isBerlin() {
 		// Check slot presence in the access list
-		if _, slotPresent := c.context.IsSlotInAccessList(c.params.Recipient, slot); !slotPresent { //nolint:staticcheck
+		//lint:ignore SA1019 deprecated functions to be migrated in #616
+		if _, slotPresent := c.context.IsSlotInAccessList(c.params.Recipient, slot); !slotPresent {
 			// If the caller cannot afford the cost, this change will be rolled back
 			// If he does afford it, we can skip checking the same thing later on, during execution
 			c.context.AccessStorage(c.params.Recipient, slot)

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -270,7 +270,7 @@ func opSload(c *context) {
 	slot := tosca.Key(top.Bytes32())
 	if c.isBerlin() {
 		// Check slot presence in the access list
-		if _, slotPresent := c.context.IsSlotInAccessList(c.params.Recipient, slot); !slotPresent {
+		if _, slotPresent := c.context.IsSlotInAccessList(c.params.Recipient, slot); !slotPresent { //nolint:staticcheck
 			// If the caller cannot afford the cost, this change will be rolled back
 			// If he does afford it, we can skip checking the same thing later on, during execution
 			c.context.AccessStorage(c.params.Recipient, slot)


### PR DESCRIPTION
The goal is still to enable #608

Three kinds:
- staticcheck detects range checks that are equal to type range. This is superfluous as the compiler already did that 
- deprecated calls, these are bigger than I. Are they really deprecated?  The code and the uses seem quite critical to me. 