### PR TITLE
Add support for collecting C++ coverage data from Go processes

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -221,15 +221,15 @@ Ideally, pull requests targeting performance improvements should include such a 
 
 ## Code Coverage
 
-Code coverage of the Tosca project is a work in progress. As the different systems get integrated, more features will be added and documented here.
-Go has native support for coverage, which makes getting this metric for `lfvm` or `geth` driver runs quite simple.
+The Tosca project allows to collect coverage reports for unit tests and CT runs. 
+More about coverage in [the docs folder](docs/coverage.md)
 
 ### CT Driver Code coverage
 
 To run the the CT driver code coverage simply run `make ct-coverage-lfvm` or `make ct-coverage-geth`, these commands will create the folder `Tosca/go/build/coverage/` and a sub folder with the corresponding interpreter's name. In this directory an instrumented version of the driver will be built and then run. The reports of the coverage of this run will also be in this directory, where lastly an HTML version of the report will be added as well. As more interpreter implementations are added to the Tosca project, they should also be added to the makefile.
 
 
-### C++ Code coverage
+### C++ Code Unit Test Coverage
 
 Current code coverage infrastructure uses GNU gcov system. This is supported in both Gcc and Clang, although Clang target gcov version may not be the installed one. For this reason the current infrastructure is currently enabled for Gcc only. 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,5 +84,12 @@ pipeline {
                 sh 'make test-cpp'
             }
         }
+
+        stage('Test C++ coverage support') {
+            steps {
+                sh 'make tosca-cpp-coverage'
+                sh 'go test -v  -run ^TestDumpCppCoverageData$ ./go/ct/common/ -- --expect-coverage'
+            }
+        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,7 @@ pipeline {
         stage('Test C++ coverage support') {
             steps {
                 sh 'make tosca-cpp-coverage'
-                sh 'go test -v  -run ^TestDumpCppCoverageData$ ./go/ct/common/ -- --expect-coverage'
+                sh 'go test -v  -run ^TestDumpCppCoverageData$ ./go/ct/common/ --expect-coverage'
             }
         }
     }

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ ct-coverage-geth: coverage-go
 
 ct-coverage-evmzero: tosca-cpp-coverage
 ct-coverage-evmzero: 
-	go run ./go/ct/driver run -f push evmzero ; \
+	go run ./go/ct/driver run evmzero ; \
 	echo "Coverage report generated in cpp/build/coverage/index.html"
 	@cd cpp/build ; \
 	cmake --build .  --target coverage 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ tosca-cpp:
 		-DTOSCA_ASAN="$(TOSCA_CPP_ASAN)"; \
 	cmake --build build --parallel
 
+tosca-cpp-coverage: TOSCA_CPP_BUILD = Debug
+tosca-cpp-coverage: TOSCA_CPP_COVERAGE = ON
+tosca-cpp-coverage: tosca-cpp
+
 evmone:
 	@cd third_party/evmone ; \
 	cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_SHARED_LIBRARY_SUFFIX_CXX=.so ; \
@@ -52,6 +56,13 @@ ct-coverage-geth: TOSCA_GO_COVERAGE_EVM=geth
 ct-coverage-geth: TOSCA_GO_COVERAGE_DEPENDENCY_PACKAGES=github.com/ethereum/go-ethereum/core/vm/...
 ct-coverage-geth: coverage-go
 
+ct-coverage-evmzero: tosca-cpp-coverage
+ct-coverage-evmzero: 
+	go run ./go/ct/driver run -f push evmzero ; \
+	echo "Coverage report generated in cpp/build/coverage/index.html"
+	@cd cpp/build ; \
+	cmake --build .  --target coverage 
+
 test: test-go test-cpp
 
 test-go: tosca-go
@@ -64,6 +75,10 @@ test-cpp: tosca-cpp
 test-cpp-asan: TOSCA_CPP_BUILD = Debug
 test-cpp-asan: TOSCA_CPP_ASAN = ON
 test-cpp-asan: test-cpp
+
+cpp-coverage-report: 
+	@cd cpp/build ; \
+	cmake --build .  --target coverage 
 
 test-cpp-coverage: TOSCA_CPP_BUILD = Debug
 test-cpp-coverage: TOSCA_CPP_COVERAGE = ON

--- a/cpp/cmake/tosca_coverage.cmake
+++ b/cpp/cmake/tosca_coverage.cmake
@@ -14,10 +14,6 @@ if(TOSCA_COVERAGE)
   add_link_options(--coverage)
   add_definitions(-DTOSCA_COVERAGE=1)
 
-  find_program(LCOV lcov REQUIRED)
-  find_program(GCOVR gcovr REQUIRED)
-  find_program(GENHTML genhtml REQUIRED)
-
   add_custom_target(coverage
     COMMENT "Generating coverage report."
 

--- a/cpp/cmake/tosca_coverage.cmake
+++ b/cpp/cmake/tosca_coverage.cmake
@@ -1,36 +1,57 @@
 include_guard(GLOBAL)
 
-
 option(TOSCA_COVERAGE "Enable coverage report for evmzero." OFF)
 
 if(TOSCA_COVERAGE)
+ 
   if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # gcc uses gcov, clang should use it as well, but it has version compatibility issues
     # between compiler generate code and the gcov tool.
-    message(FATAL_ERROR "Coverage is only supported with GCC.")
+    message(FATAL_ERROR "Coverage build currently is only supported with GCC.")
   endif()
 
-  add_compile_options($<$<CXX_COMPILER_ID:GNU>:--coverage>)
-  add_link_options($<$<CXX_COMPILER_ID:GNU>:--coverage>)
+  add_compile_options(--coverage)
+  add_link_options(--coverage)
+  add_definitions(-DTOSCA_COVERAGE=1)
 
   find_program(LCOV lcov REQUIRED)
+  find_program(GCOVR gcovr REQUIRED)
   find_program(GENHTML genhtml REQUIRED)
 
   add_custom_target(coverage
     COMMENT "Generating coverage report."
+
+    # Capture coverage data
     COMMAND ${LCOV} 
       --capture 
       --directory .  
       "$<$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},13.2.0>:--ignore-errors>" 
       "$<$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},13.2.0>:mismatch,mismatch,gcov>"
       --output-file coverage.info
+
+    # filter coverage data
     COMMAND ${LCOV} 
       --remove coverage.info 
       '/usr/include/*' 
       '/usr/lib/*' 
       '*/third_party/*'
       --output-file filtered.info
-    COMMAND ${GENHTML} filtered.info --output-directory coverage
+
+    # build and compress HTML report
+    COMMAND ${GENHTML} filtered.info --output-directory coverage --parallel
+    COMMAND tar czvf coverage.tar.gz coverage/ 
+
+    # Text report
+    COMMAND ${GCOVR} -r .. | tee coverage.txt
+
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
+
+  # Add a target to clean coverage data (will print found data coverage report)
+  # executed on demand
+  add_custom_target(clean_coverage_data
+    COMMAND ${GCOVR} -r .. 
+    COMMAND ${CMAKE_COMMAND} -E remove -f coverage.txt coverage coverage.tar.gz
+  )
+
 endif()

--- a/cpp/cmake/tosca_coverage.cmake
+++ b/cpp/cmake/tosca_coverage.cmake
@@ -7,7 +7,7 @@ if(TOSCA_COVERAGE)
   if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # Gcc uses Gcov, clang should use it as well, but it has version compatibility issues
     # between compiler generate code and the gcov tool. 
-    # Feel free to experiment Clang Gcov # support, unfortunatelly, it requires too much 
+    # Feel free to experiment with Clang Gcov # support, unfortunately, it requires too much 
     # manual tinkering to enable it in an automated way. 
     # Gcc and Gcov are released together, so they should be compatible.
     message(FATAL_ERROR "Coverage build only enabled for GCC.")

--- a/cpp/cmake/tosca_coverage.cmake
+++ b/cpp/cmake/tosca_coverage.cmake
@@ -5,9 +5,12 @@ option(TOSCA_COVERAGE "Enable coverage report for evmzero." OFF)
 if(TOSCA_COVERAGE)
  
   if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    # gcc uses gcov, clang should use it as well, but it has version compatibility issues
-    # between compiler generate code and the gcov tool.
-    message(FATAL_ERROR "Coverage build currently is only supported with GCC.")
+    # Gcc uses Gcov, clang should use it as well, but it has version compatibility issues
+    # between compiler generate code and the gcov tool. 
+    # Feel free to experiment Clang Gcov # support, unfortunatelly, it requires too much 
+    # manual tinkering to enable it in an automated way. 
+    # Gcc and Gcov are released together, so they should be compatible.
+    message(FATAL_ERROR "Coverage build only enabled for GCC.")
   endif()
 
   add_compile_options(--coverage)

--- a/cpp/common/CMakeLists.txt
+++ b/cpp/common/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(coverage)
+
 ###########################################################
 # Library
 add_library(tosca_common INTERFACE)

--- a/cpp/common/coverage/CMakeLists.txt
+++ b/cpp/common/coverage/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+add_library(tosca_collect_coverage SHARED collect_coverage.c)

--- a/cpp/common/coverage/collect_coverage.c
+++ b/cpp/common/coverage/collect_coverage.c
@@ -13,7 +13,7 @@ int IsCoverageEnabled() {
 #endif
 }
 
-/// When using Gcov, Shared libraries do collect coverage data,
+/// When using Gcov, shared libraries do collect coverage data,
 /// but it is not automatically written into a file. Usually, GCC would
 /// add a corresponding call to the end of a `main` function, but it
 /// can not do this for a Go application. Thus, the dumping of

--- a/cpp/common/coverage/collect_coverage.c
+++ b/cpp/common/coverage/collect_coverage.c
@@ -3,8 +3,8 @@
 extern void __gcov_dump();
 #endif
 
-/// Reports whenever the library (and therefore the complete c++ project)
-/// was compiled with coverage flags.
+// Reports whenever the library (and therefore the complete c++ project)
+// was compiled with coverage flags.
 int IsCoverageEnabled() {
 #if defined(TOSCA_COVERAGE)
   return 1;
@@ -13,15 +13,15 @@ int IsCoverageEnabled() {
 #endif
 }
 
-/// When using Gcov, shared libraries do collect coverage data,
-/// but it is not automatically written into a file. Usually, GCC would
-/// add a corresponding call to the end of a `main` function, but it
-/// can not do this for a Go application. Thus, the dumping of
-/// coverage data of C++ library code needs to be triggered explicitly
-/// by calling this function at the end of an application.
-/// Calling this function will dump coverage data for all loaded C++ libraries
-/// compiled with coverage flags. If coverage data collection is disabled,
-/// this function is a no-op.
+// When using Gcov, shared libraries do collect coverage data,
+// but it is not automatically written into a file. Usually, GCC would
+// add a corresponding call to the end of a `main` function, but it
+// can not do this for a Go application. Thus, the dumping of
+// coverage data of C++ library code needs to be triggered explicitly
+// by calling this function at the end of an application.
+// Calling this function will dump coverage data for all loaded C++ libraries
+// compiled with coverage flags. If coverage data collection is disabled,
+// this function is a no-op.
 void DumpCoverageData() {
 #if defined(TOSCA_COVERAGE)
   // Since Gcc 11, before __gcov_flush()

--- a/cpp/common/coverage/collect_coverage.c
+++ b/cpp/common/coverage/collect_coverage.c
@@ -1,0 +1,30 @@
+
+#if defined(TOSCA_COVERAGE)
+extern void __gcov_dump();
+#endif
+
+/// Reports whenever the library (and therefore the complete c++ project)
+/// was compiled with coverage flags.
+int IsCoverageEnabled() {
+#if defined(TOSCA_COVERAGE)
+  return 1;
+#else
+  return 0;
+#endif
+}
+
+/// When using Gcov, Shared libraries do collect coverage data,
+/// but it is not automatically written into a file. Usually, GCC would
+/// add a corresponding call to the end of a `main` function, but it
+/// can not do this for a Go application. Thus, the dumping of
+/// coverage data of C++ library code needs to be triggered explicitly
+/// by calling this function at the end of an application.
+/// Calling this function will dump coverage data for all loaded C++ libraries
+/// compiled with coverage flags. If coverage data collection is disabled,
+/// this function is a no-op.
+void DumpCoverageData() {
+#if defined(TOSCA_COVERAGE)
+  // Since Gcc 11, before __gcov_flush()
+  __gcov_dump();
+#endif
+}

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,45 @@
+# Code Coverage
+
+The Tosca project collects coverage data using different technologies for the C++ and Go code bases. 
+
+## Coverage in Go
+
+The official [documentation](https://go.dev/doc/build-cover) explains how to use it.
+Both Unit tests and CT driver can produce coverage reports.
+
+By default Go coverage will only include the source of included files, not dependencies. 
+The argument `-coverpkg=./go/...,github.com/project/dependency-name/` will include coverage reports from included code.
+
+## Coverage in C++
+
+C and C++ can be instrumented for coverage reports using both Gcc and Clang, nevertheless procedure is slightly different:
+- Gcc uses [gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html), there is an ecosystem of tools around gcov, to filter, modify and produce reports: [lcov](https://wiki.documentfoundation.org/Development/Lcov)
+- [Clang](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html) implements its [own coverage technology](https://clang.llvm.org/docs/SanitizerCoverage.html), but in theory they provide support for gcov. This later follows a different paradigm, as the coverage engine will only record data for the module indicated at runtime. 
+
+Tosca uses *gcov* to collect coverage data from the C++ tests.
+At the time this document was written, Clang compilation support for Gcov would require some extra work at the compilation level.
+
+By default all available source files collect coverage data. Third party and system headers coverage is filtered out after collection using lcov.
+```bash
+lcov --remove coverage.info /usr/include/* /usr/lib/*' */third_party/* --output-file filtered.info
+```
+- Text report is generated can can be found in `cpp/build/coverage.txt`
+- Html report is generated and can be found in `cpp/build/coverage/index.html` or compressed as `cpp/build/coverage.tar.gz`
+
+
+## Collect C++ coverage when running CT evmzero 
+
+Gcov collects coverage data during runtime and only at the end of the process is saved into a file. This instrumentation is added to the main function of the C++ process, and since CT is Go, be added. 
+It is possible to call the Gcov dump routine in runtime, by calling __gcov_dump. A mechanism to invoke such routine from Go has been implemented, so that the CT can generate the required data files. 
+
+To retrieve the coverage report execute in the following order:
+```bash
+make tosca-cpp-coverage
+go run ./go/ct/driver run evmzero
+make cpp-coverage-report
+```
+
+When replacing `make tosca-cpp-coverage` with `make cpp-test-coverage`, unit test coverage will be combined into the report.
+
+Results can be found as in the same folder as described before.
+

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -29,7 +29,7 @@ lcov --remove coverage.info /usr/include/* /usr/lib/*' */third_party/* --output-
 
 ## Collect C++ coverage when running CT evmzero 
 
-Gcov collects coverage data during runtime and only at the end of the process is saved into a file. This instrumentation is added to the main function of the C++ process, and since CT is Go, be added. 
+Gcov collects coverage data during runtime and only at the end of the process it is saved into a file. This mechanism would be called automatically on the C++ main process, but has to be called manually when using evmzero from a Go process.
 It is possible to call the Gcov dump routine in runtime, by calling __gcov_dump. A mechanism to invoke such routine from Go has been implemented, so that the CT can generate the required data files. 
 
 To retrieve the coverage report execute in the following order:

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -12,8 +12,8 @@ The argument `-coverpkg=./go/...,github.com/project/dependency-name/` will inclu
 
 ## Coverage in C++
 
-C and C++ can be instrumented for coverage reports using both Gcc and Clang, nevertheless procedure is slightly different:
-- Gcc uses [gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html), there is an ecosystem of tools around gcov, to filter, modify and produce reports: [lcov](https://wiki.documentfoundation.org/Development/Lcov)
+C and C++ can be instrumented for coverage reports using both Gcc and Clang. However, the actual procedure to do so is slightly different:
+- Gcc uses [gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html); there is an ecosystem of tools around gcov, to filter, modify and produce reports: [lcov](https://wiki.documentfoundation.org/Development/Lcov)
 - [Clang](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html) implements its [own coverage technology](https://clang.llvm.org/docs/SanitizerCoverage.html), but in theory they provide support for gcov. This later follows a different paradigm, as the coverage engine will only record data for the module indicated at runtime. 
 
 Tosca uses *gcov* to collect coverage data from the C++ tests.
@@ -23,16 +23,16 @@ By default all available source files collect coverage data. Third party and sys
 ```bash
 lcov --remove coverage.info /usr/include/* /usr/lib/*' */third_party/* --output-file filtered.info
 ```
-- Text report is generated can can be found in `cpp/build/coverage.txt`
+- Text report is generated and can be found in `cpp/build/coverage.txt`
 - Html report is generated and can be found in `cpp/build/coverage/index.html` or compressed as `cpp/build/coverage.tar.gz`
 
 
 ## Collect C++ coverage when running CT evmzero 
 
 Gcov collects coverage data during runtime and only at the end of the process it is saved into a file. This mechanism would be called automatically on the C++ main process, but has to be called manually when using evmzero from a Go process.
-It is possible to call the Gcov dump routine in runtime, by calling __gcov_dump. A mechanism to invoke such routine from Go has been implemented, so that the CT can generate the required data files. 
+It is possible to call the Gcov dump routine in runtime, by calling __gcov_dump. A mechanism to invoke this routine from Go has been implemented, so that the CT can generate the required data files. 
 
-To retrieve the coverage report execute in the following order:
+To retrieve the coverage report execute the following commands:
 ```bash
 make tosca-cpp-coverage
 go run ./go/ct/driver run evmzero
@@ -41,5 +41,5 @@ make cpp-coverage-report
 
 When replacing `make tosca-cpp-coverage` with `make cpp-test-coverage`, unit test coverage will be combined into the report.
 
-Results can be found as in the same folder as described before.
+Results can be found in the same folder as described before.
 

--- a/go/ct/common/cpp_coverage.go
+++ b/go/ct/common/cpp_coverage.go
@@ -10,7 +10,8 @@ void DumpCoverageData();
 import "C"
 
 // isCppCoverageEnabled returns true if C++ has been compiled with coverage enabled.
-// this assumes that every C++ library loaded at runtime has been compiled with coverage enabled.
+// This assumes that every C++ library loaded at runtime for which coverage data should
+// be collected has been compiled with coverage enabled.
 func isCppCoverageEnabled() bool {
 	return C.IsCoverageEnabled() != 0
 }
@@ -18,6 +19,7 @@ func isCppCoverageEnabled() bool {
 // DumpCppCoverageData triggers the C++ code to dump coverage data.
 // Not calling this function will result in no coverage data being reported
 // for runtime loaded C and C++ libraries.
+// If coverage data collection is not enabled, this function is a no-op.
 func DumpCppCoverageData() {
 	C.DumpCoverageData()
 }

--- a/go/ct/common/cpp_coverage.go
+++ b/go/ct/common/cpp_coverage.go
@@ -1,3 +1,13 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
 package common
 
 /*

--- a/go/ct/common/cpp_coverage.go
+++ b/go/ct/common/cpp_coverage.go
@@ -1,0 +1,23 @@
+package common
+
+/*
+#cgo LDFLAGS: -L${SRCDIR}/../../../cpp/build/common/coverage -ltosca_collect_coverage
+#cgo LDFLAGS: -Wl,-rpath,${SRCDIR}/../../../cpp/build/common/coverage
+
+int IsCoverageEnabled();
+void DumpCoverageData();
+*/
+import "C"
+
+// isCppCoverageEnabled returns true if C++ has been compiled with coverage enabled.
+// this assumes that every C++ library loaded at runtime has been compiled with coverage enabled.
+func isCppCoverageEnabled() bool {
+	return C.IsCoverageEnabled() != 0
+}
+
+// DumpCppCoverageData triggers the C++ code to dump coverage data.
+// Not calling this function will result in no coverage data being reported
+// for runtime loaded C and C++ libraries.
+func DumpCppCoverageData() {
+	C.DumpCoverageData()
+}

--- a/go/ct/common/cpp_coverage_test.go
+++ b/go/ct/common/cpp_coverage_test.go
@@ -4,7 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings" // Add this line to import the "strings" package
+	"strings"
 	"testing"
 )
 
@@ -27,6 +27,8 @@ func TestDumpCppCoverageData(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		// .gcno are generated at compile time, with source code locations and other meta
+		// .gcda are generated at runtime with the actual coverage
 		found = strings.HasSuffix(s, ".gcda")
 		return nil
 	})
@@ -35,6 +37,6 @@ func TestDumpCppCoverageData(t *testing.T) {
 	}
 
 	if !found {
-		t.Fatalf("Failed to find gcda files")
+		t.Fatalf("Failed, test generated no coverage data files")
 	}
 }

--- a/go/ct/common/cpp_coverage_test.go
+++ b/go/ct/common/cpp_coverage_test.go
@@ -1,3 +1,13 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
 package common
 
 import (

--- a/go/ct/common/cpp_coverage_test.go
+++ b/go/ct/common/cpp_coverage_test.go
@@ -4,14 +4,26 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
+	"slices"
 	"strings"
 	"testing"
 )
 
 func TestDumpCppCoverageData(t *testing.T) {
 
-	if !isCppCoverageEnabled() {
-		t.Skip("C++ coverage is not enabled")
+	testArguments := parseCustomArguments(os.Args)
+	expectEnabled := slices.Contains(testArguments, "--expect-coverage")
+	enabled := isCppCoverageEnabled()
+
+	if !enabled {
+		if expectEnabled {
+			t.Fatalf("Failed, cpp coverage is not enabled")
+		} else {
+			t.Skip("Skipping test, cpp coverage disabled and not expected to be enabled")
+		}
+	} else if !expectEnabled {
+		t.Fatalf("Failed, cpp coverage is enabled, but it was expected disabled")
 	}
 
 	// write coverage data into tempDir directory
@@ -39,4 +51,51 @@ func TestDumpCppCoverageData(t *testing.T) {
 	if !found {
 		t.Fatalf("Failed, test generated no coverage data files")
 	}
+}
+
+func TestParseCustomArguments(t *testing.T) {
+
+	tests := map[string]struct {
+		name     string
+		args     []string
+		expected []string
+	}{
+		"empty": {
+			args:     []string{},
+			expected: nil,
+		},
+		"No custom arguments": {
+			args:     []string{"program", "arg1", "arg2"},
+			expected: nil,
+		},
+		"Custom arguments present": {
+			args:     []string{"program", "--", "custom1", "custom2"},
+			expected: []string{"custom1", "custom2"},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			result := parseCustomArguments(test.args)
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf("Unexpected result. Got: %v, Expected: %v", result, test.expected)
+			}
+		})
+	}
+}
+
+// parseCustomArguments is a helper function to parse custom arguments found
+// after the "--" separator in the command line arguments.
+func parseCustomArguments(args []string) []string {
+	var afterDash []string
+	foundDash := false
+
+	for _, arg := range args {
+		if foundDash {
+			afterDash = append(afterDash, arg)
+		} else if arg == "--" {
+			foundDash = true
+		}
+	}
+	return afterDash
 }

--- a/go/ct/common/cpp_coverage_test.go
+++ b/go/ct/common/cpp_coverage_test.go
@@ -11,19 +11,19 @@
 package common
 
 import (
+	"flag"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"reflect"
-	"slices"
 	"strings"
 	"testing"
 )
 
+var stateImpl = flag.Bool("expect-coverage", false, "enable if the unit test is expecting a coverage build")
+
 func TestDumpCppCoverageData(t *testing.T) {
 
-	testArguments := parseCustomArguments(os.Args)
-	expectEnabled := slices.Contains(testArguments, "--expect-coverage")
+	expectEnabled := *stateImpl
 	enabled := isCppCoverageEnabled()
 
 	if !enabled {
@@ -61,51 +61,4 @@ func TestDumpCppCoverageData(t *testing.T) {
 	if !found {
 		t.Fatalf("Failed, test generated no coverage data files")
 	}
-}
-
-func TestParseCustomArguments(t *testing.T) {
-
-	tests := map[string]struct {
-		name     string
-		args     []string
-		expected []string
-	}{
-		"empty": {
-			args:     []string{},
-			expected: nil,
-		},
-		"No custom arguments": {
-			args:     []string{"program", "arg1", "arg2"},
-			expected: nil,
-		},
-		"Custom arguments present": {
-			args:     []string{"program", "--", "custom1", "custom2"},
-			expected: []string{"custom1", "custom2"},
-		},
-	}
-
-	for testName, test := range tests {
-		t.Run(testName, func(t *testing.T) {
-			result := parseCustomArguments(test.args)
-			if !reflect.DeepEqual(result, test.expected) {
-				t.Errorf("Unexpected result. Got: %v, Expected: %v", result, test.expected)
-			}
-		})
-	}
-}
-
-// parseCustomArguments is a helper function to parse custom arguments found
-// after the "--" separator in the command line arguments.
-func parseCustomArguments(args []string) []string {
-	var afterDash []string
-	foundDash := false
-
-	for _, arg := range args {
-		if foundDash {
-			afterDash = append(afterDash, arg)
-		} else if arg == "--" {
-			foundDash = true
-		}
-	}
-	return afterDash
 }

--- a/go/ct/common/cpp_coverage_test.go
+++ b/go/ct/common/cpp_coverage_test.go
@@ -51,7 +51,7 @@ func TestDumpCppCoverageData(t *testing.T) {
 		}
 		// .gcno are generated at compile time, with source code locations and other meta
 		// .gcda are generated at runtime with the actual coverage
-		found = strings.HasSuffix(s, ".gcda")
+		found = found || strings.HasSuffix(s, ".gcda")
 		return nil
 	})
 	if err != nil {

--- a/go/ct/common/cpp_coverage_test.go
+++ b/go/ct/common/cpp_coverage_test.go
@@ -1,0 +1,40 @@
+package common
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings" // Add this line to import the "strings" package
+	"testing"
+)
+
+func TestDumpCppCoverageData(t *testing.T) {
+
+	if !isCppCoverageEnabled() {
+		t.Skip("C++ coverage is not enabled")
+	}
+
+	// write coverage data into tempDir directory
+	tempDir := t.TempDir()
+	os.Setenv("GCOV_PREFIX", tempDir)
+
+	// run dump routine
+	DumpCppCoverageData()
+
+	// check that at least one file is generated
+	found := false
+	err := filepath.WalkDir(tempDir, func(s string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		found = strings.HasSuffix(s, ".gcda")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to walk directory %s: %v", tempDir, err)
+	}
+
+	if !found {
+		t.Fatalf("Failed to find gcda files")
+	}
+}

--- a/go/ct/driver/run.go
+++ b/go/ct/driver/run.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/Fantom-foundation/Tosca/go/ct"
+	"github.com/Fantom-foundation/Tosca/go/ct/common"
 	cliUtils "github.com/Fantom-foundation/Tosca/go/ct/driver/cli"
 	"github.com/Fantom-foundation/Tosca/go/ct/rlz"
 	"github.com/Fantom-foundation/Tosca/go/ct/spc"
@@ -57,6 +58,7 @@ var evms = map[string]ct.Evm{
 }
 
 func doRun(context *cli.Context) error {
+	defer common.DumpCppCoverageData()
 
 	jobCount := cliUtils.JobsFlag.Fetch(context)
 	seed := cliUtils.SeedFlag.Fetch(context)


### PR DESCRIPTION
When running a C++ library from go, the coverage instrumentation is never dump to file and is lost. This process needs to be done manually in these cross-language environments.

The solution proposed loads a C library in the Go program, which exports the functionality to dump coverage data into files. This dumps coverage data for any loaded library in the program namespace with coverage enabled. 

