### PR TITLE
Add integration test for different call types

### DIFF
--- a/go/integration_test/processor/scenario.go
+++ b/go/integration_test/processor/scenario.go
@@ -244,7 +244,7 @@ func (c *scenarioContext) GetBlockHash(number int64) tosca.Hash {
 }
 
 func (c *scenarioContext) GetCommittedStorage(addr tosca.Address, key tosca.Key) tosca.Word {
-	panic("implement me")
+	return c.original[addr].Storage[key]
 }
 
 func (c *scenarioContext) IsAddressInAccessList(addr tosca.Address) bool {

--- a/go/processor/floria/run_context_test.go
+++ b/go/processor/floria/run_context_test.go
@@ -145,8 +145,6 @@ func TestTransferValue_InCallRestoreFailed(t *testing.T) {
 		Input:     []byte{},
 	}
 
-	context.EXPECT().GetCodeHash(params.Recipient).Return(tosca.Hash{})
-	context.EXPECT().GetCode(params.Recipient).Return([]byte{})
 	context.EXPECT().CreateSnapshot()
 	context.EXPECT().GetBalance(params.Sender).Return(tosca.NewValue(0))
 	context.EXPECT().RestoreSnapshot(gomock.Any())


### PR DESCRIPTION
One of the biggest differences between the different call types is whether they access the same storage. An integration test writing into storage and reading from the same slot in an inner call is added in this PR.
Some minor restructuring as preparation for the implementation in Floria is also performed.