### PR TITLE
SPC: re-enable Specification_NumberOfTestCasesMatchesRuleInfo

### DIFF
--- a/go/ct/spc/specification_test.go
+++ b/go/ct/spc/specification_test.go
@@ -243,9 +243,7 @@ func TestSpecification_AtMostOneCodeAtPC(t *testing.T) {
 	}
 }
 
-// TODO: re-enable this test when runtime is not an issue anymore.
-// note: before committing run it locally where timeout is not an issue.
-func Specification_NumberOfTestCasesMatchesRuleInfo(t *testing.T) {
+func TestSpecification_NumberOfTestCasesMatchesRuleInfo(t *testing.T) {
 	rules := getAllRules()
 
 	for _, rule := range rules {


### PR DESCRIPTION
This test was disabled because it was generating timeouts in CI. Now that it's runtime has been reduced to under a minute, it should be fine to re-enable it. 
This PR fixes #615