### PR TITLE
Github report coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -62,20 +62,21 @@ jobs:
     - name: CT regression tests evmzero
       run: go run ./go/ct/driver regressions evmzero
 
-    - name: Coverage
-      uses: actions/github-script@v6
-      with:
-       script: |
-          const execSync = require('child_process').execSync;
-          const coverageResult = execSync('make coverage-check', { encoding: 'utf-8' });
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: `Test results:\n\n${coverageResult}`
-          });
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # TODO: re-enable when unit test coverage is increased
+    # - name: Test coverage
+    #   uses: actions/github-script@v6
+    #   with:
+    #    script: |
+    #       const execSync = require('child_process').execSync;
+    #       const coverageResult = execSync('make test-coverage', { encoding: 'utf-8' });
+    #       github.rest.issues.createComment({
+    #         issue_number: context.issue.number,
+    #         owner: context.repo.owner,
+    #         repo: context.repo.repo,
+    #         body: `Test results:\n\n${coverageResult}`
+    #       });
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     # see issue #316
     #- name: CT rule coverage test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,6 +63,7 @@ jobs:
       run: go run ./go/ct/driver regressions evmzero
 
     - name: Test coverage
+      if: github.ref != 'refs/heads/main'
       uses: actions/github-script@v6
       with:
        script: |
@@ -76,10 +77,3 @@ jobs:
           });
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    # see issue #316
-    #- name: CT rule coverage test
-    #  run: go run ./go/ct/driver test
-
-    #- name: CT on LFVM
-    #  run: go run ./go/ct/driver run lfvm

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -62,21 +62,20 @@ jobs:
     - name: CT regression tests evmzero
       run: go run ./go/ct/driver regressions evmzero
 
-    # TODO: re-enable when unit test coverage is increased
-    # - name: Test coverage
-    #   uses: actions/github-script@v6
-    #   with:
-    #    script: |
-    #       const execSync = require('child_process').execSync;
-    #       const coverageResult = execSync('make test-coverage', { encoding: 'utf-8' });
-    #       github.rest.issues.createComment({
-    #         issue_number: context.issue.number,
-    #         owner: context.repo.owner,
-    #         repo: context.repo.repo,
-    #         body: `Test results:\n\n${coverageResult}`
-    #       });
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Test coverage
+      uses: actions/github-script@v6
+      with:
+       script: |
+          const execSync = require('child_process').execSync;
+          const coverageResult = execSync('make test-coverage', { encoding: 'utf-8' });
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `Test results:\n\n${coverageResult}`
+          });
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     # see issue #316
     #- name: CT rule coverage test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -62,6 +62,21 @@ jobs:
     - name: CT regression tests evmzero
       run: go run ./go/ct/driver regressions evmzero
 
+    - name: Coverage
+      uses: actions/github-script@v6
+      with:
+       script: |
+          const execSync = require('child_process').execSync;
+          const coverageResult = execSync('make coverage-check', { encoding: 'utf-8' });
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `Test results:\n\n${coverageResult}`
+          });
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     # see issue #316
     #- name: CT rule coverage test
     #  run: go run ./go/ct/driver test

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,0 +1,59 @@
+# (mandatory) 
+# Path to coverprofile file (output of `go test -coverprofile` command).
+#
+# For cases where there are many coverage profiles, such as when running 
+# unit tests and integration tests separately, you can combine all those
+# profiles into one. In this case, the profile should have a comma-separated list 
+# of profile files, e.g., 'cover_unit.out,cover_integration.out'.
+profile: cover.out
+
+# (optional; but recommended to set) 
+# When specified reported file paths will not contain local prefix in the output
+local-prefix: "github.com/org/project"
+
+# Holds coverage thresholds percentages, values should be in range [0-100]
+threshold:
+  # (optional; default 0) 
+  # The minimum coverage that each file should have
+  file: 40
+
+  # (optional; default 0) 
+  # The minimum coverage that each package should have
+  package: 80
+
+  # (optional; default 0) 
+  # The minimum total coverage project should have
+  total: 95
+
+# Holds regexp rules which will override thresholds for matched files or packages 
+# using their paths.
+#
+# First rule from this list that matches file or package is going to apply 
+# new threshold to it. If project has multiple rules that match same path, 
+# override rules should be listed in order from specific to more general rules.
+override:
+  # Increase coverage threshold to 100% for `foo` package 
+  # (default is 80, as configured above in this example)
+  # - threshold: 100
+  #   path: ^pkg/lib/foo$
+
+# Holds regexp rules which will exclude matched files or packages 
+# from coverage statistics
+exclude:
+  # Exclude files or packages matching their paths
+  paths:
+    - ^(.+)mock(.+)         # mock files should not be tested
+    - go/ct/common/error.go # error file only declares error type without any logic
+    - go/ct/driver/         # entry points, logic should be tested elsewhere.
+    - go/examples           # examples are not tested.
+    - go/interpreter/lfvm/error.go # error file only declares error type without any logic
+    - go/interpreter/lfvm/instructions.go # these are tested by driver
+    - go/tosca/interpreter.go # this file does not contain logic
+    - go/tosca/world_state.go # this file does not contain logic
+    - third_party/  # exclude all files in `third_party` directory
+
+
+ 
+# NOTES:
+# - symbol `/` in all path regexps will be replaced by current OS file path separator
+#   to properly work on Windows

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,9 +1,19 @@
-# (mandatory) 
+# Copyright (c) 2024 Fantom Foundation
+#
+# Use of this software is governed by the Business Source License included
+# in the LICENSE file and at fantom.foundation/bsl11.
+#
+# Change Date: 2028-4-16
+#
+# On the date above, in accordance with the Business Source License, use of
+# this software will be governed by the GNU Lesser General Public License v3.
+
+# (mandatory)
 # Path to coverprofile file (output of `go test -coverprofile` command).
 #
-# For cases where there are many coverage profiles, such as when running 
+# For cases where there are many coverage profiles, such as when running
 # unit tests and integration tests separately, you can combine all those
-# profiles into one. In this case, the profile should have a comma-separated list 
+# profiles into one. In this case, the profile should have a comma-separated list
 # of profile files, e.g., 'cover_unit.out,cover_integration.out'.
 profile: cover.out
 

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -19,11 +19,11 @@ threshold:
 
   # (optional; default 0) 
   # The minimum coverage that each package should have
-  package: 80
+  package: 85
 
   # (optional; default 0) 
   # The minimum total coverage project should have
-  total: 90
+  total: 68
 
 # Holds regexp rules which will override thresholds for matched files or packages 
 # using their paths.
@@ -32,10 +32,96 @@ threshold:
 # new threshold to it. If project has multiple rules that match same path, 
 # override rules should be listed in order from specific to more general rules.
 override:
-  # Increase coverage threshold to 100% for `foo` package 
-  # (default is 80, as configured above in this example)
-  # - threshold: 100
-  #   path: ^pkg/lib/foo$
+  # files
+  - threshold: 0
+    path: go/ct/common/bytes.go
+  - threshold: 0
+    path: go/ct/common/cpp_coverage.go
+  - threshold: 0
+    path: go/ct/common/revisions.go
+  - threshold: 0
+    path: go/ct/gen/assignment.go
+  - threshold: 0
+    path: go/ct/gen/state.go
+  - threshold: 0
+    path: go/ct/rlz/conditions.go
+  - threshold: 0
+    path: go/ct/rlz/domains.go
+  - threshold: 0
+    path: go/ct/rlz/effect.go
+  - threshold: 0
+    path: go/ct/rlz/expressions.go
+  - threshold: 0
+    path: go/ct/rlz/parameters.go
+  - threshold: 0
+    path: go/ct/spc/specification.go
+  - threshold: 0
+    path: go/ct/st/transient_storage.go
+  - threshold: 0
+    path: go/ct/utils/adapter.go
+  - threshold: 0
+    path: go/geth_adapter/adapter.go
+  - threshold: 0
+    path: go/integration_test/processor/scenario.go
+  - threshold: 0
+    path: go/interpreter/evmc/evmc_interpreter.go
+  - threshold: 0
+    path: go/interpreter/evmc/evmc_steppable_interpreter.go
+  - threshold: 0
+    path: go/interpreter/geth/ct.go
+  - threshold: 0
+    path: go/interpreter/lfvm/converter.go
+  - threshold: 0
+    path: go/interpreter/lfvm/hash_cache.go
+  - threshold: 0
+    path: go/interpreter/lfvm/instruction.go
+  - threshold: 0
+    path: go/interpreter/lfvm/interpreter.go
+  - threshold: 0
+    path: go/interpreter/lfvm/lfvm.go
+  - threshold: 0
+    path: go/interpreter/lfvm/opcode.go
+  - threshold: 0
+    path: go/interpreter/lfvm/shadow.go
+  - threshold: 0
+    path: go/interpreter/lfvm/super_instructions.go
+  - threshold: 0
+    path: go/processor/floria/processor.go
+  - threshold: 0
+    path: go/processor/opera/processor.go
+  - threshold: 0
+    path: go/tosca/interpreter_registry.go
+  - threshold: 0
+    path: go/tosca/utils.go
+  # packages
+  - threshold: 0
+    path: go/ct/common
+  - threshold: 0
+    path: go/ct/rlz
+  - threshold: 0
+    path: go/ct/spc
+  - threshold: 0
+    path: go/ct/utils
+  - threshold: 0
+    path: go/geth_adapter
+  - threshold: 0
+    path: go/interpreter/evmzero
+  - threshold: 0
+    path: go/interpreter/geth
+  - threshold: 0
+    path: go/interpreter/evmone
+  - threshold: 0
+    path: go/integration_test/processor
+  - threshold: 0
+    path: go/interpreter/evmc
+  - threshold: 0
+    path: go/interpreter/lfvm
+  - threshold: 0
+    path: go/processor/floria
+  - threshold: 0
+    path: go/processor/opera
+  - threshold: 0
+    path: go/tosca
 
 # Holds regexp rules which will exclude matched files or packages 
 # from coverage statistics
@@ -48,8 +134,6 @@ exclude:
     - go/examples           # examples are not tested.
     - go/interpreter/lfvm/errors.go # error file only declares error type without any logic
     - go/interpreter/lfvm/instructions.go # these are tested by driver
-    - go/tosca/interpreter.go # this file does not contain logic
-    - go/tosca/world_state.go # this file does not contain logic
     - third_party/  # exclude all files in `third_party` directory
 
 

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -15,7 +15,7 @@ local-prefix: "github.com/org/project"
 threshold:
   # (optional; default 0) 
   # The minimum coverage that each file should have
-  file: 40
+  file: 80
 
   # (optional; default 0) 
   # The minimum coverage that each package should have
@@ -23,7 +23,7 @@ threshold:
 
   # (optional; default 0) 
   # The minimum total coverage project should have
-  total: 95
+  total: 90
 
 # Holds regexp rules which will override thresholds for matched files or packages 
 # using their paths.
@@ -46,7 +46,7 @@ exclude:
     - go/ct/common/error.go # error file only declares error type without any logic
     - go/ct/driver/         # entry points, logic should be tested elsewhere.
     - go/examples           # examples are not tested.
-    - go/interpreter/lfvm/error.go # error file only declares error type without any logic
+    - go/interpreter/lfvm/errors.go # error file only declares error type without any logic
     - go/interpreter/lfvm/instructions.go # these are tested by driver
     - go/tosca/interpreter.go # this file does not contain logic
     - go/tosca/world_state.go # this file does not contain logic

--- a/Makefile
+++ b/Makefile
@@ -116,3 +116,8 @@ fuzz-lfvm-diff:
 # TODO: disabbled until test is fixed #549
 # fuzz-evmzero-diff:
 # 	go test -fuzz=FuzzDifferentialEvmZeroVsGeth ./go/ct/
+
+coverage-check:
+	@go install github.com/vladopajic/go-test-coverage/v2@latest
+	@go test --count=1 --coverprofile=cover.out ./... > /dev/null 2>&1
+	@go-test-coverage --config .testcoverage.yml

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ fuzz-lfvm-diff:
 # fuzz-evmzero-diff:
 # 	go test -fuzz=FuzzDifferentialEvmZeroVsGeth ./go/ct/
 
-coverage-check:
+test-coverage:
 	@go install github.com/vladopajic/go-test-coverage/v2@latest
 	@go test --count=1 --coverprofile=cover.out ./... > /dev/null 2>&1
 	@go-test-coverage --config .testcoverage.yml

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,6 @@ fuzz-lfvm-diff:
 # 	go test -fuzz=FuzzDifferentialEvmZeroVsGeth ./go/ct/
 
 test-coverage:
-	@go install github.com/vladopajic/go-test-coverage/v2@latest
+	@go install github.com/vladopajic/go-test-coverage/v2@v2.10.1
 	@go test --count=1 --coverprofile=cover.out ./... > /dev/null 2>&1
 	@go-test-coverage --config .testcoverage.yml

--- a/go/ct/common/hash.go
+++ b/go/ct/common/hash.go
@@ -15,7 +15,7 @@ import (
 	"pgregory.net/rand"
 )
 
-func GetRandomHash(rnd *rand.Rand) tosca.Hash {
+func GetRandomHash(rnd *rand.Rand) tosca.Hash { // coverage-ignore nothing to test
 	var res tosca.Hash
 	_, _ = rnd.Read(res[:]) // rnd.Read never returns an error
 	return res

--- a/go/ct/common/hash.go
+++ b/go/ct/common/hash.go
@@ -15,7 +15,7 @@ import (
 	"pgregory.net/rand"
 )
 
-func GetRandomHash(rnd *rand.Rand) tosca.Hash { // coverage-ignore nothing to test
+func GetRandomHash(rnd *rand.Rand) tosca.Hash {
 	var res tosca.Hash
 	_, _ = rnd.Read(res[:]) // rnd.Read never returns an error
 	return res


### PR DESCRIPTION
This PR adds a github workflow, a makefile target and a config file. These combined produce a report on the coverage and (when enabled) post this report on the PR.

This is currently disabled because the unit-test coverage of some packages does not meet the current requirements. This needs to be fixed in a separate PR or lowered thresholds. 

NOTE: 
a series of follow-up PRs will add unit tests to increase coverage and eventually empty the list of overrides