### PR TITLE
Document and Script how to use C++ coverage in CT.

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -221,15 +221,15 @@ Ideally, pull requests targeting performance improvements should include such a 
 
 ## Code Coverage
 
-Code coverage of the Tosca project is a work in progress. As the different systems get integrated, more features will be added and documented here.
-Go has native support for coverage, which makes getting this metric for `lfvm` or `geth` driver runs quite simple.
+The Tosca project allows to collect coverage reports for unit tests and CT runs. 
+More about coverage in [the docs folder](docs/coverage.md)
 
 ### CT Driver Code coverage
 
 To run the the CT driver code coverage simply run `make ct-coverage-lfvm` or `make ct-coverage-geth`, these commands will create the folder `Tosca/go/build/coverage/` and a sub folder with the corresponding interpreter's name. In this directory an instrumented version of the driver will be built and then run. The reports of the coverage of this run will also be in this directory, where lastly an HTML version of the report will be added as well. As more interpreter implementations are added to the Tosca project, they should also be added to the makefile.
 
 
-### C++ Code coverage
+### C++ Code Unit Test Coverage
 
 Current code coverage infrastructure uses GNU gcov system. This is supported in both Gcc and Clang, although Clang target gcov version may not be the installed one. For this reason the current infrastructure is currently enabled for Gcc only. 
 

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,13 @@ ct-coverage-geth: TOSCA_GO_COVERAGE_EVM=geth
 ct-coverage-geth: TOSCA_GO_COVERAGE_DEPENDENCY_PACKAGES=github.com/ethereum/go-ethereum/core/vm/...
 ct-coverage-geth: coverage-go
 
+ct-coverage-evmzero: tosca-cpp-coverage
+ct-coverage-evmzero: 
+	go run ./go/ct/driver run -f push evmzero ; \
+	echo "Coverage report generated in cpp/build/coverage/index.html"
+	@cd cpp/build ; \
+	cmake --build .  --target coverage 
+
 test: test-go test-cpp
 
 test-go: tosca-go

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ tosca-cpp:
 		-DTOSCA_ASAN="$(TOSCA_CPP_ASAN)"; \
 	cmake --build build --parallel
 
+test-cpp-coverage: TOSCA_CPP_BUILD = Debug
+tosca-cpp-coverage: TOSCA_CPP_COVERAGE = ON
+tosca-cpp-coverage: tosca-cpp
+
 evmone:
 	@cd third_party/evmone ; \
 	cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_SHARED_LIBRARY_SUFFIX_CXX=.so ; \
@@ -64,6 +68,10 @@ test-cpp: tosca-cpp
 test-cpp-asan: TOSCA_CPP_BUILD = Debug
 test-cpp-asan: TOSCA_CPP_ASAN = ON
 test-cpp-asan: test-cpp
+
+cpp-coverage-report: 
+	@cd cpp/build ; \
+	cmake --build .  --target coverage 
 
 test-cpp-coverage: TOSCA_CPP_BUILD = Debug
 test-cpp-coverage: TOSCA_CPP_COVERAGE = ON

--- a/cpp/cmake/tosca_coverage.cmake
+++ b/cpp/cmake/tosca_coverage.cmake
@@ -1,36 +1,60 @@
 include_guard(GLOBAL)
 
-
 option(TOSCA_COVERAGE "Enable coverage report for evmzero." OFF)
 
 if(TOSCA_COVERAGE)
-  if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+ 
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     # gcc uses gcov, clang should use it as well, but it has version compatibility issues
     # between compiler generate code and the gcov tool.
     message(FATAL_ERROR "Coverage is only supported with GCC.")
   endif()
 
-  add_compile_options($<$<CXX_COMPILER_ID:GNU>:--coverage>)
-  add_link_options($<$<CXX_COMPILER_ID:GNU>:--coverage>)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 
-  find_program(LCOV lcov REQUIRED)
-  find_program(GENHTML genhtml REQUIRED)
+    add_compile_options(--coverage -fprofile-arcs)
+    add_link_options(--coverage -fprofile-arcs)
+    add_definitions(-DTOSCA_COVERAGE=true)
 
-  add_custom_target(coverage
-    COMMENT "Generating coverage report."
-    COMMAND ${LCOV} 
-      --capture 
-      --directory .  
-      "$<$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},13.2.0>:--ignore-errors>" 
-      "$<$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},13.2.0>:mismatch,mismatch,gcov>"
-      --output-file coverage.info
-    COMMAND ${LCOV} 
-      --remove coverage.info 
-      '/usr/include/*' 
-      '/usr/lib/*' 
-      '*/third_party/*'
-      --output-file filtered.info
-    COMMAND ${GENHTML} filtered.info --output-directory coverage
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  )
+    find_program(LCOV lcov REQUIRED)
+    find_program(GCOVR gcovr REQUIRED)
+    find_program(GENHTML genhtml REQUIRED)
+
+    add_custom_target(coverage
+      COMMENT "Generating coverage report."
+
+      # Capture coverage data
+      COMMAND ${LCOV} 
+        --capture 
+        --directory .  
+        "$<$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},13.2.0>:--ignore-errors>" 
+        "$<$<VERSION_GREATER_EQUAL:${CMAKE_CXX_COMPILER_VERSION},13.2.0>:mismatch,mismatch,gcov>"
+        --output-file coverage.info
+
+      # filter coverage data
+      COMMAND ${LCOV} 
+        --remove coverage.info 
+        '/usr/include/*' 
+        '/usr/lib/*' 
+        '*/third_party/*'
+        --output-file filtered.info
+
+      # build and compress HTML report
+      COMMAND ${GENHTML} filtered.info --output-directory coverage --parallel
+      COMMAND tar czvf coverage.tar.gz coverage/ 
+
+      # Text report
+      COMMAND ${GCOVR} -r .. | tee coverage.txt
+
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+
+    # Add a target to clean coverage data (will print found data coverage report)
+    # executed on demand
+    add_custom_target(clean_coverage_data
+      COMMAND ${GCOVR} -r .. 
+      COMMAND ${CMAKE_COMMAND} -E remove -f coverage.txt coverage coverage.tar.gz
+    )
+
+  endif()
 endif()

--- a/cpp/cmake/tosca_coverage.cmake
+++ b/cpp/cmake/tosca_coverage.cmake
@@ -44,7 +44,7 @@ if(TOSCA_COVERAGE)
       COMMAND tar czvf coverage.tar.gz coverage/ 
 
       # Text report
-      COMMAND ${GCOVR} -r .. | tee coverage.txt
+      COMMAND ${GCOVR} -r .. --gcov-ignore-parse-errors | tee coverage.txt
 
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )

--- a/cpp/vm/evmzero/evmzero.cc
+++ b/cpp/vm/evmzero/evmzero.cc
@@ -134,7 +134,8 @@ class VM : public evmc_vm {
             .set_option = [](evmc_vm* vm, char const* name, char const* value) -> evmc_set_option_result {
               return static_cast<VM*>(vm)->SetOption(name, value);
             },
-        } {}
+        } {
+  }
 
   evmc_result Execute(std::span<const uint8_t> code,              //
                       const evmc_message* message,                //

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,32 @@
+# Code Coverage
+
+The Tosca project collects coverage data using different technologies for the C++ and Go code bases. 
+
+## Coverage in Go
+
+The official [documentation](https://go.dev/doc/build-cover) explains how to use it.
+Both Unit tests and CT driver can produce coverage reports.
+
+By default Go coverage will only include the source of included files, not dependencies. 
+The argument `-coverpkg=./go/...,github.com/project/dependency-name/` will include coverage reports from included code.
+
+## Coverage in C++
+
+C and C++ can be instrumented for coverage reports using both Gcc and Clang, nevertheless procedure is slightly different:
+- Gcc uses [gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html), there is an ecosystem of tools around gcov, to filter, modify and produce reports: [lcov](https://wiki.documentfoundation.org/Development/Lcov)
+- [Clang](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html) implements its [own coverage technology](https://clang.llvm.org/docs/SanitizerCoverage.html), but in theory they provide support for gcov. This later follows a different paradigm, as the coverage engine will only record data for the module indicated at runtime. 
+
+Tosca uses *gcov* to collect coverage data from the C++ tests.
+
+By default all available source files collect coverage data. Third party and system headers coverage is filtered out after collection using lcov.
+```bash
+lcov --remove coverage.info /usr/include/* /usr/lib/*' */third_party/* --output-file filtered.info
+```
+- Text report is generated can can be found in `cpp/build/coverage.txt`
+- Html report is generated and can be found in `cpp/build/coverage/index.html` or compressed as `cpp/build/coverage.tar.gz`
+
+
+## Collect C++ coverage when running CT evmzero 
+
+Gcov collects coverage data during runtime and only  at the end of the process 
+

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -28,5 +28,17 @@ lcov --remove coverage.info /usr/include/* /usr/lib/*' */third_party/* --output-
 
 ## Collect C++ coverage when running CT evmzero 
 
-Gcov collects coverage data during runtime and only  at the end of the process 
+Gcov collects coverage data during runtime and only at the end of the process is saved into a file. This instrumentation is added to the main function of the C++ process, and since CT is Go, it wont execute. 
+For this reason, Go needs to manually de-initialize the shared library, to manually call the coverage dump routine. This will happen automatically whenever the `libevmzero.so` is compiled with coverage support.
+
+To retrieve the coverage report execute in the following order:
+```bash
+make tosca-cpp-coverage
+go run ./go/ct/driver run evmzero
+make cpp-coverage-report
+```
+
+When replacing `make tosca-cpp-coverage` with `make cpp-test-coverage`, unit test coverage will be combined into the report.
+
+Results can be found as in the same folder as described before.
 

--- a/go/ct/driver/probe.go
+++ b/go/ct/driver/probe.go
@@ -28,7 +28,6 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"github.com/dsnet/golib/unitconv"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/exp/maps"
 )
 
 var ProbeCmd = cliUtils.AddCommonFlags(cli.Command{
@@ -53,10 +52,11 @@ func doProbe(context *cli.Context) error {
 		evmIdentifier = context.Args().Get(0)
 	}
 
-	evm, ok := evms[evmIdentifier]
-	if !ok {
-		return fmt.Errorf("invalid EVM identifier, use one of: %v", maps.Keys(evms))
+	evm, err := getVm(evmIdentifier)
+	if err != nil {
+		return err
 	}
+	defer evm.Destroy()
 
 	jobCount := cliUtils.JobsFlag.Fetch(context)
 	if jobCount <= 0 {

--- a/go/ct/driver/regressions.go
+++ b/go/ct/driver/regressions.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/ct/spc"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/exp/maps"
 )
 
 var RegressionsCmd = cliUtils.AddCommonFlags(cli.Command{
@@ -83,13 +82,14 @@ func doRegressionTests(context *cli.Context) error {
 		evmIdentifier = context.Args().Get(0)
 	}
 
-	evm, ok := evms[evmIdentifier]
-	if !ok {
-		return fmt.Errorf("invalid EVM identifier, use one of: %v", maps.Keys(evms))
+	evm, err := getVm(evmIdentifier)
+	if err != nil {
+		return err
 	}
+	defer evm.Destroy()
 
 	inputs := context.StringSlice("input")
-	inputs, err := enumerateInputs(inputs)
+	inputs, err = enumerateInputs(inputs)
 	if err != nil {
 		return err
 	}

--- a/go/ct/driver/vms.go
+++ b/go/ct/driver/vms.go
@@ -1,3 +1,13 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
 package main
 
 import (

--- a/go/ct/driver/vms.go
+++ b/go/ct/driver/vms.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/Fantom-foundation/Tosca/go/ct"
+	"github.com/Fantom-foundation/Tosca/go/interpreter/evmzero"
+	"github.com/Fantom-foundation/Tosca/go/interpreter/geth"
+	"github.com/Fantom-foundation/Tosca/go/interpreter/lfvm"
+	"golang.org/x/exp/maps"
+)
+
+func getVm(evmIdentifier string) (ct.Evm, error) {
+
+	var allowedEVMs = map[string]func() ct.Evm{
+		"lfvm":    func() ct.Evm { return lfvm.NewConformanceTestingTarget() },
+		"geth":    func() ct.Evm { return geth.NewConformanceTestingTarget() },
+		"evmzero": func() ct.Evm { return evmzero.NewConformanceTestingTarget() },
+	}
+
+	if f, ok := allowedEVMs[evmIdentifier]; ok {
+		return f(), nil
+	}
+
+	return nil, fmt.Errorf("invalid EVM identifier, use one of: %v", maps.Keys(allowedEVMs))
+}

--- a/go/ct/evm.go
+++ b/go/ct/evm.go
@@ -17,4 +17,8 @@ type Evm interface {
 	// StepN executes up to N instructions on the given state, returning the resulting state or an error.
 	// The function may modify the provided state to produce the result state.
 	StepN(state *st.State, numSteps int) (*st.State, error)
+
+	// Destroy cleans up any resources associated with the EVM.
+	// It may execute de-initialization code: like dumping coverage data to file
+	Destroy()
 }

--- a/go/interpreter/evmc/evmc_steppable_interpreter.go
+++ b/go/interpreter/evmc/evmc_steppable_interpreter.go
@@ -35,6 +35,10 @@ type SteppableEvmcInterpreter struct {
 	vm *evmc.VMSteppable
 }
 
+func (e *SteppableEvmcInterpreter) Destroy() {
+	e.vm.Destroy()
+}
+
 func (e *SteppableEvmcInterpreter) StepN(
 	params tosca.Parameters,
 	state *st.State,

--- a/go/interpreter/evmzero/ct.go
+++ b/go/interpreter/evmzero/ct.go
@@ -49,3 +49,7 @@ func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 
 	return evmzeroSteppable.StepN(vmParams, state, numSteps)
 }
+
+func (a ctAdapter) Destroy() {
+	evmzeroSteppable.Destroy()
+}

--- a/go/interpreter/geth/ct.go
+++ b/go/interpreter/geth/ct.go
@@ -88,6 +88,10 @@ func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 	return state, nil
 }
 
+func (a ctAdapter) Destroy() {
+	// Go code does not need to destroy the interpreter.
+}
+
 func convertGethStatusToCtStatus(state *geth_vm.InterpreterState) (st.StatusCode, error) {
 	switch state.Status {
 	case geth_vm.Running:

--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -116,6 +116,10 @@ func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 	return state, nil
 }
 
+func (a ctAdapter) Destroy() {
+	// Go code does not need to destroy the interpreter.
+}
+
 var pcMapCache = struct {
 	maxSize int
 	data    map[[32]byte]*PcMap


### PR DESCRIPTION
This PR is mostly documentation, should explain itself.

But there are some script changes
- enable c++ unit tests coverage in PR CI, because it is pretty fast.
- modify scripts to allow generating reports without compiling or running anything. Useful to compile-run-report arbitrary commands. 


fixes #623