### PR TITLE
Fix new linter findings

### DIFF
--- a/go/ct/driver/probe.go
+++ b/go/ct/driver/probe.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"sync"
@@ -193,7 +194,7 @@ func testState(specification spc.Specification, state *st.State, evm ct.Evm) err
 	defer result.Release()
 
 	if !expected.Eq(result) {
-		return fmt.Errorf(formatDiffForUser(state, result, expected, rules[0].Name))
+		return errors.New(formatDiffForUser(state, result, expected, rules[0].Name))
 	}
 	return nil
 }

--- a/go/ct/driver/run.go
+++ b/go/ct/driver/run.go
@@ -182,7 +182,7 @@ func runTest(input *st.State, evm ct.Evm, filter *regexp.Regexp) error {
 	if result.Eq(expected) {
 		return nil
 	}
-	return fmt.Errorf(formatDiffForUser(input, result, expected, rule.Name))
+	return errors.New(formatDiffForUser(input, result, expected, rule.Name))
 }
 
 func formatDiffForUser(input, result, expected *st.State, ruleName string) string {

--- a/go/ct/evm_test.go
+++ b/go/ct/evm_test.go
@@ -95,7 +95,7 @@ func TestCt_ExplicitCases(t *testing.T) {
 					if !res.Eq(output) {
 						t.Errorf("Invalid result, wanted %v, got %v", output, res)
 						for _, diff := range output.Diff(res) {
-							t.Errorf(diff)
+							t.Error(diff)
 						}
 					}
 				})

--- a/go/integration_test/interpreter/integration_test.go
+++ b/go/integration_test/interpreter/integration_test.go
@@ -941,7 +941,7 @@ func runOverflowTests(t *testing.T, instruction vm.OpCode, tests []overflowTestC
 					// Check the result.
 					if test.result != nil {
 
-						if res.Output != nil && len(res.Output) >= 32 {
+						if len(res.Output) >= 32 {
 							result := big.NewInt(0).SetBytes(res.Output[0:32])
 							if result.Cmp(test.result) != 0 {
 								t.Errorf("execution result is different want: %v, got: %v", test.result, result)


### PR DESCRIPTION
since we are installing the static check module with `@latest` whenever they release a new version we might get new findings. 
This is party good because we can keep improving our code quality, but it means that occasionally PRs will fail for reasons unrelated its changes. 