### PR TITLE
LFVM: memory tests

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -33,7 +33,7 @@ threshold:
 
   # (optional; default 0) 
   # The minimum total coverage project should have
-  total: 68
+  total: 74
 
 # Holds regexp rules which will override thresholds for matched files or packages 
 # using their paths.

--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -206,12 +206,14 @@ func convertCtMemoryToLfvmMemory(memory *st.Memory) (*Memory, error) {
 	data := memory.Read(0, uint64(memory.Size()))
 
 	result := NewMemory()
-	err := result.SetWithCapacityCheck(0, uint64(len(data)), data)
+	size := uint64(len(data))
+	result.ensureCapacityWithoutGas(size)
+	err := result.set(0, size, data)
 	return result, err
 }
 
 func convertLfvmMemoryToCtMemory(memory *Memory) *st.Memory {
 	result := st.NewMemory()
-	result.Set(memory.GetSlice(0, memory.Len()))
+	result.Set(memory.getSlice(0, memory.len()))
 	return result
 }

--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -207,13 +207,13 @@ func convertCtMemoryToLfvmMemory(memory *st.Memory) (*Memory, error) {
 
 	result := NewMemory()
 	size := uint64(len(data))
-	result.expandMemory(size)
+	result.expandMemoryWithoutCharging(size, result.getExpansionCosts(size))
 	err := result.set(0, size, data)
 	return result, err
 }
 
 func convertLfvmMemoryToCtMemory(memory *Memory) *st.Memory {
 	result := st.NewMemory()
-	result.Set(memory.getSlice(0, memory.len()))
+	result.Set(memory.getSlice(0, memory.length()))
 	return result
 }

--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -207,7 +207,7 @@ func convertCtMemoryToLfvmMemory(memory *st.Memory) (*Memory, error) {
 
 	result := NewMemory()
 	size := uint64(len(data))
-	result.ensureCapacityWithoutGas(size)
+	result.expandMemory(size)
 	err := result.set(0, size, data)
 	return result, err
 }

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -394,7 +394,7 @@ func opCallDataCopy(c *context) {
 		return
 	}
 
-	if c.memory.ensureCapacity(memOffset64, length64, c) != nil {
+	if c.memory.expandMemoryAndCharge(memOffset64, length64, c) != nil {
 		return
 	}
 
@@ -801,7 +801,7 @@ func opCodeCopy(c *context) {
 		return
 	}
 
-	if c.memory.ensureCapacity(memOffset.Uint64(), length.Uint64(), c) != nil {
+	if c.memory.expandMemoryAndCharge(memOffset.Uint64(), length.Uint64(), c) != nil {
 		return
 	}
 	codeCopy := getData(c.params.Code, uint64CodeOffset, length.Uint64())
@@ -876,7 +876,7 @@ func opCreate(c *context) {
 		return
 	}
 
-	if c.memory.ensureCapacity(offset.Uint64(), size.Uint64(), c) != nil {
+	if c.memory.expandMemoryAndCharge(offset.Uint64(), size.Uint64(), c) != nil {
 		return
 	}
 
@@ -947,7 +947,7 @@ func opCreate2(c *context) {
 		return
 	}
 
-	if c.memory.ensureCapacity(offset.Uint64(), size.Uint64(), c) != nil {
+	if c.memory.expandMemoryAndCharge(offset.Uint64(), size.Uint64(), c) != nil {
 		return
 	}
 
@@ -1052,7 +1052,7 @@ func opExtCodeCopy(c *context) {
 		uint64CodeOffset = math.MaxUint64
 	}
 
-	if c.memory.ensureCapacity(memOffset.Uint64(), length.Uint64(), c) != nil {
+	if c.memory.expandMemoryAndCharge(memOffset.Uint64(), length.Uint64(), c) != nil {
 		return
 	}
 	codeCopy := getData(c.context.GetCode(addr), uint64CodeOffset, length.Uint64())
@@ -1162,7 +1162,7 @@ func genericCall(c *context, kind tosca.CallKind) {
 
 	// first use static and dynamic gas cost and then resize the memory
 	// when out of gas is happening, then mem should not be resized
-	c.memory.ensureCapacityWithoutGas(needed_memory_size)
+	c.memory.expandMemory(needed_memory_size)
 	if !value.IsZero() {
 		cost += CallStipend
 	}

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -586,11 +586,11 @@ func TestMCopy(t *testing.T) {
 				t.Errorf("expected status %v, got %v", test.expectedStatus, ctxt.status)
 				return
 			}
-			if ctxt.memory.len() != uint64(len(test.memoryAfter)) {
-				t.Errorf("expected memory size %d, got %d", uint64(len(test.memoryAfter)), ctxt.memory.len())
+			if ctxt.memory.length() != uint64(len(test.memoryAfter)) {
+				t.Errorf("expected memory size %d, got %d", uint64(len(test.memoryAfter)), ctxt.memory.length())
 			}
 
-			if memoryData := ctxt.memory.getSlice(0, ctxt.memory.len()); !bytes.Equal(memoryData, test.memoryAfter) {
+			if memoryData := ctxt.memory.getSlice(0, ctxt.memory.length()); !bytes.Equal(memoryData, test.memoryAfter) {
 				t.Errorf("expected memory %v, got %v", test.memoryAfter, memoryData)
 			}
 			if ctxt.gas != test.gasAfter {

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -586,11 +586,12 @@ func TestMCopy(t *testing.T) {
 				t.Errorf("expected status %v, got %v", test.expectedStatus, ctxt.status)
 				return
 			}
-			if ctxt.memory.Len() != uint64(len(test.memoryAfter)) {
-				t.Errorf("expected memory size %d, got %d", uint64(len(test.memoryAfter)), ctxt.memory.Len())
+			if ctxt.memory.len() != uint64(len(test.memoryAfter)) {
+				t.Errorf("expected memory size %d, got %d", uint64(len(test.memoryAfter)), ctxt.memory.len())
 			}
-			if !bytes.Equal(ctxt.memory.Data(), test.memoryAfter) {
-				t.Errorf("expected memory %v, got %v", test.memoryAfter, ctxt.memory.Data())
+
+			if memoryData := ctxt.memory.getSlice(0, ctxt.memory.len()); !bytes.Equal(memoryData, test.memoryAfter) {
+				t.Errorf("expected memory %v, got %v", test.memoryAfter, memoryData)
 			}
 			if ctxt.gas != test.gasAfter {
 				t.Errorf("expected gas %d, got %d", test.gasAfter, ctxt.gas)

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -186,11 +186,11 @@ func getOutput(ctxt *context) ([]byte, error) {
 			}
 
 			// Extract the result from the memory
-			if err := ctxt.memory.EnsureCapacity(offset, size, ctxt); err != nil {
+			if err := ctxt.memory.ensureCapacity(offset, size, ctxt); err != nil {
 				return nil, err
 			}
 			res = make([]byte, size)
-			ctxt.memory.CopyData(offset, res)
+			ctxt.memory.getData(offset, res)
 		}
 	}
 	return res, nil

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -186,11 +186,11 @@ func getOutput(ctxt *context) ([]byte, error) {
 			}
 
 			// Extract the result from the memory
-			if err := ctxt.memory.expandMemoryAndCharge(offset, size, ctxt); err != nil {
+			if err := ctxt.memory.expandMemory(offset, size, ctxt); err != nil {
 				return nil, err
 			}
 			res = make([]byte, size)
-			ctxt.memory.getData(offset, res)
+			ctxt.memory.readData(offset, res)
 		}
 	}
 	return res, nil

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -186,7 +186,7 @@ func getOutput(ctxt *context) ([]byte, error) {
 			}
 
 			// Extract the result from the memory
-			if err := ctxt.memory.ensureCapacity(offset, size, ctxt); err != nil {
+			if err := ctxt.memory.expandMemoryAndCharge(offset, size, ctxt); err != nil {
 				return nil, err
 			}
 			res = make([]byte, size)

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -799,7 +799,7 @@ func benchmarkFib(b *testing.B, arg int, with_super_instructions bool) {
 		}
 		res := make([]byte, size.Uint64())
 		offset := ctxt.resultOffset
-		ctxt.memory.CopyData(offset.Uint64(), res)
+		ctxt.memory.getData(offset.Uint64(), res)
 
 		got := (int(res[28]) << 24) | (int(res[29]) << 16) | (int(res[30]) << 8) | (int(res[31]) << 0)
 		if wanted != got {

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -799,7 +799,7 @@ func benchmarkFib(b *testing.B, arg int, with_super_instructions bool) {
 		}
 		res := make([]byte, size.Uint64())
 		offset := ctxt.resultOffset
-		ctxt.memory.getData(offset.Uint64(), res)
+		ctxt.memory.readData(offset.Uint64(), res)
 
 		got := (int(res[28]) << 24) | (int(res[29]) << 16) | (int(res[30]) << 8) | (int(res[31]) << 0)
 		if wanted != got {

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -168,11 +168,15 @@ func (m *Memory) Set(offset, size uint64, value []byte) error {
 			return errGasUintOverflow
 		}
 		if offset+size > m.Len() {
-			return fmt.Errorf("memory too small, size %d, attempted to write %d bytes at %d", m.Len(), size, offset)
+			return errSetMemTooSmall(m.Len(), size, offset)
 		}
 		copy(m.store[offset:offset+size], value)
 	}
 	return nil
+}
+
+func errSetMemTooSmall(memSize, size, offset uint64) error {
+	return ConstError(fmt.Sprintf("memory too small, size %d, attempted to write %d bytes at %d", memSize, size, offset))
 }
 
 func (m *Memory) SetWithCapacityAndGasCheck(offset, size uint64, value []byte, c *context) error {

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -197,8 +197,7 @@ func (m *Memory) CopyWord(offset uint64, trg *uint256.Int, c *context) error {
 	if err != nil {
 		return err
 	}
-	toWrite := m.store[offset : offset+32]
-	trg.SetBytes32(toWrite) //m.store[offset : offset+32])
+	trg.SetBytes32(m.store[offset : offset+32])
 	return nil
 }
 

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -180,22 +180,12 @@ func (m *Memory) SetWithCapacityAndGasCheck(offset, size uint64, value []byte, c
 	if err != nil {
 		return err
 	}
-	err = m.Set(offset, size, value)
-	if err != nil {
-		return err
-	}
-	return nil
+	return m.Set(offset, size, value)
 }
 
 func (m *Memory) SetWithCapacityCheck(offset, size uint64, value []byte) error {
 	m.EnsureCapacityWithoutGas(size)
-	if size > 0 {
-		if offset+size < offset {
-			return errGasUintOverflow
-		}
-		copy(m.store[offset:offset+size], value)
-	}
-	return nil
+	return m.Set(offset, size, value)
 }
 
 func (m *Memory) CopyWord(offset uint64, trg *uint256.Int, c *context) error {

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -197,7 +197,8 @@ func (m *Memory) CopyWord(offset uint64, trg *uint256.Int, c *context) error {
 	if err != nil {
 		return err
 	}
-	trg.SetBytes32(m.store[offset : offset+32])
+	toWrite := m.store[offset : offset+32]
+	trg.SetBytes32(toWrite) //m.store[offset : offset+32])
 	return nil
 }
 

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -169,14 +169,14 @@ func (m *Memory) Set(offset, size uint64, value []byte) error {
 			return errGasUintOverflow
 		}
 		if offset+size > m.Len() {
-			return errInsufficientMemory(m.Len(), size, offset)
+			return makeInsufficientMemoryError(m.Len(), size, offset)
 		}
 		copy(m.store[offset:offset+size], value)
 	}
 	return nil
 }
 
-func errInsufficientMemory(memSize, size, offset uint64) error {
+func makeInsufficientMemoryError(memSize, size, offset uint64) error {
 	return tosca.ConstError(fmt.Sprintf("memory too small, size %d, attempted to write %d bytes at %d", memSize, size, offset))
 }
 

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -112,10 +112,6 @@ func (m *Memory) SetByte(offset uint64, value byte, c *context) error {
 	if err != nil {
 		return err
 	}
-
-	if m.Len() < offset+1 {
-		return fmt.Errorf("memory too small, size %d, attempted to write at position %d", m.Len(), offset)
-	}
 	m.store[offset] = value
 	return nil
 }
@@ -124,10 +120,6 @@ func (m *Memory) SetWord(offset uint64, value *uint256.Int, c *context) error {
 	err := m.EnsureCapacity(offset, 32, c)
 	if err != nil {
 		return err
-	}
-
-	if m.Len() < offset+32 {
-		return fmt.Errorf("memory too small, size %d, attempted to write 32 byte at position %d", m.Len(), offset)
 	}
 
 	// Inlining and unrolling value.WriteToSlice(..) lead to a 7x speedup
@@ -201,9 +193,6 @@ func (m *Memory) SetWithCapacityCheck(offset, size uint64, value []byte) error {
 		if offset+size < offset {
 			return errGasUintOverflow
 		}
-		if offset+size > m.Len() {
-			return fmt.Errorf("memory too small, size %d, attempted to write %d bytes at %d", m.Len(), size, offset)
-		}
 		copy(m.store[offset:offset+size], value)
 	}
 	return nil
@@ -213,9 +202,6 @@ func (m *Memory) CopyWord(offset uint64, trg *uint256.Int, c *context) error {
 	err := m.EnsureCapacity(offset, 32, c)
 	if err != nil {
 		return err
-	}
-	if m.Len() < offset+32 {
-		return fmt.Errorf("memory too small, size %d, attempted to read 32 byte at position %d", m.Len(), offset)
 	}
 	trg.SetBytes32(m.store[offset : offset+32])
 	return nil

--- a/go/interpreter/lfvm/memory_test.go
+++ b/go/interpreter/lfvm/memory_test.go
@@ -51,7 +51,7 @@ func TestMemory_ExpansionCosts_ComputesCorrectCosts(t *testing.T) {
 	}
 }
 
-func TestMemory_CopyWord_CopiesData(t *testing.T) {
+func TestMemory_GetWord_CopiesData(t *testing.T) {
 
 	valueSmall := uint256.NewInt(0x1223457890abcdef)
 	valueMiddle := uint256.NewInt(0).Lsh(valueSmall, 64)
@@ -100,7 +100,7 @@ func TestMemory_CopyWord_CopiesData(t *testing.T) {
 	}
 }
 
-func TestMemory_CopyWord_ReturnsError(t *testing.T) {
+func TestMemory_GetWord_ReturnsError(t *testing.T) {
 
 	valueSmall := uint256.NewInt(0x1223457890abcdef)
 	baseTargetValue := uint256.NewInt(1)
@@ -349,7 +349,7 @@ func TestMemory_Set_ErrorCases(t *testing.T) {
 	}
 }
 
-func TestMemory_CopyData(t *testing.T) {
+func TestMemory_GetData(t *testing.T) {
 
 	baseStore := []byte{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef}
 	baseTarget := []byte{0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32}

--- a/go/interpreter/lfvm/memory_test.go
+++ b/go/interpreter/lfvm/memory_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/Fantom-foundation/Tosca/go/tosca"
+	"github.com/holiman/uint256"
 )
 
 func TestExpansionCosts(t *testing.T) {
@@ -47,3 +48,120 @@ func TestExpansionCosts(t *testing.T) {
 		}
 	}
 }
+
+func TestCopyWord(t *testing.T) {
+
+	testValue := []byte{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef}
+
+	tests := map[string]struct {
+		setup          func(*Memory, *context)
+		offset         uint64
+		expectedTarget uint256.Int
+		expectedError  error
+	}{
+		"regular": {
+			setup: func(m *Memory, ctxt *context) {
+				m.store = make([]byte, 32)
+				copy(m.store[24:], testValue)
+				ctxt.gas = 100
+			},
+			offset:         0,
+			expectedTarget: *uint256.NewInt(0).SetBytes8(testValue),
+			expectedError:  nil},
+		"not enough gas": {
+			setup: func(m *Memory, ctxt *context) {
+				m.store = make([]byte, 32)
+				copy(m.store[24:], testValue)
+				ctxt.gas = 6
+			},
+			offset:         64,
+			expectedTarget: *uint256.NewInt(0),
+			expectedError:  errOutOfGas},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctxt := getEmptyContext()
+			m := NewMemory()
+			target := uint256.NewInt(0)
+			test.setup(m, &ctxt)
+
+			err := m.CopyWord(test.offset, target, &ctxt)
+			if err != test.expectedError {
+				t.Errorf("unexpected error, want: %v, got: %v", test.expectedError, err)
+			}
+			if target.Cmp(&test.expectedTarget) != 0 {
+				t.Errorf("unexpected target value, want: %v, got: %v", test.expectedTarget, target)
+			}
+		})
+	}
+}
+
+func TestSetByte(t *testing.T) {
+
+	tests := map[string]struct {
+		value    byte
+		offset   uint64
+		gas      tosca.Gas
+		expected error
+	}{
+		"regular":        {value: 0x12, offset: 0, gas: 100, expected: nil},
+		"not enough gas": {value: 0x12, offset: 64, gas: 0, expected: errOutOfGas},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctxt := getEmptyContext()
+			m := NewMemory()
+			ctxt.gas = test.gas
+
+			err := m.SetByte(test.offset, test.value, &ctxt)
+			if err != test.expected {
+				t.Errorf("unexpected error, want: %v, got: %v", test.expected, err)
+			}
+			if err == nil && m.store[test.offset] != test.value {
+				t.Errorf("unexpected value, want: %v, got: %v", test.value, m.store[test.offset])
+			}
+		})
+	}
+}
+
+func TestSetWordProperlyReportsNotEnoughGas(t *testing.T) {
+	ctxt := getEmptyContext()
+	m := NewMemory()
+	ctxt.gas = 0
+	err := m.SetWord(0, uint256.NewInt(0), &ctxt)
+	if err != errOutOfGas {
+		t.Errorf("unexpected error, want: %v, got: %v", errOutOfGas, err)
+	}
+}
+
+// func TestSet(t *testing.T) {
+
+// 	tests := map[string]struct {
+// 		size     uint64
+// 		offset   uint64
+// 		expected error
+// 	}{
+// 		"regular":         {size: 8, offset: 0, expected: nil},
+// 		"size overflow":   {size: math.MaxUint64, offset: 1, expected: errGasUintOverflow},
+// 		"offset overflow": {size: 32, offset: math.MaxUint64, expected: errGasUintOverflow},
+// 		"not enough memory": {size: 32, offset: 32,
+// 			expected: fmt.Errorf("memory too small, size %d, attempted to write %d bytes at %d", 8, 32, 32)},
+// 	}
+
+// 	for name, test := range tests {
+// 		t.Run(name, func(t *testing.T) {
+// 			ctxt := getEmptyContext()
+// 			m := NewMemory()
+// 			m.store = make([]byte, 8)
+// 			ctxt.gas = 100
+
+// 			err := m.Set(test.offset, test.size, []byte{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef})
+// 			if !strings.Contains(err.Error(), test.expected.Error()) {
+// 				t.Errorf("unexpected error, want: %v, got: %v", test.expected, err)
+// 			}
+// 		})
+// 	}
+
+// }

--- a/go/interpreter/lfvm/memory_test.go
+++ b/go/interpreter/lfvm/memory_test.go
@@ -248,7 +248,7 @@ func TestMemory_SetWord_ReportsNotEnoughGas(t *testing.T) {
 			gas:    6,
 			offset: 24,
 			expectedData: append(
-				append([]byte{23: 0x1, 0x02, 4: 0x1}, testValue...),
+				append([]byte{23: 0x0}, testValue...),
 				[]byte{7: 0x0}...)},
 		"offset same as memory size": {
 			memory:       testValue,
@@ -327,7 +327,7 @@ func TestMemory_Set_ErrorCases(t *testing.T) {
 		"not enough memory": {
 			size:     32,
 			offset:   32,
-			expected: errInsufficientMemory(8, 32, 32),
+			expected: makeInsufficientMemoryError(8, 32, 32),
 		},
 	}
 

--- a/go/interpreter/lfvm/memory_test.go
+++ b/go/interpreter/lfvm/memory_test.go
@@ -53,40 +53,29 @@ func TestMemory_ExpansionCosts_ComputesCorrectCosts(t *testing.T) {
 	}
 }
 
-func TestMemory_CopyWord_CopiesDataOrReturnsError(t *testing.T) {
+func TestMemory_CopyWord_CopiesData(t *testing.T) {
 
-	testValue := []byte{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef}
-	testValue2 := append(testValue, bytes.Repeat([]byte{0x00}, 24)...)
-	testValue3 := append(
-		append(bytes.Repeat([]byte{0x00}, 16), testValue...),
-		bytes.Repeat([]byte{0x00}, 8)...)
+	valueSmall := uint256.NewInt(0x1223457890abcdef)
+	valueMiddle := uint256.NewInt(0).Lsh(valueSmall, 64)
+	valueBig := uint256.NewInt(0).Lsh(valueSmall, 256-16)
+	memorySize := uint64(32)
 
 	tests := map[string]struct {
-		gas           tosca.Gas
-		offset        uint64
-		expectedData  uint256.Int
-		expectedError error
+		offset       uint64
+		expectedData *uint256.Int
 	}{
 		"regular": {
-			gas:           100,
-			offset:        0,
-			expectedData:  *uint256.NewInt(1).SetBytes8(testValue),
-			expectedError: nil},
-		"not enough gas": {
-			gas:           6,
-			offset:        64,
-			expectedData:  *uint256.NewInt(1),
-			expectedError: errOutOfGas},
-		"offset fits in memory": {
-			gas:           100,
-			offset:        24,
-			expectedData:  *uint256.NewInt(1).SetBytes32(testValue2),
-			expectedError: nil},
-		"offset same as memory size": {
-			gas:           100,
-			offset:        8,
-			expectedData:  *uint256.NewInt(1).SetBytes32(testValue3),
-			expectedError: nil},
+			offset:       0,
+			expectedData: valueSmall},
+		"small offset": {
+			offset:       memorySize / 4,
+			expectedData: valueMiddle},
+		"big offset crops value": {
+			offset:       memorySize - 2,
+			expectedData: valueBig},
+		"big offset returns zero": {
+			offset:       memorySize,
+			expectedData: uint256.NewInt(0)},
 	}
 
 	for name, test := range tests {
@@ -94,38 +83,81 @@ func TestMemory_CopyWord_CopiesDataOrReturnsError(t *testing.T) {
 			ctxt := getEmptyContext()
 			m := NewMemory()
 			target := uint256.NewInt(1)
-			m.store = make([]byte, 32)
-			copy(m.store[24:], testValue)
+			m.store = make([]byte, memorySize)
+			copy(m.store[24:], valueSmall.Bytes())
+			ctxt.gas = 100
+
+			err := m.CopyWord(test.offset, target, &ctxt)
+			if err != nil {
+				t.Fatalf("unexpected error, want: %v, got: %v", nil, err)
+			}
+			if target.Cmp(test.expectedData) != 0 {
+				t.Errorf("unexpected target value, want: %x, got: %x", *test.expectedData, *target)
+			}
+		})
+	}
+}
+
+func TestMemory_CopyWord_ReturnsError(t *testing.T) {
+
+	valueSmall := uint256.NewInt(0x1223457890abcdef)
+	baseTargetValue := uint256.NewInt(1)
+	memorySize := uint64(32)
+	enoughGas := tosca.Gas(100)
+
+	tests := map[string]struct {
+		gas           tosca.Gas
+		offset        uint64
+		expectedError error
+	}{
+		"not enough gas": {
+			gas:           6,
+			offset:        uint64(memorySize * 2),
+			expectedError: errOutOfGas},
+		"offset overflow": {
+			gas:           enoughGas,
+			offset:        math.MaxUint64,
+			expectedError: errGasUintOverflow},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctxt := getEmptyContext()
+			m := NewMemory()
+			target := baseTargetValue
+			m.store = make([]byte, memorySize)
+			copy(m.store[24:], valueSmall.Bytes())
 			ctxt.gas = test.gas
 
 			err := m.CopyWord(test.offset, target, &ctxt)
 			if !errors.Is(err, test.expectedError) {
 				t.Fatalf("unexpected error, want: %v, got: %v", test.expectedError, err)
 			}
-			if target.Cmp(&test.expectedData) != 0 {
-				t.Errorf("unexpected target value, want: %x, got: %x", test.expectedData, *target)
+			if target.Cmp(baseTargetValue) != 0 {
+				t.Errorf("unexpected target value, want: %x, got: %x", *baseTargetValue, *target)
 			}
 		})
 	}
 }
 
-func TestMemory_SetByte(t *testing.T) {
+func TestMemory_SetByte_SuccessfulCases(t *testing.T) {
+
+	baseData := []byte{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef}
 
 	tests := map[string]struct {
-		memory   []byte
-		value    byte
-		offset   uint64
-		gas      tosca.Gas
-		expected error
+		memory []byte
+		offset uint64
 	}{
-		"regular empty memory": {value: 0x12, offset: 0, gas: 100, expected: nil},
-		"not enough gas":       {value: 0x12, offset: 64, gas: 0, expected: errOutOfGas},
-		"offset overflow": {value: 0x12, offset: math.MaxUint64, gas: 100,
-			expected: errGasUintOverflow},
-		"regular with memory": {memory: []byte{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef},
-			value: 0x12, offset: 0, gas: 100, expected: nil},
-		"regular with memory and offset": {memory: []byte{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef},
-			value: 0x12, offset: 4, gas: 100, expected: nil},
+		"regular empty memory": {},
+		"regular with memory": {
+			memory: baseData,
+			offset: 0},
+		"regular with memory and offset": {
+			memory: baseData,
+			offset: 4},
+		"offset trigger memory expansion": {
+			memory: baseData[:4],
+			offset: 8},
 	}
 
 	for name, test := range tests {
@@ -133,16 +165,50 @@ func TestMemory_SetByte(t *testing.T) {
 			ctxt := getEmptyContext()
 			m := NewMemory()
 			m.store = test.memory
+			ctxt.gas = tosca.Gas(100)
+			value := byte(0x12)
+
+			err := m.SetByte(test.offset, value, &ctxt)
+			if err != nil {
+				t.Errorf("unexpected error, want: %v, got: %v", nil, err)
+			}
+			if m.Len() < test.offset {
+				t.Errorf("unexpected memory size, want: %d, got: %d", test.offset, m.Len())
+			}
+			if m.store[test.offset] != value {
+				t.Errorf("unexpected value, want: %v, got: %v", value, m.store[test.offset])
+			}
+		})
+	}
+}
+
+func TestMemory_SetByte_ErrorCases(t *testing.T) {
+
+	tests := map[string]struct {
+		offset   uint64
+		gas      tosca.Gas
+		expected error
+	}{
+		"not enough gas": {
+			offset:   64,
+			gas:      0,
+			expected: errOutOfGas},
+		"offset overflow": {
+			offset:   math.MaxUint64,
+			gas:      100,
+			expected: errGasUintOverflow},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctxt := getEmptyContext()
+			m := NewMemory()
+			m.store = []byte{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef}
 			ctxt.gas = test.gas
 
-			err := m.SetByte(test.offset, test.value, &ctxt)
+			err := m.SetByte(test.offset, 0x12, &ctxt)
 			if !errors.Is(err, test.expected) {
 				t.Errorf("unexpected error, want: %v, got: %v", test.expected, err)
-			}
-			if err == nil {
-				if m.store[test.offset] != test.value {
-					t.Errorf("unexpected value, want: %v, got: %v", test.value, m.store[test.offset])
-				}
 			}
 		})
 	}
@@ -201,17 +267,58 @@ func TestMemory_SetWord_ReportsNotEnoughGas(t *testing.T) {
 	}
 }
 
-func TestMemory_Set(t *testing.T) {
+func TestMemory_Set_SuccessfulCases(t *testing.T) {
+
+	tests := map[string]struct {
+		size   uint64
+		offset uint64
+	}{
+		"regular": {size: 8, offset: 0},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctxt := getEmptyContext()
+			m := NewMemory()
+			m.store = make([]byte, 8)
+			ctxt.gas = 100
+
+			data := []byte{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef}
+			err := m.Set(test.offset, test.size, data)
+
+			if err != nil {
+				t.Fatalf("unexpected error, want: %v, got: %v", nil, err)
+			}
+
+			if m.Len() != test.size+test.offset {
+				t.Errorf("unexpected memory size, want: %d, got: %d", test.size+test.offset, m.Len())
+			}
+			if !bytes.Equal(m.store[test.offset:], data) {
+				t.Errorf("unexpected memory value, want: %x, got: %x", data, m.store[test.offset:])
+			}
+
+		})
+	}
+}
+
+func TestMemory_Set_ErrorCases(t *testing.T) {
 
 	tests := map[string]struct {
 		size     uint64
 		offset   uint64
 		expected error
 	}{
-		"regular":         {size: 8, offset: 0, expected: nil},
-		"size overflow":   {size: math.MaxUint64, offset: 1, expected: errGasUintOverflow},
-		"offset overflow": {size: 32, offset: math.MaxUint64, expected: errGasUintOverflow},
-		"not enough memory": {size: 32, offset: 32,
+		"size overflow": {
+			size:     math.MaxUint64,
+			offset:   1,
+			expected: errGasUintOverflow},
+		"offset overflow": {
+			size:     32,
+			offset:   math.MaxUint64,
+			expected: errGasUintOverflow},
+		"not enough memory": {
+			size:     32,
+			offset:   32,
 			expected: errSetMemTooSmall(8, 32, 32)},
 	}
 
@@ -225,17 +332,7 @@ func TestMemory_Set(t *testing.T) {
 			data := []byte{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef}
 			err := m.Set(test.offset, test.size, data)
 
-			if err == nil {
-				if test.expected != nil {
-					t.Errorf("expected error %v, got nil", test.expected)
-				}
-				if m.Len() != test.size+test.offset {
-					t.Errorf("unexpected memory size, want: %d, got: %d", test.size+test.offset, m.Len())
-				}
-				if !bytes.Equal(m.store[test.offset:], data) {
-					t.Errorf("unexpected memory value, want: %x, got: %x", data, m.store[test.offset:])
-				}
-			} else if !errors.Is(err, test.expected) {
+			if !errors.Is(err, test.expected) {
 				t.Errorf("unexpected error, want: %v, got: %v", test.expected, err)
 			}
 
@@ -254,11 +351,19 @@ func TestMemory_CopyData(t *testing.T) {
 		offset   uint64
 		expected []byte
 	}{
-		"regular": {target: baseTarget, store: baseStore, expected: baseStore[:len(baseTarget)]},
-		"offset bigger than memory": {target: baseTarget, store: baseStore, offset: 9,
+		"regular": {
+			target:   baseTarget,
+			store:    baseStore,
+			expected: baseStore[:len(baseTarget)]},
+		"offset bigger than memory": {
+			target:   baseTarget,
+			store:    baseStore,
+			offset:   9,
 			expected: bytes.Repeat([]byte{0}, len(baseTarget))},
-		"padding needed": {store: baseStore,
-			offset: 4, target: baseTarget,
+		"padding needed": {
+			target:   baseTarget,
+			store:    baseStore,
+			offset:   4,
 			expected: []byte{0x90, 0xab, 0xcd, 0xef, 0, 0, 0}},
 	}
 
@@ -280,6 +385,8 @@ func TestMemory_CopyData(t *testing.T) {
 func TestMemory_GetSliceWithCapacity(t *testing.T) {
 
 	baseStore := []byte{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef}
+	memorySize := uint64(8)
+	baseEmpty := bytes.Repeat([]byte{0}, int(memorySize))
 
 	tests := map[string]struct {
 		store    []byte
@@ -287,15 +394,33 @@ func TestMemory_GetSliceWithCapacity(t *testing.T) {
 		size     uint64
 		expected []byte
 	}{
-		"regular":                 {store: baseStore, offset: 0, size: 8, expected: baseStore},
-		"regular in empty memory": {store: []byte{}, offset: 0, size: 8, expected: bytes.Repeat([]byte{0}, 8)},
-		"size zero":               {store: baseStore, offset: 0, size: 0, expected: nil},
-		"size+offset bigger than memory": {store: baseStore, offset: 4, size: 8,
-			expected: nil},
-		"expand memory": {store: baseStore, offset: 0, size: 12,
-			expected: append(baseStore, bytes.Repeat([]byte{0}, 4)...)},
-		"offset bigger than memory": {store: baseStore, offset: uint64(len(baseStore) + 2), size: 4,
-			expected: nil},
+		"regular": {
+			store:    baseStore,
+			offset:   0,
+			size:     memorySize,
+			expected: baseStore},
+		"regular in empty memory": {
+			store:    []byte{},
+			offset:   0,
+			size:     memorySize,
+			expected: baseEmpty},
+		"size zero": {
+			store:  baseStore,
+			offset: 0,
+			size:   0},
+		"expand memory": {
+			store:    baseStore,
+			offset:   0,
+			size:     memorySize + 4,
+			expected: append(baseStore, baseEmpty[:4]...)},
+		"offset bigger than memory": {
+			store:  baseStore,
+			offset: uint64(len(baseStore) + 2),
+			size:   4},
+		"size+offset bigger than memory": {
+			store:  baseStore,
+			offset: 4,
+			size:   8},
 	}
 
 	for name, test := range tests {

--- a/go/interpreter/lfvm/super_instructions.go
+++ b/go/interpreter/lfvm/super_instructions.go
@@ -86,7 +86,7 @@ func opDup2_Mstore(c *context) {
 	var addr = c.stack.peek()
 
 	offset := addr.Uint64()
-	if err := c.memory.SetWord(offset, value, c); err != nil {
+	if err := c.memory.setWord(offset, value, c); err != nil {
 		c.signalError()
 	}
 }


### PR DESCRIPTION
This PR cleans a little bit the memory functions, in particular those that call `EnsureCapacity` and then other memory methods. 
Many checks are removed, all of them checking that there is space in the memory, but since this is ensured by `EnsureCapacity` which is called just before the checks, these checks cannot fail.

Tests are added to verify expected behaviour and error reporting of memory methods.