### PR TITLE
Floria: support for precompiled contracts

### DIFF
--- a/go/integration_test/processor/precompiled_test.go
+++ b/go/integration_test/processor/precompiled_test.go
@@ -17,7 +17,7 @@ import (
 	"slices"
 	"testing"
 
-	processor_test_utils "github.com/Fantom-foundation/Tosca/go/processor"
+	test_utils "github.com/Fantom-foundation/Tosca/go/processor"
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 	"github.com/Fantom-foundation/Tosca/go/tosca/vm"
 )
@@ -27,16 +27,16 @@ func TestProcessor_AllPreCompiledContractsAreAvailable(t *testing.T) {
 		address tosca.Address
 		input   []byte
 	}{
-		"ecrecover":          {processor_test_utils.NewAddress(0x1), bytes.Repeat([]byte{0}, 256)},
-		"sha256hash":         {processor_test_utils.NewAddress(0x2), bytes.Repeat([]byte{0}, 256)},
-		"ripemd160hash":      {processor_test_utils.NewAddress(0x3), bytes.Repeat([]byte{0}, 256)},
-		"dataCopy":           {processor_test_utils.NewAddress(0x4), bytes.Repeat([]byte{0}, 256)},
-		"bigModExp":          {processor_test_utils.NewAddress(0x5), bytes.Repeat([]byte{0}, 256)},
-		"bn256Add":           {processor_test_utils.NewAddress(0x6), bytes.Repeat([]byte{0}, 256)},
-		"bn256ScalarMul":     {processor_test_utils.NewAddress(0x7), bytes.Repeat([]byte{0}, 256)},
-		"bn256Pairing":       {processor_test_utils.NewAddress(0x8), bytes.Repeat([]byte{0}, 192)},
-		"blake2F":            {processor_test_utils.NewAddress(0x9), bytes.Repeat([]byte{0}, 213)},
-		"kzgPointEvaluation": {processor_test_utils.NewAddress(0xa), processor_test_utils.ValidPointEvaluationInput},
+		"ecrecover":          {test_utils.NewAddress(0x1), make([]byte, 256)},
+		"sha256hash":         {test_utils.NewAddress(0x2), make([]byte, 256)},
+		"ripemd160hash":      {test_utils.NewAddress(0x3), make([]byte, 256)},
+		"dataCopy":           {test_utils.NewAddress(0x4), make([]byte, 256)},
+		"bigModExp":          {test_utils.NewAddress(0x5), make([]byte, 256)},
+		"bn256Add":           {test_utils.NewAddress(0x6), make([]byte, 256)},
+		"bn256ScalarMul":     {test_utils.NewAddress(0x7), make([]byte, 256)},
+		"bn256Pairing":       {test_utils.NewAddress(0x8), make([]byte, 192)},
+		"blake2F":            {test_utils.NewAddress(0x9), make([]byte, 213)},
+		"kzgPointEvaluation": {test_utils.NewAddress(0xa), test_utils.ValidPointEvaluationInput},
 	}
 
 	for processorName, processor := range getProcessors() {

--- a/go/integration_test/processor/precompiled_test.go
+++ b/go/integration_test/processor/precompiled_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package processor
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"slices"
+	"testing"
+
+	processor_test_utils "github.com/Fantom-foundation/Tosca/go/processor"
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+	"github.com/Fantom-foundation/Tosca/go/tosca/vm"
+)
+
+func TestProcessor_AllPreCompiledContractsAreAvailable(t *testing.T) {
+	tests := map[string]struct {
+		address tosca.Address
+		input   []byte
+	}{
+		"ecrecover":          {processor_test_utils.NewAddress(0x1), bytes.Repeat([]byte{0}, 256)},
+		"sha256hash":         {processor_test_utils.NewAddress(0x2), bytes.Repeat([]byte{0}, 256)},
+		"ripemd160hash":      {processor_test_utils.NewAddress(0x3), bytes.Repeat([]byte{0}, 256)},
+		"dataCopy":           {processor_test_utils.NewAddress(0x4), bytes.Repeat([]byte{0}, 256)},
+		"bigModExp":          {processor_test_utils.NewAddress(0x5), bytes.Repeat([]byte{0}, 256)},
+		"bn256Add":           {processor_test_utils.NewAddress(0x6), bytes.Repeat([]byte{0}, 256)},
+		"bn256ScalarMul":     {processor_test_utils.NewAddress(0x7), bytes.Repeat([]byte{0}, 256)},
+		"bn256Pairing":       {processor_test_utils.NewAddress(0x8), bytes.Repeat([]byte{0}, 192)},
+		"blake2F":            {processor_test_utils.NewAddress(0x9), bytes.Repeat([]byte{0}, 213)},
+		"kzgPointEvaluation": {processor_test_utils.NewAddress(0xa), processor_test_utils.ValidPointEvaluationInput},
+	}
+
+	for processorName, processor := range getProcessors() {
+		for contractName, contract := range tests {
+			t.Run(fmt.Sprintf("%s-%s", processorName, contractName), func(t *testing.T) {
+
+				code := []byte{}
+				// save input to memory
+				for i := 0; i < len(contract.input); i += 32 {
+					code = append(code,
+						byte(vm.PUSH1), byte(i),
+						byte(vm.CALLDATALOAD),
+						byte(vm.PUSH1), byte(i),
+						byte(vm.MSTORE),
+					)
+				}
+
+				// push call arguments to stack
+				code = append(code, pushToStack([]*big.Int{
+					big.NewInt(int64(sufficientGas)),           // gas send to nested call
+					new(big.Int).SetBytes(contract.address[:]), // call target
+					big.NewInt(0),                          // value to transfer
+					big.NewInt(0),                          // argument offset
+					big.NewInt(int64(len(contract.input))), // argument size
+					big.NewInt(0),                          // result offset
+					big.NewInt(32),                         // result size
+				})...)
+
+				// call and return whether it was successful
+				code = append(code, []byte{
+					byte(vm.CALL),
+					byte(vm.PUSH1), byte(0),
+					byte(vm.MSTORE),
+					byte(vm.PUSH1), byte(32),
+					byte(vm.PUSH1), byte(0),
+					byte(vm.RETURN),
+				}...)
+
+				sender := tosca.Address{0x42}
+				receiver := tosca.Address{0x43}
+				state := WorldState{
+					sender:   Account{},
+					receiver: Account{Code: code},
+				}
+				transaction := tosca.Transaction{
+					Sender:    sender,
+					Recipient: &receiver,
+					GasLimit:  sufficientGas,
+					Input:     contract.input,
+				}
+
+				transactionContext := newScenarioContext(state)
+				blockParameters := tosca.BlockParameters{Revision: tosca.R13_Cancun}
+
+				// Run the processor
+				result, err := processor.Run(blockParameters, transaction, transactionContext)
+				if err != nil || !result.Success {
+					t.Errorf("execution was not successful or failed with error %v", err)
+				}
+				if !slices.Equal(result.Output, append(bytes.Repeat([]byte{0}, 31), byte(1))) {
+					t.Errorf("call to precompiled contract %s was not successful", contractName)
+				}
+			})
+		}
+	}
+}

--- a/go/integration_test/processor/scenario.go
+++ b/go/integration_test/processor/scenario.go
@@ -222,7 +222,7 @@ func (c *scenarioContext) SetTransientStorage(tosca.Address, tosca.Key, tosca.Wo
 }
 
 func (c *scenarioContext) AccessAccount(tosca.Address) tosca.AccessStatus {
-	panic("implement me")
+	return false // correct value only important inside of the interpreter
 }
 
 func (c *scenarioContext) AccessStorage(tosca.Address, tosca.Key) tosca.AccessStatus {
@@ -248,7 +248,7 @@ func (c *scenarioContext) GetCommittedStorage(addr tosca.Address, key tosca.Key)
 }
 
 func (c *scenarioContext) IsAddressInAccessList(addr tosca.Address) bool {
-	panic("implement me")
+	return false // correct value only important inside of the interpreter
 }
 
 func (c *scenarioContext) IsSlotInAccessList(addr tosca.Address, key tosca.Key) (addressPresent, slotPresent bool) {

--- a/go/integration_test/processor/scenario.go
+++ b/go/integration_test/processor/scenario.go
@@ -111,10 +111,11 @@ func (s *Scenario) Clone() Scenario {
 // scenarioContext implements the tosca.WorldState interface facilitating the
 // interaction with a test-case specific context.
 type scenarioContext struct {
-	original WorldState
-	current  WorldState
-	logs     []tosca.Log
-	undo     []func()
+	original   WorldState
+	current    WorldState
+	logs       []tosca.Log
+	undo       []func()
+	accessList map[tosca.Address]tosca.AccessStatus
 }
 
 func NewScenarioContext() *scenarioContext {
@@ -221,8 +222,13 @@ func (c *scenarioContext) SetTransientStorage(tosca.Address, tosca.Key, tosca.Wo
 	panic("implement me")
 }
 
-func (c *scenarioContext) AccessAccount(tosca.Address) tosca.AccessStatus {
-	return false // correct value only important inside of the interpreter
+func (c *scenarioContext) AccessAccount(address tosca.Address) tosca.AccessStatus {
+	_, ok := c.accessList[address]
+	if !ok {
+		return tosca.WarmAccess
+	}
+	c.accessList[address] = true
+	return tosca.ColdAccess
 }
 
 func (c *scenarioContext) AccessStorage(tosca.Address, tosca.Key) tosca.AccessStatus {
@@ -247,8 +253,9 @@ func (c *scenarioContext) GetCommittedStorage(addr tosca.Address, key tosca.Key)
 	return c.original[addr].Storage[key]
 }
 
-func (c *scenarioContext) IsAddressInAccessList(addr tosca.Address) bool {
-	return false // correct value only important inside of the interpreter
+func (c *scenarioContext) IsAddressInAccessList(address tosca.Address) bool {
+	_, ok := c.accessList[address]
+	return ok
 }
 
 func (c *scenarioContext) IsSlotInAccessList(addr tosca.Address, key tosca.Key) (addressPresent, slotPresent bool) {

--- a/go/interpreter/evmone/evmone.go
+++ b/go/interpreter/evmone/evmone.go
@@ -51,7 +51,7 @@ type evmoneInstance struct {
 	e *evmc.EvmcInterpreter
 }
 
-const newestSupportedRevision = tosca.R10_London
+const newestSupportedRevision = tosca.R13_Cancun
 
 func (e *evmoneInstance) Run(params tosca.Parameters) (tosca.Result, error) {
 	if params.Revision > newestSupportedRevision {

--- a/go/processor/floria/precompiled.go
+++ b/go/processor/floria/precompiled.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package floria
+
+import (
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+	"github.com/ethereum/go-ethereum/common"
+	geth "github.com/ethereum/go-ethereum/core/vm"
+)
+
+func handlePrecompiled(revision tosca.Revision, input tosca.Data, address tosca.Address, gas tosca.Gas) (tosca.CallResult, bool) {
+	contract, ok := precompiledContract(address, revision)
+	if !ok {
+		return tosca.CallResult{}, false
+	}
+	gasCost := contract.RequiredGas(input)
+	if gas < tosca.Gas(gasCost) {
+		return tosca.CallResult{}, true
+	}
+	gas -= tosca.Gas(gasCost)
+	output, err := contract.Run(input)
+
+	return tosca.CallResult{
+		Success: err == nil, // precompiled contracts only return errors on invalid input
+		Output:  output,
+		GasLeft: gas,
+	}, true
+}
+
+func precompiledContract(address tosca.Address, revision tosca.Revision) (geth.PrecompiledContract, bool) {
+	var precompiles map[common.Address]geth.PrecompiledContract
+	switch revision {
+	case tosca.R13_Cancun:
+		precompiles = geth.PrecompiledContractsCancun
+	case tosca.R12_Shanghai, tosca.R11_Paris, tosca.R10_London, tosca.R09_Berlin:
+		precompiles = geth.PrecompiledContractsBerlin
+	default: // Istanbul is the oldest supported revision supported by Sonic
+		precompiles = geth.PrecompiledContractsIstanbul
+	}
+	contract, ok := precompiles[common.Address(address)]
+	return contract, ok
+}

--- a/go/processor/floria/precompiled.go
+++ b/go/processor/floria/precompiled.go
@@ -16,8 +16,8 @@ import (
 	geth "github.com/ethereum/go-ethereum/core/vm"
 )
 
-func handlePrecompiled(revision tosca.Revision, input tosca.Data, address tosca.Address, gas tosca.Gas) (tosca.CallResult, bool) {
-	contract, ok := precompiledContract(address, revision)
+func handlePrecompiledContract(revision tosca.Revision, input tosca.Data, address tosca.Address, gas tosca.Gas) (tosca.CallResult, bool) {
+	contract, ok := getPrecompiledContract(address, revision)
 	if !ok {
 		return tosca.CallResult{}, false
 	}
@@ -35,7 +35,7 @@ func handlePrecompiled(revision tosca.Revision, input tosca.Data, address tosca.
 	}, true
 }
 
-func precompiledContract(address tosca.Address, revision tosca.Revision) (geth.PrecompiledContract, bool) {
+func getPrecompiledContract(address tosca.Address, revision tosca.Revision) (geth.PrecompiledContract, bool) {
 	var precompiles map[common.Address]geth.PrecompiledContract
 	switch revision {
 	case tosca.R13_Cancun:

--- a/go/processor/floria/precompiled_test.go
+++ b/go/processor/floria/precompiled_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package floria
+
+import (
+	"strings"
+	"testing"
+
+	processor_test_utils "github.com/Fantom-foundation/Tosca/go/processor"
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+)
+
+func TestPrecompiled_RightNumberOfContractsDependingOnRevision(t *testing.T) {
+	tests := []struct {
+		revision          tosca.Revision
+		numberOfContracts int
+	}{
+		{tosca.R07_Istanbul, 9},
+		{tosca.R09_Berlin, 9},
+		{tosca.R10_London, 9},
+		{tosca.R11_Paris, 9},
+		{tosca.R12_Shanghai, 9},
+		{tosca.R13_Cancun, 10},
+	}
+
+	for _, test := range tests {
+		count := 0
+		for i := byte(0x01); i < byte(0x42); i++ {
+			address := processor_test_utils.NewAddress(i)
+			_, isPrecompiled := precompiledContract(address, test.revision)
+			if isPrecompiled {
+				count++
+			}
+		}
+		if count != test.numberOfContracts {
+			t.Errorf("unexpected number of precompiled contracts for revision %v, want %v, got %v", test.revision, test.numberOfContracts, count)
+		}
+	}
+}
+
+func TestPrecompiled_AddressesAreHandledCorrectly(t *testing.T) {
+	tests := map[string]struct {
+		revision      tosca.Revision
+		address       tosca.Address
+		gas           tosca.Gas
+		isPrecompiled bool
+		success       bool
+	}{
+		"nonPrecompiled":            {tosca.R09_Berlin, processor_test_utils.NewAddress(0x20), 3000, false, false},
+		"ecrecover-success":         {tosca.R10_London, processor_test_utils.NewAddress(0x01), 3000, true, true},
+		"ecrecover-outOfGas":        {tosca.R10_London, processor_test_utils.NewAddress(0x01), 1, true, false},
+		"pointEvaluation-success":   {tosca.R13_Cancun, processor_test_utils.NewAddress(0x0a), 55000, true, true},
+		"pointEvaluation-outOfGas":  {tosca.R13_Cancun, processor_test_utils.NewAddress(0x0a), 1, true, false},
+		"pointEvaluation-preCancun": {tosca.R10_London, processor_test_utils.NewAddress(0x0a), 3000, false, false},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			input := tosca.Data{}
+			if strings.Contains(name, "pointEvaluation") {
+				input = processor_test_utils.ValidPointEvaluationInput
+			}
+
+			result, isPrecompiled := handlePrecompiled(test.revision, input, test.address, test.gas)
+			if isPrecompiled != test.isPrecompiled {
+				t.Errorf("unexpected precompiled, want %v, got %v", test.isPrecompiled, isPrecompiled)
+			}
+			if result.Success != test.success {
+				t.Errorf("unexpected success, want %v, got %v", test.success, result.Success)
+			}
+		})
+	}
+}

--- a/go/processor/floria/precompiled_test.go
+++ b/go/processor/floria/precompiled_test.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"testing"
 
-	processor_test_utils "github.com/Fantom-foundation/Tosca/go/processor"
+	test_utils "github.com/Fantom-foundation/Tosca/go/processor"
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 )
 
@@ -34,8 +34,8 @@ func TestPrecompiled_RightNumberOfContractsDependingOnRevision(t *testing.T) {
 	for _, test := range tests {
 		count := 0
 		for i := byte(0x01); i < byte(0x42); i++ {
-			address := processor_test_utils.NewAddress(i)
-			_, isPrecompiled := precompiledContract(address, test.revision)
+			address := test_utils.NewAddress(i)
+			_, isPrecompiled := getPrecompiledContract(address, test.revision)
 			if isPrecompiled {
 				count++
 			}
@@ -54,12 +54,12 @@ func TestPrecompiled_AddressesAreHandledCorrectly(t *testing.T) {
 		isPrecompiled bool
 		success       bool
 	}{
-		"nonPrecompiled":            {tosca.R09_Berlin, processor_test_utils.NewAddress(0x20), 3000, false, false},
-		"ecrecover-success":         {tosca.R10_London, processor_test_utils.NewAddress(0x01), 3000, true, true},
-		"ecrecover-outOfGas":        {tosca.R10_London, processor_test_utils.NewAddress(0x01), 1, true, false},
-		"pointEvaluation-success":   {tosca.R13_Cancun, processor_test_utils.NewAddress(0x0a), 55000, true, true},
-		"pointEvaluation-outOfGas":  {tosca.R13_Cancun, processor_test_utils.NewAddress(0x0a), 1, true, false},
-		"pointEvaluation-preCancun": {tosca.R10_London, processor_test_utils.NewAddress(0x0a), 3000, false, false},
+		"nonPrecompiled":            {tosca.R09_Berlin, test_utils.NewAddress(0x20), 3000, false, false},
+		"ecrecover-success":         {tosca.R10_London, test_utils.NewAddress(0x01), 3000, true, true},
+		"ecrecover-outOfGas":        {tosca.R10_London, test_utils.NewAddress(0x01), 1, true, false},
+		"pointEvaluation-success":   {tosca.R13_Cancun, test_utils.NewAddress(0x0a), 55000, true, true},
+		"pointEvaluation-outOfGas":  {tosca.R13_Cancun, test_utils.NewAddress(0x0a), 1, true, false},
+		"pointEvaluation-preCancun": {tosca.R10_London, test_utils.NewAddress(0x0a), 3000, false, false},
 	}
 
 	for name, test := range tests {
@@ -67,10 +67,10 @@ func TestPrecompiled_AddressesAreHandledCorrectly(t *testing.T) {
 
 			input := tosca.Data{}
 			if strings.Contains(name, "pointEvaluation") {
-				input = processor_test_utils.ValidPointEvaluationInput
+				input = test_utils.ValidPointEvaluationInput
 			}
 
-			result, isPrecompiled := handlePrecompiled(test.revision, input, test.address, test.gas)
+			result, isPrecompiled := handlePrecompiledContract(test.revision, input, test.address, test.gas)
 			if isPrecompiled != test.isPrecompiled {
 				t.Errorf("unexpected precompiled, want %v, got %v", test.isPrecompiled, isPrecompiled)
 			}

--- a/go/processor/floria/run_context.go
+++ b/go/processor/floria/run_context.go
@@ -74,6 +74,11 @@ func (r runContext) Call(kind tosca.CallKind, parameters tosca.CallParameters) (
 		return tosca.CallResult{}, nil
 	}
 
+	output, isPrecompiled := handlePrecompiled(r.blockParameters.Revision, parameters.Input, recipient, parameters.Gas)
+	if isPrecompiled {
+		return output, nil
+	}
+
 	interpreterParameters := tosca.Parameters{
 		BlockParameters:       r.blockParameters,
 		TransactionParameters: r.transactionParameters,

--- a/go/processor/floria/run_context.go
+++ b/go/processor/floria/run_context.go
@@ -74,7 +74,7 @@ func (r runContext) Call(kind tosca.CallKind, parameters tosca.CallParameters) (
 		return tosca.CallResult{}, nil
 	}
 
-	output, isPrecompiled := handlePrecompiled(r.blockParameters.Revision, parameters.Input, recipient, parameters.Gas)
+	output, isPrecompiled := handlePrecompiledContract(r.blockParameters.Revision, parameters.Input, recipient, parameters.Gas)
 	if isPrecompiled {
 		return output, nil
 	}

--- a/go/processor/test_utils.go
+++ b/go/processor/test_utils.go
@@ -8,7 +8,7 @@
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
 
-package processor_test_utils
+package test_utils
 
 import "github.com/Fantom-foundation/Tosca/go/tosca"
 

--- a/go/processor/test_utils.go
+++ b/go/processor/test_utils.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package processor_test_utils
+
+import "github.com/Fantom-foundation/Tosca/go/tosca"
+
+// valid input for point evaluation taken from geth
+var ValidPointEvaluationInput = []byte{1, 231, 152, 21, 71, 8, 254, 119, 137, 66, 150, 52, 5, 60, 191, 159,
+	153, 182, 25, 249, 240, 132, 4, 137, 39, 51, 63, 206, 99, 127, 84, 155, 86, 76,
+	10, 17, 160, 247, 4, 244, 252, 62, 138, 207, 224, 248, 36, 95, 10, 209, 52, 123,
+	55, 143, 191, 150, 226, 6, 218, 17, 165, 211, 99, 6, 36, 210, 80, 50, 230, 122,
+	126, 106, 73, 16, 223, 88, 52, 184, 254, 112, 230, 188, 254, 234, 192, 53, 36,
+	52, 25, 107, 223, 75, 36, 133, 213, 161, 143, 89, 168, 210, 161, 166, 37, 161,
+	127, 63, 234, 15, 229, 235, 140, 137, 109, 179, 118, 79, 49, 133, 72, 27, 194,
+	47, 145, 180, 170, 255, 204, 162, 95, 38, 147, 104, 87, 188, 58, 124, 37, 57,
+	234, 142, 195, 169, 82, 183, 135, 48, 51, 224, 56, 50, 110, 135, 237, 62, 18,
+	118, 253, 20, 2, 83, 250, 8, 233, 252, 37, 251, 45, 154, 152, 82, 127, 194, 42,
+	44, 150, 18, 251, 234, 253, 173, 68, 108, 188, 123, 205, 189, 205, 120, 10, 242,
+	193, 106}
+
+func NewAddress(in byte) tosca.Address {
+	val := tosca.NewValue(uint64(in))
+	return tosca.Address(val[12:32])
+}


### PR DESCRIPTION
This PR adds support for precompiled contracts to Floria. 
Although unrelated but just a small fix, the newest supported revision of evmone is updated since the newly introduced tests have been failing. 
Fixes #576.