### PR TITLE
Reorder makefile commands

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -56,19 +56,13 @@ jobs:
     - name: Test
       run: make test-go
 
-    - name: CT regression tests LFVM
-      run: go run ./go/ct/driver regressions lfvm
-
-    - name: CT regression tests evmzero
-      run: go run ./go/ct/driver regressions evmzero
-
-    - name: Test coverage
+    - name: Report coverage
       if: github.ref != 'refs/heads/main'
       uses: actions/github-script@v6
       with:
        script: |
           const execSync = require('child_process').execSync;
-          const coverageResult = execSync('make test-coverage', { encoding: 'utf-8' });
+          const coverageResult = execSync('make coverage-report', { encoding: 'utf-8' });
           github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
@@ -77,3 +71,9 @@ jobs:
           });
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: CT regression tests LFVM
+      run: go run ./go/ct/driver regressions lfvm
+
+    - name: CT regression tests evmzero
+      run: go run ./go/ct/driver regressions evmzero

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ ct-coverage-evmzero:
 test: test-go test-cpp
 
 test-go: tosca-go
-	@go test ./... -count 1
+	@go test ./... -count 1 --coverprofile=cover.out
 
 test-cpp: tosca-cpp
 	@cd cpp/build ; \
@@ -117,7 +117,8 @@ fuzz-lfvm-diff:
 # fuzz-evmzero-diff:
 # 	go test -fuzz=FuzzDifferentialEvmZeroVsGeth ./go/ct/
 
-test-coverage:
+test-coverage: test-go coverage-report
+
+coverage-report:
 	@go install github.com/vladopajic/go-test-coverage/v2@v2.10.1
-	@go test --count=1 --coverprofile=cover.out ./... > /dev/null 2>&1
 	@go-test-coverage --config .testcoverage.yml


### PR DESCRIPTION
After merging the report coverage we observed that the tests were running 2 times for each commit and there was also a problem with the coverage report trying to publish in a PR when a commit was done into main (which has no PR). Also keeping into consideration that when developing it's easier to run just one command to get the report and not having to mentally record whether the `cover.out` is updated or not, we came up with this solution:
- for development one runs `make test-coverage` which will run the tests and then report the coverage on the updated code.
- for commits in PRs (aka branches that are not main) this is separated into 2 steps, `make tests-go` and `make coverage-report`
- for commits in main, this will only run `make tests-go`. 

Hence preventing commits in PRs to run tests twice while still facilitating a single command to run both things locally