### PR TITLE
LFVM: remove converter err

### DIFF
--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -43,16 +43,13 @@ func (a ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 		codeHash = *params.CodeHash
 	}
 
-	converted, err := Convert(
+	converted := Convert(
 		params.Code,
 		false, /* no super instructions */
 		params.CodeHash == nil,
 		false, /* with code cache */
 		codeHash,
 	)
-	if err != nil {
-		return nil, err
-	}
 
 	pcMap, err := getPcMap(state.Code)
 	if err != nil {

--- a/go/interpreter/lfvm/ct_test.go
+++ b/go/interpreter/lfvm/ct_test.go
@@ -211,10 +211,7 @@ func TestConvertToLfvm_Code(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			for _, cur := range test {
-				got, err := convert(cur.evmCode, false)
-				if err != nil {
-					t.Fatalf("failed to convert VM code to lfvm context: %v", err)
-				}
+				got := convert(cur.evmCode, false)
 
 				want := cur.lfvmCode
 

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -477,10 +477,7 @@ func benchmarkFib(b *testing.B, arg int, with_super_instructions bool) {
 	example := getFibExample()
 
 	// Convert example to LFVM format.
-	converted, err := convert(example.code, with_super_instructions)
-	if err != nil {
-		b.Fatalf("error converting code: %v", err)
-	}
+	converted := convert(example.code, with_super_instructions)
 
 	// Create input data.
 

--- a/go/interpreter/lfvm/lfvm.go
+++ b/go/interpreter/lfvm/lfvm.go
@@ -45,16 +45,13 @@ func (v *VM) Run(params tosca.Parameters) (tosca.Result, error) {
 		return tosca.Result{}, &tosca.ErrUnsupportedRevision{Revision: params.Revision}
 	}
 
-	converted, err := Convert(
+	converted := Convert(
 		params.Code,
 		v.with_super_instructions,
 		params.CodeHash == nil,
 		v.no_code_cache,
 		codeHash,
 	)
-	if err != nil {
-		return tosca.Result{}, err
-	}
 
 	return Run(params, converted, v.with_statistics, v.no_shaCache, v.logging)
 }


### PR DESCRIPTION
This PR removes the returned error from `converter` and `Converter` functions from LFVM, and adds testing for the converter file. 

The particular error that is removed (previously in line `converter.go#111 `) can not be triggered (`res.length() > i`) because:
note: `.lenght()` returns the value of `res.nextPos`
- in the case of `VM.JUMPDEST`, `padNoOpsUntil(i)` updates `nextPos` to the value of `i`, then `appendCode` increases `nextPos` by one, lastly `i` is also increased by one. 
- `appendInstructions` makes calls to `appendOp` and `appendData` and returns however many times this functions were called -1,  and this returned value is then used to increment `i`, +1. 
So it can never happen that `nextPos > i` 

Also the check that all valid opcodes are covered is moved to a unit test, even if this panic could only trigger during initialization, now that all opcodes are implemented it should be a unit test. 
