### PR TITLE
Implement create calls

### DIFF
--- a/go/integration_test/processor/processor_test.go
+++ b/go/integration_test/processor/processor_test.go
@@ -40,7 +40,7 @@ func getScenarios() map[string]Scenario {
 	// TODO: improve organization of test scenarios
 
 	createdAddress := tosca.Address(crypto.CreateAddress(common.Address{1}, 4))
-	allTestCases := map[string]Scenario{
+	return map[string]Scenario{
 		"SuccessfulValueTransfer": {
 			Before: WorldState{
 				{1}: Account{Balance: tosca.NewValue(100), Nonce: 4},
@@ -171,15 +171,6 @@ func getScenarios() map[string]Scenario {
 			},
 		},
 	}
-
-	// todo remove once all cases are supported
-	floriaTestCases := []string{"SuccessfulValueTransfer", "FailedValueTransfer", "SuccessfulContractCall", "RevertingContractCall"}
-	supportedTestCases := map[string]Scenario{}
-	for _, testCase := range floriaTestCases {
-		supportedTestCases[testCase] = allTestCases[testCase]
-	}
-
-	return supportedTestCases
 }
 
 func RunProcessorTests(t *testing.T, processor tosca.Processor) {

--- a/go/processor/floria/processor_test.go
+++ b/go/processor/floria/processor_test.go
@@ -38,8 +38,9 @@ func TestProcessor_HandleNonce(t *testing.T) {
 	context.EXPECT().GetNonce(tosca.Address{1}).Return(uint64(10))
 
 	transaction := tosca.Transaction{
-		Sender: tosca.Address{1},
-		Nonce:  9,
+		Sender:    tosca.Address{1},
+		Recipient: &tosca.Address{2},
+		Nonce:     9,
 	}
 
 	err := handleNonce(transaction, context)
@@ -58,8 +59,9 @@ func TestProcessor_NonceMissmatch(t *testing.T) {
 	context.EXPECT().GetNonce(tosca.Address{1}).Return(uint64(5))
 
 	transaction := tosca.Transaction{
-		Sender: tosca.Address{1},
-		Nonce:  10,
+		Sender:    tosca.Address{1},
+		Recipient: &tosca.Address{2},
+		Nonce:     10,
 	}
 	err := handleNonce(transaction, context)
 	if err == nil {

--- a/go/processor/floria/run_context.go
+++ b/go/processor/floria/run_context.go
@@ -49,7 +49,7 @@ func (r runContext) Call(kind tosca.CallKind, parameters tosca.CallParameters) (
 	if kind == tosca.Create || kind == tosca.Create2 {
 		if parameters.Recipient == (tosca.Address{}) {
 			code = tosca.Code(parameters.Input)
-			codeHash = hashFromCode(code)
+			codeHash = hashCode(code)
 		}
 		createdAddress = createAddress(
 			kind,
@@ -93,9 +93,7 @@ func (r runContext) Call(kind tosca.CallKind, parameters tosca.CallParameters) (
 	result, err := r.interpreter.Run(interpreterParameters)
 	if err != nil || !result.Success {
 		r.RestoreSnapshot(snapshot)
-	}
-
-	if kind == tosca.Create || kind == tosca.Create2 {
+	} else if kind == tosca.Create || kind == tosca.Create2 {
 		r.SetCode(createdAddress, tosca.Code(result.Output))
 	}
 
@@ -108,7 +106,7 @@ func (r runContext) Call(kind tosca.CallKind, parameters tosca.CallParameters) (
 	}, err
 }
 
-func hashFromCode(code tosca.Code) tosca.Hash {
+func hashCode(code tosca.Code) tosca.Hash {
 	return tosca.Hash(crypto.Keccak256(code))
 }
 

--- a/go/processor/floria/run_context.go
+++ b/go/processor/floria/run_context.go
@@ -14,6 +14,10 @@ import (
 	"fmt"
 
 	"github.com/Fantom-foundation/Tosca/go/tosca"
+
+	// geth dependencies
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 type runContext struct {
@@ -26,30 +30,48 @@ type runContext struct {
 }
 
 func (r runContext) Call(kind tosca.CallKind, parameters tosca.CallParameters) (tosca.CallResult, error) {
-
 	if r.depth > MaxRecursiveDepth {
 		return tosca.CallResult{}, nil
 	}
 	r.depth++
 	defer func() { r.depth-- }()
 
-	snapshot := r.CreateSnapshot()
-	if err := transferValue(r, parameters.Value, parameters.Sender, parameters.Recipient); err != nil {
-		r.RestoreSnapshot(snapshot)
-		return tosca.CallResult{}, nil
-	}
-
 	codeHash := r.GetCodeHash(parameters.Recipient)
 	code := r.GetCode(parameters.Recipient)
 
-	sender := parameters.Sender
 	if kind == tosca.DelegateCall || kind == tosca.CallCode {
 		code = r.GetCode(parameters.CodeAddress)
 		codeHash = r.GetCodeHash(parameters.CodeAddress)
 	}
 
+	recipient := parameters.Recipient
+	var createdAddress tosca.Address
+	if kind == tosca.Create || kind == tosca.Create2 {
+		if parameters.Recipient == (tosca.Address{}) {
+			code = tosca.Code(parameters.Input)
+			codeHash = hashFromCode(code)
+		}
+		createdAddress = createAddress(
+			kind,
+			parameters.Sender,
+			r.GetNonce(parameters.Sender),
+			parameters.Salt,
+			codeHash,
+		)
+
+		r.SetNonce(parameters.Sender, r.GetNonce(parameters.Sender)+1)
+		r.SetNonce(createdAddress, 1)
+		recipient = createdAddress
+	}
+
 	if kind == tosca.StaticCall {
 		r.static = true
+	}
+
+	snapshot := r.CreateSnapshot()
+	if err := transferValue(r, parameters.Value, parameters.Sender, recipient); err != nil {
+		r.RestoreSnapshot(snapshot)
+		return tosca.CallResult{}, nil
 	}
 
 	interpreterParameters := tosca.Parameters{
@@ -58,10 +80,10 @@ func (r runContext) Call(kind tosca.CallKind, parameters tosca.CallParameters) (
 		Context:               r,
 		Kind:                  kind,
 		Static:                r.static,
-		Depth:                 r.depth - 1, // depth is already incremented
+		Depth:                 r.depth - 1, // depth has already been incremented
 		Gas:                   parameters.Gas,
-		Recipient:             parameters.Recipient,
-		Sender:                sender,
+		Recipient:             recipient,
+		Sender:                parameters.Sender,
 		Input:                 parameters.Input,
 		Value:                 parameters.Value,
 		CodeHash:              &codeHash,
@@ -73,12 +95,34 @@ func (r runContext) Call(kind tosca.CallKind, parameters tosca.CallParameters) (
 		r.RestoreSnapshot(snapshot)
 	}
 
+	if kind == tosca.Create || kind == tosca.Create2 {
+		r.SetCode(createdAddress, tosca.Code(result.Output))
+	}
+
 	return tosca.CallResult{
-		Output:    result.Output,
-		GasLeft:   result.GasLeft,
-		GasRefund: result.GasRefund,
-		Success:   result.Success,
+		Output:         result.Output,
+		GasLeft:        result.GasLeft,
+		GasRefund:      result.GasRefund,
+		Success:        result.Success,
+		CreatedAddress: createdAddress,
 	}, err
+}
+
+func hashFromCode(code tosca.Code) tosca.Hash {
+	return tosca.Hash(crypto.Keccak256(code))
+}
+
+func createAddress(
+	kind tosca.CallKind,
+	sender tosca.Address,
+	nonce uint64,
+	salt tosca.Hash,
+	initHash tosca.Hash,
+) tosca.Address {
+	if kind == tosca.Create {
+		return tosca.Address(crypto.CreateAddress(common.Address(sender), nonce))
+	}
+	return tosca.Address(crypto.CreateAddress2(common.Address(sender), common.Hash(salt), initHash[:]))
 }
 
 func transferValue(

--- a/go/processor/floria/run_context_test.go
+++ b/go/processor/floria/run_context_test.go
@@ -148,6 +148,8 @@ func TestTransferValue_InCallRestoreFailed(t *testing.T) {
 		Input:     []byte{},
 	}
 
+	context.EXPECT().GetCodeHash(params.Recipient).Return(tosca.Hash{})
+	context.EXPECT().GetCode(params.Recipient).Return([]byte{})
 	context.EXPECT().CreateSnapshot()
 	context.EXPECT().GetBalance(params.Sender).Return(tosca.NewValue(0))
 	context.EXPECT().RestoreSnapshot(gomock.Any())
@@ -230,5 +232,4 @@ func TestTransferValue_FailedValueTransfer(t *testing.T) {
 			}
 		})
 	}
-
 }


### PR DESCRIPTION
This PR adds support for CREATE and CREATE2 instructions to Floria. To ensure the right address is calculated another integration test is added, stressing this calculation. 