### PR TITLE
Suppress export of geth reference interpreter to go-ethereum

### DIFF
--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -38,7 +38,15 @@ const adapterDebug = false
 
 func init() {
 	for name, interpreter := range tosca.GetAllRegisteredInterpreters() {
-		RegisterGethInterpreter(name, interpreter)
+		// We register all tosca interpreters except the geth reference interpreter.
+		// Tosca's geth reference implementation in combination with the adapter
+		// implemented would lead to unexpected behavior since geth would no longer
+		// use its own interpreter when requesting the `geth` interpreter. Instead
+		// Tosca's geth reference wrapped in the adapter would be used -- a combination
+		// that is not well tested.
+		if name == "" || name != "geth" {
+			RegisterGethInterpreter(name, interpreter)
+		}
 	}
 }
 

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 	geth "github.com/ethereum/go-ethereum/core/vm"
 	"go.uber.org/mock/gomock"
+
+	_ "github.com/Fantom-foundation/Tosca/go/interpreter/geth"
 )
 
 //go:generate mockgen -source adapter_test.go -destination adapter_test_mocks.go -package geth_adapter
@@ -71,5 +73,19 @@ func TestRunContextAdapter_SetBalanceHasCorrectEffect(t *testing.T) {
 			adapter := &runContextAdapter{evm: &geth.EVM{StateDB: stateDb}}
 			adapter.SetBalance(tosca.Address{}, test.after)
 		})
+	}
+}
+
+func TestRunContextAdapter_ReferenceGethInterpreterIsNotExported(t *testing.T) {
+	if res := tosca.GetInterpreter("geth"); res == nil {
+		t.Fatal("geth reference interpreter not available in Tosca")
+	}
+	evm := &geth.EVM{}
+	interpreter := geth.NewInterpreter("geth", evm, geth.Config{})
+	if interpreter == nil {
+		t.Fatal("no interpreter registered for 'geth'")
+	}
+	if _, ok := interpreter.(*gethInterpreterAdapter); ok {
+		t.Fatal("geth reference interpreter is exported")
 	}
 }


### PR DESCRIPTION
This PR fixes the support for running the `geth` interpreter with the `aida` or `floria` processor in Aida.

The change in this PR prevents the `geth` reference interpreter maintained by Tosca to replace the `geth` interpreter implementation in a host system like Sonic or Aida. Before this change, the geth version included in the host system got replaced by a version with the following structure:
```
gethToToscaAdapter(toscaToGethAdapter(gethReferenceInterpreter)))
```
This is a surprising setup, that is not the expected configuration when users are selecting the `geth` VM option in Aida or Sonic.

The issue was not discovered earlier since the [RegisterInterpreterFactory](https://github.com/Fantom-foundation/go-ethereum-sonic/blob/2400937cc3b1c370ea8735d7af86eac621e4eb70/core/vm/tosca_integration.go#L72) function in `go-ethereum-sonic` is not checking for name collisions. This should be fixed eventually, but even if it would be checked, the correct response would have been a panic. Thus, the call needs to be prevented in the first place anyway.

This is part of #402