### PR TITLE
CT: fix makefile geth coverage command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ evmone:
 	cmake --build build --parallel -t evmone
 
 coverage-go: DATE=$(shell date +"%Y-%m-%d-%T")
-coverage-go: TOSCA_GO_COVERAGE_DIR=./go/build/coverage/${TOSCA_GO_COVERAGE_EVM}/${DATE}/
+coverage-go: TOSCA_GO_COVERAGE_DIR=./go/build/coverage/${TOSCA_GO_COVERAGE_EVM}/${DATE}
 coverage-go:
-	go build -cover -o ${TOSCA_GO_COVERAGE_DIR}/driver ./go/ct/driver/ ; \
+	go build -cover -o ${TOSCA_GO_COVERAGE_DIR}/driver -coverpkg=./go/...,${TOSCA_GO_COVERAGE_DEPENDENCY_PACKAGES} ./go/ct/driver/ ; \
 	GOCOVERDIR=${TOSCA_GO_COVERAGE_DIR} ${TOSCA_GO_COVERAGE_DIR}/driver run --max-errors 1 ${TOSCA_GO_COVERAGE_EVM} ; \
 	go tool covdata textfmt --i ${TOSCA_GO_COVERAGE_DIR} -o ${TOSCA_GO_COVERAGE_DIR}/driver_coverage_report.txt ; \
 	go tool cover -html ${TOSCA_GO_COVERAGE_DIR}/driver_coverage_report.txt -o ${TOSCA_GO_COVERAGE_DIR}/coverage_output.html
@@ -49,6 +49,7 @@ ct-coverage-lfvm: TOSCA_GO_COVERAGE_EVM=lfvm
 ct-coverage-lfvm: coverage-go
 
 ct-coverage-geth: TOSCA_GO_COVERAGE_EVM=geth
+ct-coverage-geth: TOSCA_GO_COVERAGE_DEPENDENCY_PACKAGES=github.com/ethereum/go-ethereum/core/vm/...
 ct-coverage-geth: coverage-go
 
 test: test-go test-cpp


### PR DESCRIPTION
This pr adds the `github.com/ethereum/go-ethereum/core/vm/...` packages to the coverage report of geth. This is the correction of an oversight. 
The resulting report accounts for coverage of all packages in both `./go/...` as well as `github.com/ethereum/go-ethereum/core/vm/...`, which would be created in an analogous place as before. 