### PR TITLE
improve rlz coverage 

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -44,14 +44,6 @@ threshold:
 override:
   # files
   - threshold: 0
-    path: go/ct/rlz/domains.go
-  - threshold: 0
-    path: go/ct/rlz/effect.go
-  - threshold: 0
-    path: go/ct/rlz/expressions.go
-  - threshold: 0
-    path: go/ct/rlz/parameters.go
-  - threshold: 0
     path: go/ct/spc/specification.go
   - threshold: 0
     path: go/ct/st/transient_storage.go

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -44,8 +44,6 @@ threshold:
 override:
   # files
   - threshold: 0
-    path: go/ct/rlz/conditions.go
-  - threshold: 0
     path: go/ct/rlz/domains.go
   - threshold: 0
     path: go/ct/rlz/effect.go
@@ -97,6 +95,8 @@ override:
   # packages
   - threshold: 0
     path: go/ct/rlz
+  - threshold: 0
+    path: go/ct/common
   - threshold: 0
     path: go/ct/spc
   - threshold: 0

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -86,10 +86,6 @@ override:
 
   # packages
   - threshold: 0
-    path: go/ct/rlz
-  - threshold: 0
-    path: go/ct/common
-  - threshold: 0
     path: go/ct/spc
   - threshold: 0
     path: go/ct/utils

--- a/go/ct/rlz/conditions_test.go
+++ b/go/ct/rlz/conditions_test.go
@@ -518,7 +518,7 @@ func TestCondition_IsRevisionCondition(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			if got, want := IsRevisionCondition(test.condition), test.isRevision; got != want {
-				t.Errorf("condition %v failed to be recognize. got %v, want %v", test.condition, got, want)
+				t.Errorf("condition %v is not a revision condition. got %v, want %v", test.condition, got, want)
 			}
 		})
 	}

--- a/go/ct/rlz/conditions_test.go
+++ b/go/ct/rlz/conditions_test.go
@@ -632,6 +632,74 @@ func TestCondition_ConflictingAccountWarmConditionsAreUnsatisfiable(t *testing.T
 	}
 }
 
+func TestCondition_NotEqualRestrictAndCheck(t *testing.T) {
+	gen := gen.NewStateGenerator()
+	condition := Ne(Gas(), 1)
+	condition.Restrict(gen)
+	state, err := gen.Generate(rand.New(0))
+	if err != nil {
+		t.Fatalf("failed to build state: %v", err)
+	}
+	if checked, err := condition.Check(state); err != nil || !checked {
+		t.Errorf("failed to restrict and check condition: %v", err)
+	}
+}
+
+func TestCondition_LessThanRestrictAndCheck(t *testing.T) {
+	gen := gen.NewStateGenerator()
+	condition := Lt(Gas(), 2)
+	condition.Restrict(gen)
+	state, err := gen.Generate(rand.New(0))
+	if err != nil {
+		t.Fatalf("failed to build state: %v", err)
+	}
+	if checked, err := condition.Check(state); err != nil || !checked {
+		t.Errorf("failed to restrict and check condition: %v", err)
+	}
+}
+
+func TestCondition_LessEqualRestrictAndCheck(t *testing.T) {
+	gen := gen.NewStateGenerator()
+	condition := Le(Gas(), 2)
+	condition.Restrict(gen)
+	state, err := gen.Generate(rand.New(0))
+	if err != nil {
+		t.Fatalf("failed to build state: %v", err)
+	}
+	if checked, err := condition.Check(state); err != nil || !checked {
+		t.Errorf("failed to restrict and check condition: %v", err)
+	}
+}
+
+func TestCondition_GreaterThanRestrictAndCheck(t *testing.T) {
+	gen := gen.NewStateGenerator()
+	condition := Gt(Gas(), 0)
+	condition.Restrict(gen)
+	state, err := gen.Generate(rand.New(0))
+	if err != nil {
+		t.Fatalf("failed to build state: %v", err)
+	}
+	if checked, err := condition.Check(state); err != nil || !checked {
+		t.Errorf("failed to restrict and check condition: %v", err)
+	}
+}
+
+func TestCondition_GreaterEqualRestrictAndCheck(t *testing.T) {
+	gen := gen.NewStateGenerator()
+	condition := Ge(Gas(), 0)
+	condition.Restrict(gen)
+	state, err := gen.Generate(rand.New(0))
+	if err != nil {
+		t.Fatalf("failed to build state: %v", err)
+	}
+	if checked, err := condition.Check(state); err != nil || !checked {
+		t.Errorf("failed to restrict and check condition: %v", err)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////
+// Benchmarks
+
 func BenchmarkCondition_IsAddressWarmCheckWarm(b *testing.B) {
 	state := st.NewState(st.NewCode([]byte{}))
 	state.Accounts.MarkWarm(NewAddress(NewU256(42)))

--- a/go/ct/rlz/conditions_test.go
+++ b/go/ct/rlz/conditions_test.go
@@ -608,8 +608,8 @@ func TestCondition_CheckFail(t *testing.T) {
 		// only Param and Op can return errors on eval, which is where the errors from check come from.
 		{Eq(Param(1), NewU256(1)), func(s st.State) { s.Stack.Resize(0) }},
 		{Ne(Param(1), NewU256(1)), func(s st.State) { s.Stack.Resize(0) }},
-		// Op and Param expressions only support equaility constraints,
-		// hence the non equality constraints cannot produce error on check with the current expressions.
+		// Op and Param expressions only support equality constraints,
+		// hence the inequality constraints cannot produce error on check with the current expressions.
 		// {Lt(Param(1), NewU256(1)), func(s st.State) { s.Stack.Resize(0) }},
 		// {Le(Param(1), NewU256(1)), func(s st.State) { s.Stack.Resize(0) }},
 		// {Gt(Param(1), NewU256(1)), func(s st.State) { s.Stack.Resize(0) }},

--- a/go/ct/rlz/domains_test.go
+++ b/go/ct/rlz/domains_test.go
@@ -25,8 +25,8 @@ func TestRemoveDuplicatesGeneric(t *testing.T) {
 
 	tests := map[string]struct {
 		generic_type reflect.Type
-		input        interface{}
-		expected     interface{}
+		input        any
+		expected     any
 	}{
 		"empty": {
 			generic_type: reflect.TypeOf(1),
@@ -68,7 +68,7 @@ func TestRemoveDuplicatesGeneric(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var result interface{}
+			var result any
 			switch tc.generic_type {
 			case reflect.TypeOf(1):
 				result = removeDuplicatesGeneric[int](tc.input.([]int))
@@ -158,31 +158,28 @@ func TestDomain_Less(t *testing.T) {
 
 func TestDomain_PredecessorPanic(t *testing.T) {
 
-	tests := map[string]struct {
-		value        interface{}
-		generic_type reflect.Type
-	}{
-		"bool":       {value: true, generic_type: reflect.TypeOf(true)},
-		"statusCode": {value: st.Running, generic_type: reflect.TypeOf(st.Running)},
-		"opCode":     {value: vm.ADD, generic_type: reflect.TypeOf(vm.ADD)},
+	tests := map[string]any{
+		"bool":       true,
+		"statusCode": st.Running,
+		"opCode":     vm.ADD,
 	}
 
-	for name, tc := range tests {
+	for name, value := range tests {
 		t.Run(name, func(t *testing.T) {
 			defer func() {
 				if r := recover(); r == nil {
 					t.Errorf("The code did not panic")
 				}
 			}()
-			switch tc.generic_type {
-			case reflect.TypeOf(true):
-				boolDomain{}.Predecessor(tc.value.(bool))
-			case reflect.TypeOf(st.Running):
-				statusCodeDomain{}.Predecessor(tc.value.(st.StatusCode))
-			case reflect.TypeOf(vm.ADD):
-				opCodeDomain{}.Predecessor(tc.value.(vm.OpCode))
+			switch value := value.(type) {
+			case bool:
+				boolDomain{}.Predecessor(value)
+			case st.StatusCode:
+				statusCodeDomain{}.Predecessor(value)
+			case vm.OpCode:
+				opCodeDomain{}.Predecessor(value)
 			default:
-				t.Errorf("Add type to test cases: %v", tc.generic_type)
+				t.Errorf("Add type to test cases: %T", value)
 			}
 		})
 	}
@@ -192,8 +189,8 @@ func TestDomain_PredecessorPanic(t *testing.T) {
 func TestDomain_Predecessor(t *testing.T) {
 
 	tests := map[string]struct {
-		got  interface{}
-		want interface{}
+		got  any
+		want any
 	}{
 		"uint16": {got: uint16Domain{}.Predecessor(uint16(1)), want: uint16(0)},
 		"revision": {got: revisionDomain{}.Predecessor(tosca.R09_Berlin),
@@ -224,32 +221,28 @@ func TestDomain_Predecessor(t *testing.T) {
 }
 
 func TestDomain_SuccessorPanic(t *testing.T) {
-
-	tests := map[string]struct {
-		value        interface{}
-		generic_type reflect.Type
-	}{
-		"bool":       {value: true, generic_type: reflect.TypeOf(true)},
-		"statusCode": {value: st.Running, generic_type: reflect.TypeOf(st.Running)},
-		"opCode":     {value: vm.ADD, generic_type: reflect.TypeOf(vm.ADD)},
+	tests := map[string]any{
+		"bool":       true,
+		"statusCode": st.Running,
+		"opCode":     vm.ADD,
 	}
 
-	for name, tc := range tests {
+	for name, value := range tests {
 		t.Run(name, func(t *testing.T) {
 			defer func() {
 				if r := recover(); r == nil {
 					t.Errorf("The code did not panic")
 				}
 			}()
-			switch tc.generic_type {
-			case reflect.TypeOf(true):
-				boolDomain{}.Successor(tc.value.(bool))
-			case reflect.TypeOf(st.Running):
-				statusCodeDomain{}.Successor(tc.value.(st.StatusCode))
-			case reflect.TypeOf(vm.ADD):
-				opCodeDomain{}.Successor(tc.value.(vm.OpCode))
+			switch value := value.(type) {
+			case bool:
+				boolDomain{}.Successor(value)
+			case st.StatusCode:
+				statusCodeDomain{}.Successor(value)
+			case vm.OpCode:
+				opCodeDomain{}.Successor(value)
 			default:
-				t.Errorf("Add type to test cases: %v", tc.generic_type)
+				t.Errorf("Add type to test cases: %T", value)
 			}
 		})
 	}
@@ -259,8 +252,8 @@ func TestDomain_SuccessorPanic(t *testing.T) {
 func TestDomain_Successor(t *testing.T) {
 
 	tests := map[string]struct {
-		got  interface{}
-		want interface{}
+		got  any
+		want any
 	}{
 		"uint16": {got: uint16Domain{}.Successor(uint16(1)), want: uint16(2)},
 		"revision": {got: revisionDomain{}.Successor(tosca.R09_Berlin),
@@ -293,8 +286,8 @@ func TestDomain_Successor(t *testing.T) {
 func TestDomain_SomethingNotEqual(t *testing.T) {
 
 	tests := map[string]struct {
-		got  interface{}
-		want interface{}
+		got  any
+		want any
 	}{
 		"bool-true":  {got: boolDomain{}.SomethingNotEqual(true), want: false},
 		"bool-false": {got: boolDomain{}.SomethingNotEqual(false), want: true},
@@ -325,14 +318,14 @@ func TestDomain_SomethingNotEqual(t *testing.T) {
 
 func TestDomain_SamplesBool(t *testing.T) {
 
-	opcdoesAllSamples := make([]vm.OpCode, 0, 256)
+	opcodesAllSamples := make([]vm.OpCode, 0, 256)
 	for i := 0; i < 256; i++ {
-		opcdoesAllSamples = append(opcdoesAllSamples, vm.OpCode(i))
+		opcodesAllSamples = append(opcodesAllSamples, vm.OpCode(i))
 	}
 
 	tests := map[string]struct {
-		got  interface{}
-		want interface{}
+		got  any
+		want any
 	}{
 		"bool-samples": {got: boolDomain{}.Samples(true), want: []bool{false, true}},
 		"bool-samples-for-all": {got: boolDomain{}.SamplesForAll([]bool{}),
@@ -363,7 +356,7 @@ func TestDomain_SamplesBool(t *testing.T) {
 		"statusCode-samplesforall": {got: statusCodeDomain{}.SamplesForAll([]st.StatusCode{}),
 			want: []st.StatusCode{st.Running, st.Stopped, st.Reverted, st.Failed}},
 		"opcpode-samplesforall": {got: opCodeDomain{}.SamplesForAll([]vm.OpCode{}),
-			want: opcdoesAllSamples},
+			want: opcodesAllSamples},
 		// samples calls samples for all
 		"blocknumberoffset-samples": {got: BlockNumberOffsetDomain{}.Samples(int64(23)),
 			want: []int64{math.MinInt64, -1, 0, 1, 255, 256, 257, math.MaxInt64, 22, 23, 24},

--- a/go/ct/rlz/domains_test.go
+++ b/go/ct/rlz/domains_test.go
@@ -11,8 +11,14 @@
 package rlz
 
 import (
+	"math"
 	"reflect"
 	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/ct/common"
+	"github.com/Fantom-foundation/Tosca/go/ct/st"
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+	"github.com/Fantom-foundation/Tosca/go/tosca/vm"
 )
 
 func TestRemoveDuplicatesGeneric(t *testing.T) {
@@ -75,6 +81,299 @@ func TestRemoveDuplicatesGeneric(t *testing.T) {
 			}
 			if !reflect.DeepEqual(result, tc.expected) {
 				t.Errorf("Expected %v, but got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestDomain_Equal(t *testing.T) {
+
+	tests := map[string]struct {
+		got  bool
+		want bool
+	}{
+		"bool-true":       {got: boolDomain{}.Equal(true, true), want: true},
+		"bool-false":      {got: boolDomain{}.Equal(false, false), want: true},
+		"bool-true-false": {got: boolDomain{}.Equal(true, false), want: false},
+		"U256-equals": {got: u256Domain{}.Equal(common.NewU256(1, 2, 3, 4), common.NewU256(1, 2, 3, 4)),
+			want: true},
+		"U256-not-equals": {got: u256Domain{}.Equal(common.NewU256(1, 2, 3, 4), common.NewU256(4, 3, 2, 1)),
+			want: false},
+		"revision-equals": {got: revisionDomain{}.Equal(tosca.R07_Istanbul, tosca.R07_Istanbul),
+			want: true},
+		"revision-not-equals": {got: revisionDomain{}.Equal(tosca.R07_Istanbul, tosca.R09_Berlin),
+			want: false},
+		"blocknumberoffset-equals": {got: BlockNumberOffsetDomain{}.Equal(int64(1), int64(1)),
+			want: true},
+		"blocknumberoffset-not-equals": {got: BlockNumberOffsetDomain{}.Equal(int64(1), int64(2)),
+			want: false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("want %v, but got %v", tc.want, tc.got)
+			}
+		})
+	}
+}
+
+func TestDomain_Less(t *testing.T) {
+	tests := map[string]struct {
+		got  bool
+		want bool
+	}{
+		"bool-true":       {got: boolDomain{}.Less(true, true), want: false},
+		"bool-false":      {got: boolDomain{}.Less(false, false), want: false},
+		"bool-true-false": {got: boolDomain{}.Less(true, false), want: false},
+		"bool-false-true": {got: boolDomain{}.Less(false, true), want: true},
+		"U256-less-1": {got: u256Domain{}.Less(common.NewU256(0, 2, 3, 4), common.NewU256(1, 2, 3, 4)),
+			want: true},
+		"U256-less-2": {got: u256Domain{}.Less(common.NewU256(1, 1, 3, 4), common.NewU256(1, 2, 3, 4)),
+			want: true},
+		"U256-less-3": {got: u256Domain{}.Less(common.NewU256(1, 2, 2, 4), common.NewU256(1, 2, 3, 4)),
+			want: true},
+		"U256-less-4": {got: u256Domain{}.Less(common.NewU256(1, 2, 3, 3), common.NewU256(1, 2, 3, 4)),
+			want: true},
+		"U256-less-greater": {got: u256Domain{}.Less(common.NewU256(2, 2, 3, 4), common.NewU256(1, 2, 3, 4)),
+			want: false},
+		"revision-less": {got: revisionDomain{}.Less(tosca.R07_Istanbul, tosca.R09_Berlin),
+			want: true},
+		"revision-greater": {got: revisionDomain{}.Less(tosca.R09_Berlin, tosca.R07_Istanbul),
+			want: false},
+		"blocknumberoffset-less": {got: BlockNumberOffsetDomain{}.Less(int64(1), int64(2)),
+			want: true},
+		"blocknumberoffset-greater": {got: BlockNumberOffsetDomain{}.Less(int64(2), int64(1)),
+			want: false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("want %v, but got %v", tc.want, tc.got)
+			}
+		})
+	}
+}
+
+func TestDomain_PredecessorPanic(t *testing.T) {
+
+	tests := map[string]struct {
+		value        interface{}
+		generic_type reflect.Type
+	}{
+		"bool":       {value: true, generic_type: reflect.TypeOf(true)},
+		"statusCode": {value: st.Running, generic_type: reflect.TypeOf(st.Running)},
+		"opCode":     {value: vm.ADD, generic_type: reflect.TypeOf(vm.ADD)},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("The code did not panic")
+				}
+			}()
+			switch tc.generic_type {
+			case reflect.TypeOf(true):
+				boolDomain{}.Predecessor(tc.value.(bool))
+			case reflect.TypeOf(st.Running):
+				statusCodeDomain{}.Predecessor(tc.value.(st.StatusCode))
+			case reflect.TypeOf(vm.ADD):
+				opCodeDomain{}.Predecessor(tc.value.(vm.OpCode))
+			default:
+				t.Errorf("Add type to test cases: %v", tc.generic_type)
+			}
+		})
+	}
+
+}
+
+func TestDomain_Predecessor(t *testing.T) {
+
+	tests := map[string]struct {
+		got  interface{}
+		want interface{}
+	}{
+		"uint16": {got: uint16Domain{}.Predecessor(uint16(1)), want: uint16(0)},
+		"revision": {got: revisionDomain{}.Predecessor(tosca.R09_Berlin),
+			want: tosca.R07_Istanbul},
+		"revision-istanbul": {got: revisionDomain{}.Predecessor(tosca.R07_Istanbul),
+			want: common.R99_UnknownNextRevision},
+		"revision-unknown": {got: revisionDomain{}.Predecessor(common.R99_UnknownNextRevision),
+			want: common.NewestSupportedRevision},
+		"pc": {got: pcDomain{}.Predecessor(common.NewU256(1, 2, 3, 4)),
+			want: common.NewU256(1, 2, 3, 3)},
+		"pc-0": {got: pcDomain{}.Predecessor(common.NewU256(1, 2, 3, 0)),
+			want: common.NewU256(1, 2, 2, 0xffffffffffffffff)},
+		"stackSize":         {got: stackSizeDomain{}.Predecessor(1), want: 0},
+		"blocknumberoffset": {got: BlockNumberOffsetDomain{}.Predecessor(int64(1)), want: int64(0)},
+		"u256": {got: u256Domain{}.Predecessor(common.NewU256(1, 2, 3, 4)),
+			want: common.NewU256(1, 2, 3, 3)},
+		"u256-0": {got: u256Domain{}.Predecessor(common.NewU256(1, 2, 0, 4)),
+			want: common.NewU256(1, 2, 0, 3)},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("want %v, but got %v", tc.want, tc.got)
+			}
+		})
+	}
+}
+
+func TestDomain_SuccessorPanic(t *testing.T) {
+
+	tests := map[string]struct {
+		value        interface{}
+		generic_type reflect.Type
+	}{
+		"bool":       {value: true, generic_type: reflect.TypeOf(true)},
+		"statusCode": {value: st.Running, generic_type: reflect.TypeOf(st.Running)},
+		"opCode":     {value: vm.ADD, generic_type: reflect.TypeOf(vm.ADD)},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("The code did not panic")
+				}
+			}()
+			switch tc.generic_type {
+			case reflect.TypeOf(true):
+				boolDomain{}.Successor(tc.value.(bool))
+			case reflect.TypeOf(st.Running):
+				statusCodeDomain{}.Successor(tc.value.(st.StatusCode))
+			case reflect.TypeOf(vm.ADD):
+				opCodeDomain{}.Successor(tc.value.(vm.OpCode))
+			default:
+				t.Errorf("Add type to test cases: %v", tc.generic_type)
+			}
+		})
+	}
+
+}
+
+func TestDomain_Successor(t *testing.T) {
+
+	tests := map[string]struct {
+		got  interface{}
+		want interface{}
+	}{
+		"uint16": {got: uint16Domain{}.Successor(uint16(1)), want: uint16(2)},
+		"revision": {got: revisionDomain{}.Successor(tosca.R09_Berlin),
+			want: tosca.R10_London},
+		"revision-newest": {got: revisionDomain{}.Successor(common.NewestSupportedRevision),
+			want: common.R99_UnknownNextRevision},
+		"revision-unknown": {got: revisionDomain{}.Successor(common.R99_UnknownNextRevision),
+			want: tosca.R07_Istanbul},
+		"pc": {got: pcDomain{}.Successor(common.NewU256(1, 2, 3, 4)),
+			want: common.NewU256(1, 2, 3, 5)},
+		"pc-0": {got: pcDomain{}.Successor(common.NewU256(1, 2, 2, 0xffffffffffffffff)),
+			want: common.NewU256(1, 2, 3, 0)},
+		"stackSize":         {got: stackSizeDomain{}.Successor(1), want: 2},
+		"blocknumberoffset": {got: BlockNumberOffsetDomain{}.Successor(int64(1)), want: int64(2)},
+		"u256": {got: u256Domain{}.Successor(common.NewU256(1, 2, 3, 4)),
+			want: common.NewU256(1, 2, 3, 5)},
+		"u256-0": {got: u256Domain{}.Successor(common.NewU256(1, 2, 0, 4)),
+			want: common.NewU256(1, 2, 0, 5)},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("want %v, but got %v", tc.want, tc.got)
+			}
+		})
+	}
+}
+
+func TestDomain_SomethingNotEqual(t *testing.T) {
+
+	tests := map[string]struct {
+		got  interface{}
+		want interface{}
+	}{
+		"bool-true":  {got: boolDomain{}.SomethingNotEqual(true), want: false},
+		"bool-false": {got: boolDomain{}.SomethingNotEqual(false), want: true},
+		"uint16":     {got: uint16Domain{}.SomethingNotEqual(uint16(1)), want: uint16(2)},
+		"revision": {got: revisionDomain{}.SomethingNotEqual(tosca.R09_Berlin),
+			want: tosca.R10_London},
+		"statusCode-running": {got: statusCodeDomain{}.SomethingNotEqual(st.Running),
+			want: st.Stopped},
+		"statusCode-not-running": {got: statusCodeDomain{}.SomethingNotEqual(st.Stopped),
+			want: st.Running},
+		"pc": {got: pcDomain{}.SomethingNotEqual(common.NewU256(1, 2, 3, 4)),
+			want: common.NewU256(1, 2, 3, 5)},
+		"opCode":            {got: opCodeDomain{}.SomethingNotEqual(vm.ADD), want: vm.MUL},
+		"stackSize":         {got: stackSizeDomain{}.SomethingNotEqual(1), want: 2},
+		"blocknumberoffset": {got: BlockNumberOffsetDomain{}.SomethingNotEqual(int64(1)), want: int64(3)},
+		"u256": {got: u256Domain{}.SomethingNotEqual(common.NewU256(1, 2, 3, 4)),
+			want: common.NewU256(1, 2, 3, 5)},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("want %v, but got %v", tc.want, tc.got)
+			}
+		})
+	}
+}
+
+func TestDomain_SamplesBool(t *testing.T) {
+
+	opcdoesAllSamples := make([]vm.OpCode, 0, 256)
+	for i := 0; i < 256; i++ {
+		opcdoesAllSamples = append(opcdoesAllSamples, vm.OpCode(i))
+	}
+
+	tests := map[string]struct {
+		got  interface{}
+		want interface{}
+	}{
+		"bool-samples": {got: boolDomain{}.Samples(true), want: []bool{false, true}},
+		"bool-samples-for-all": {got: boolDomain{}.SamplesForAll([]bool{}),
+			want: []bool{false, true}},
+		"readonly-samples": {got: readOnlyDomain{}.Samples(true), want: []bool{true}},
+		"readonly-samples-for-all": {got: readOnlyDomain{}.SamplesForAll([]bool{}),
+			want: []bool{}},
+		// samples calls samples for all
+		"uint16-samples": {got: uint16Domain{}.Samples(uint16(1)),
+			want: []uint16{0, 65535, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048,
+				4096, 8192, 16384, 32768}},
+		// samples calls samples for all
+		"u256-samples": {got: u256Domain{}.Samples(common.NewU256(1, 2, 3, 4)),
+			want: []common.U256{common.NewU256(1, 2, 3, 3), common.NewU256(1, 2, 3, 4),
+				common.NewU256(1, 2, 3, 5), common.NewU256(), common.NewU256(1), common.NewU256(0x100),
+				common.NewU256(0x10000), common.NewU256(0x100000000), common.NewU256(0x1000000000000),
+				common.NewU256(1, 0), common.NewU256(1, 0, 0), common.NewU256(1, 0, 0, 0),
+				common.NewU256(1).Shl(common.NewU256(255)), common.NewU256(0).Not(), common.NewU256(1, 1)}},
+		// samples calls samples for all
+		"value-samples": {got: valueDomain{}.Samples(common.NewU256(1, 2, 3, 4)),
+			want: []common.U256{common.NewU256(1, 2, 3, 3), common.NewU256(1, 2, 3, 4),
+				common.NewU256(1, 2, 3, 5)},
+		},
+		// samples calls samples for all
+		"revision-samples": {got: revisionDomain{}.Samples(tosca.R09_Berlin),
+			want: []tosca.Revision{common.R99_UnknownNextRevision, tosca.R07_Istanbul, tosca.R09_Berlin, tosca.R10_London,
+				tosca.R11_Paris, tosca.R12_Shanghai, tosca.R13_Cancun}},
+		"statusCode-samplesforall": {got: statusCodeDomain{}.SamplesForAll([]st.StatusCode{}),
+			want: []st.StatusCode{st.Running, st.Stopped, st.Reverted, st.Failed}},
+		"opcpode-samplesforall": {got: opCodeDomain{}.SamplesForAll([]vm.OpCode{}),
+			want: opcdoesAllSamples},
+		// samples calls samples for all
+		"blocknumberoffset-samples": {got: BlockNumberOffsetDomain{}.Samples(int64(23)),
+			want: []int64{math.MinInt64, -1, 0, 1, 255, 256, 257, math.MaxInt64, 22, 23, 24},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if !reflect.DeepEqual(tc.got, tc.want) {
+				t.Errorf("want %v, but got %v", tc.want, tc.got)
 			}
 		})
 	}

--- a/go/ct/rlz/effect_test.go
+++ b/go/ct/rlz/effect_test.go
@@ -29,3 +29,40 @@ func TestEffect_Change(t *testing.T) {
 		t.Errorf("effect did not apply")
 	}
 }
+
+func TestEffect_String(t *testing.T) {
+	pcAdd1 := Change(func(s *st.State) {
+		s.Pc += 1
+	})
+
+	if pcAdd1.String() != "change" {
+		t.Errorf("effect string is wrong")
+	}
+}
+
+func TestEffect_NoEffect(t *testing.T) {
+	original := st.NewState(st.NewCode([]byte{}))
+	original.Pc = 1
+
+	clone := original.Clone()
+	NoEffect().Apply(clone)
+
+	if !original.Eq(clone) {
+		t.Errorf("effect should have changed anythiong")
+	}
+}
+
+func TestEffect_FailEffect(t *testing.T) {
+	state := st.NewState(st.NewCode([]byte{}))
+	state.Status = st.Running
+	state.Gas = 10
+
+	FailEffect().Apply(state)
+
+	if state.Status != st.Failed {
+		t.Errorf("effect should have failed the state")
+	}
+	if state.Gas != 0 {
+		t.Errorf("effect should have set gas to 0")
+	}
+}

--- a/go/ct/rlz/expressions.go
+++ b/go/ct/rlz/expressions.go
@@ -160,42 +160,6 @@ func (gas) String() string {
 	return "Gas"
 }
 
-////////////////////////////////////////////////////////////
-// Gas Refund Counter
-
-type gasRefund struct{}
-
-func GasRefund() Expression[tosca.Gas] {
-	return gasRefund{}
-}
-
-func (gasRefund) Property() Property { return Property("gasRefund") }
-
-func (gasRefund) Domain() Domain[tosca.Gas] { return gasDomain{} }
-
-func (gasRefund) Eval(s *st.State) (tosca.Gas, error) {
-	return s.GasRefund, nil
-}
-
-func (gasRefund) Restrict(kind RestrictionKind, amount tosca.Gas, generator *gen.StateGenerator) {
-	switch kind {
-	case RestrictLess:
-		generator.AddGasRefundUpperBound(amount - 1)
-	case RestrictLessEqual:
-		generator.AddGasRefundUpperBound(amount)
-	case RestrictEqual:
-		generator.SetGasRefund(amount)
-	case RestrictGreaterEqual:
-		generator.AddGasRefundLowerBound(amount)
-	case RestrictGreater:
-		generator.AddGasRefundLowerBound(amount + 1)
-	}
-}
-
-func (gasRefund) String() string {
-	return "GasRefund"
-}
-
 // //////////////////////////////////////////////////////////
 // Read Only Mode
 type readOnly struct{}

--- a/go/ct/rlz/expressions.go
+++ b/go/ct/rlz/expressions.go
@@ -331,7 +331,9 @@ func Constant(value U256) BindableExpression[U256] {
 	return constant{value}
 }
 
-func (constant) Property() Property { return Property("constant") }
+func (c constant) Property() Property {
+	return Property(fmt.Sprintf("constant(%v)", c.value.ToBigInt()))
+}
 
 func (constant) Domain() Domain[U256] { return u256Domain{} }
 

--- a/go/ct/rlz/expressions_test.go
+++ b/go/ct/rlz/expressions_test.go
@@ -291,3 +291,30 @@ func TestConstant_EvalReturnsValue(t *testing.T) {
 		})
 	}
 }
+
+func TestExpression_RestrictPanics(t *testing.T) {
+
+	tests := map[string]struct {
+		expression any
+		kind       RestrictionKind
+		value      any
+	}{
+		"Status":       {Status(), RestrictGreater, st.Reverted},
+		"Pc":           {Pc(), RestrictGreater, NewU256(42)},
+		"Pc-notUint64": {Pc(), RestrictEqual, NewU256(42, 42)},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			switch v := test.expression.(type) {
+			case status:
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("expected panic, but none occurred")
+					}
+				}()
+				v.Restrict(test.kind, test.value.(st.StatusCode), gen.NewStateGenerator())
+			}
+		})
+	}
+}

--- a/go/ct/rlz/expressions_test.go
+++ b/go/ct/rlz/expressions_test.go
@@ -292,7 +292,7 @@ func TestConstant_EvalReturnsValue(t *testing.T) {
 	}
 }
 
-func TestExpression_RestrictPanics(t *testing.T) {
+func TestExpression_RestrictPanicsWhenCalledWithCertainKind(t *testing.T) {
 
 	tests := map[string]struct {
 		expression interface{}
@@ -343,7 +343,8 @@ func TestExpression_Property(t *testing.T) {
 	}{
 		{ReadOnly().Property(), "readOnly"},
 		{Param(0).Property(), "param[0]"},
-		{Constant(NewU256(42)).Property(), "constant"},
+		{Constant(NewU256(42)).Property(), "constant(42)"},
+		{Constant(NewU256(1, 42)).Property(), "constant(18446744073709551658)"},
 	}
 
 	for _, test := range tests {

--- a/go/ct/rlz/expressions_test.go
+++ b/go/ct/rlz/expressions_test.go
@@ -201,27 +201,6 @@ func TestExpression_GasConstraints(t *testing.T) {
 	}
 }
 
-func TestExpression_GasRefundEval(t *testing.T) {
-	state := st.NewState(st.NewCode([]byte{}))
-	state.GasRefund = 42
-	if gas, err := GasRefund().Eval(state); err != nil || gas != 42 {
-		t.Fail()
-	}
-}
-
-func TestExpression_GasRefundRestrict(t *testing.T) {
-	generator := gen.NewStateGenerator()
-	GasRefund().Restrict(RestrictEqual, 42, generator)
-
-	state, err := generator.Generate(rand.New(0))
-	if err != nil {
-		t.Errorf("State generation failed %v", err)
-	}
-	if state.GasRefund != 42 {
-		t.Errorf("Generator was not restricted by expression")
-	}
-}
-
 func TestExpression_OpEval(t *testing.T) {
 	state := st.NewState(st.NewCode([]byte{byte(vm.STOP), byte(vm.STOP), byte(vm.ADD)}))
 	state.Pc = 2

--- a/go/ct/rlz/parameters_test.go
+++ b/go/ct/rlz/parameters_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package rlz
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/ct/common"
+)
+
+func TestNumericParameter_Samples(t *testing.T) {
+
+	tests := map[string]struct {
+		got  []common.U256
+		want []common.U256
+	}{
+		"NumericParameter": {
+			got:  NumericParameter{}.Samples(),
+			want: numericParameterSamples,
+		},
+		"jumpTargetParameter": {
+			got:  JumpTargetParameter{}.Samples(),
+			want: jumpTargetParameterSamples,
+		},
+		"MemoryOffsetParameter": {
+			got:  MemoryOffsetParameter{}.Samples(),
+			want: memoryOffsetParameterSamples,
+		},
+		"MemoryOffsetForCopyParameter": {
+			got:  MemoryOffsetForCopyParameter{}.Samples(),
+			want: memoryOffsetForCopyParameter,
+		},
+		"MemorySizeParameter": {
+			got:  MemorySizeParameter{}.Samples(),
+			want: memorySizeParameterSamples,
+		},
+		"TopicParameter": {
+			got:  TopicParameter{}.Samples(),
+			want: topicParameterSamples,
+		},
+		"AddressParameter": {
+			got:  AddressParameter{}.Samples(),
+			want: addressParameterSamples,
+		},
+		"GasParameter": {
+			got:  GasParameter{}.Samples(),
+			want: gasParameterSamples,
+		},
+		"ValueParameter": {
+			got:  ValueParameter{}.Samples(),
+			want: valueParameterSamples,
+		},
+	}
+
+	for name, tc := range tests {
+		if !reflect.DeepEqual(tc.got, tc.want) {
+			t.Errorf("%s = %v, want %v", name, tc.got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds UT to improve the coverage of the `rlz` package and removes it from the `override` config.

Some test have been deleted and refactored  together to make the most out of table testing.

Noteworthy comment:
coverage is not 100% because there are a couple of checks that can never fail but I think the should still not be removed, such as the inequalities in confitions_tests, or the `Op.Eval`. In both these cases the corresponding checks can not fail because the current implementations do no generate errors or allow values that could lead to the fail of those checks. 