### PR TITLE
LFVM: vm and opcodes tests

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -62,10 +62,6 @@ override:
   - threshold: 0
     path: go/interpreter/lfvm/hash_cache.go
   - threshold: 0
-    path: go/interpreter/lfvm/lfvm.go
-  - threshold: 0
-    path: go/interpreter/lfvm/opcode.go
-  - threshold: 0
     path: go/interpreter/lfvm/super_instructions.go
   - threshold: 0
     path: go/processor/floria/processor.go

--- a/go/interpreter/lfvm/lfvm_test.go
+++ b/go/interpreter/lfvm/lfvm_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package lfvm
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+)
+
+func TestVm_Run(t *testing.T) {
+
+	tests := map[string]struct {
+		code                  []byte
+		codeHash              tosca.Hash
+		revision              tosca.Revision
+		withSuperInstructions bool
+		withCodeCache         bool
+		expectedResult        tosca.Result
+		expectedError         error
+	}{
+		"empty code": {
+			revision: tosca.R13_Cancun,
+			expectedResult: tosca.Result{Success: true, GasLeft: 1000000,
+				GasRefund: 0, Output: []byte{}},
+		},
+		"invalid code": {
+			code:     []byte{0x0C},
+			revision: tosca.R13_Cancun,
+			expectedResult: tosca.Result{Success: false, GasLeft: 0,
+				GasRefund: 0, Output: []byte{}},
+		},
+		"newer unsupported revision": {
+			revision: newestSupportedRevision + 1,
+			expectedResult: tosca.Result{Success: false, GasLeft: 0,
+				GasRefund: 0, Output: []byte{}},
+			expectedError: &tosca.ErrUnsupportedRevision{Revision: newestSupportedRevision + 1},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			params := tosca.Parameters{
+				Gas:      1000000,
+				Code:     test.code,
+				CodeHash: &test.codeHash,
+				BlockParameters: tosca.BlockParameters{
+					Revision: test.revision,
+				},
+			}
+
+			vm := &VM{
+				with_super_instructions: test.withSuperInstructions,
+				no_code_cache:           !test.withCodeCache,
+			}
+
+			result, err := vm.Run(params)
+			if err != test.expectedError && strings.Compare(err.Error(), test.expectedError.Error()) != 0 {
+				t.Fatalf("unexpected error: want %v but got %v", test.expectedError, err)
+			}
+			if result.Success != test.expectedResult.Success {
+				t.Errorf("unexpected result, want %v but got %v",
+					test.expectedResult.Success, result.Success)
+			}
+			if result.GasLeft != test.expectedResult.GasLeft {
+				t.Errorf("unexpected GasLeft, want %v but got %v",
+					test.expectedResult.GasLeft, result.GasLeft)
+			}
+			if result.GasRefund != test.expectedResult.GasRefund {
+				t.Errorf("unexpected GasRefund, want %v but got %v",
+					test.expectedResult.GasRefund, result.GasRefund)
+			}
+			if !bytes.Equal(result.Output, test.expectedResult.Output) {
+				t.Errorf("unexpected Output, want %v but got %v",
+					test.expectedResult.Output, result.Output)
+			}
+
+		})
+	}
+
+}

--- a/go/interpreter/lfvm/lfvm_test.go
+++ b/go/interpreter/lfvm/lfvm_test.go
@@ -66,7 +66,7 @@ func TestVm_Run(t *testing.T) {
 				ConversionConfig: ConversionConfig{
 					WithSuperInstructions: false,
 				},
-				NoShaCache: true,
+				WithShaCache: true,
 			})
 			if err != nil {
 				t.Fatalf("failed to create vm: %v", err)

--- a/go/interpreter/lfvm/lfvm_test.go
+++ b/go/interpreter/lfvm/lfvm_test.go
@@ -59,9 +59,14 @@ func TestVm_Run(t *testing.T) {
 				},
 			}
 
-			vm := &VM{
-				with_super_instructions: test.withSuperInstructions,
-				no_code_cache:           !test.withCodeCache,
+			vm, err := NewVm(Config{
+				ConversionConfig: ConversionConfig{
+					WithSuperInstructions: test.withSuperInstructions,
+				},
+				NoShaCache: !test.withCodeCache,
+			})
+			if err != nil {
+				t.Fatalf("failed to create vm: %v", err)
 			}
 
 			result, err := vm.Run(params)

--- a/go/interpreter/lfvm/lfvm_test.go
+++ b/go/interpreter/lfvm/lfvm_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/Fantom-foundation/Tosca/go/tosca"
+	"github.com/Fantom-foundation/Tosca/go/tosca/vm"
 )
 
 func TestVm_Run(t *testing.T) {
@@ -34,8 +35,8 @@ func TestVm_Run(t *testing.T) {
 				GasRefund: 0,
 				Output:    []byte{}},
 		},
-		"invalid code": {
-			code:     []byte{0x0C},
+		"invalid opcode": {
+			code:     []byte{byte(vm.INVALID)},
 			revision: tosca.R13_Cancun,
 			expectedResult: tosca.Result{
 				Success:   false,

--- a/go/interpreter/lfvm/lfvm_test.go
+++ b/go/interpreter/lfvm/lfvm_test.go
@@ -41,9 +41,7 @@ func TestVm_Run(t *testing.T) {
 				GasRefund: 0, Output: []byte{}},
 		},
 		"newer unsupported revision": {
-			revision: newestSupportedRevision + 1,
-			expectedResult: tosca.Result{Success: false, GasLeft: 0,
-				GasRefund: 0, Output: []byte{}},
+			revision:      newestSupportedRevision + 1,
 			expectedError: &tosca.ErrUnsupportedRevision{Revision: newestSupportedRevision + 1},
 		},
 	}
@@ -68,6 +66,9 @@ func TestVm_Run(t *testing.T) {
 			result, err := vm.Run(params)
 			if err != test.expectedError && strings.Compare(err.Error(), test.expectedError.Error()) != 0 {
 				t.Fatalf("unexpected error: want %v but got %v", test.expectedError, err)
+			}
+			if test.expectedError != nil {
+				return
 			}
 			if result.Success != test.expectedResult.Success {
 				t.Errorf("unexpected result, want %v but got %v",

--- a/go/interpreter/lfvm/opcode.go
+++ b/go/interpreter/lfvm/opcode.go
@@ -444,6 +444,9 @@ func (o OpCode) HasArgument() bool {
 		return true
 	case PUSH1_PUSH4_DUP3:
 		return true
+	case PC:
+		return true
 	}
+
 	return false
 }

--- a/go/interpreter/lfvm/opcode_test.go
+++ b/go/interpreter/lfvm/opcode_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package lfvm
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestOpcode_String(t *testing.T) {
+	tests := []struct {
+		name   string
+		opcode OpCode
+	}{
+		{"PUSH1", PUSH1},
+		{"PUSH32", PUSH32},
+		{"INVALID", INVALID},
+		{"0x00ad", OpCode(0xAD)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.opcode.String(); got != test.name {
+				t.Errorf("expected %s, got %s", test.name, got)
+			}
+		})
+	}
+}
+
+func TestOpcode_HasArgument(t *testing.T) {
+
+	haveArgument := []OpCode{DATA, JUMP_TO, PUSH2_JUMP, PUSH2_JUMPI, PUSH1_PUSH4_DUP3}
+	for i := PUSH1; i <= PUSH32; i++ {
+		haveArgument = append(haveArgument, i)
+	}
+
+	for i := 0; i < 256; i++ {
+		op := OpCode(i)
+		if op.HasArgument() != slices.Contains(haveArgument, op) {
+			t.Errorf("failed to recognized arguments for opcode %v", op)
+		}
+	}
+
+}

--- a/go/interpreter/lfvm/opcode_test.go
+++ b/go/interpreter/lfvm/opcode_test.go
@@ -11,16 +11,28 @@
 package lfvm
 
 import (
+	"math"
 	"regexp"
 	"slices"
 	"testing"
 )
 
-func TestOpcode_String(t *testing.T) {
+func TestOpcode_UnnamedOpcodes(t *testing.T) {
 	validName := regexp.MustCompile(`^0x00[0-9A-Fa-f]{2}$`)
-	for i := 0; i < 256; i++ {
+	for i := 0; i < math.MaxUint16; i++ {
 		op := OpCode(i)
 		if !validName.MatchString(op.String()) && op > NUM_OPCODES {
+			t.Errorf("Invalid print for op %v (%d)", op, i)
+		}
+	}
+}
+
+func TestOpcode_NamedOpcodes(t *testing.T) {
+	validName := regexp.MustCompile(`^0x00[0-9A-Fa-f]{2}$`)
+	for i := 0; i < math.MaxUint16; i++ {
+		op := OpCode(i)
+		// NUM_EXECUTABLE_OPCODES is a special case, it does not have a string name
+		if validName.MatchString(op.String()) && op < NUM_OPCODES && op != NUM_EXECUTABLE_OPCODES {
 			t.Errorf("Invalid print for op %v (%d)", op, i)
 		}
 	}

--- a/go/interpreter/lfvm/opcode_test.go
+++ b/go/interpreter/lfvm/opcode_test.go
@@ -11,27 +11,22 @@
 package lfvm
 
 import (
+	"fmt"
 	"slices"
 	"testing"
 )
 
 func TestOpcode_String(t *testing.T) {
-	tests := []struct {
-		name   string
-		opcode OpCode
-	}{
-		{"PUSH1", PUSH1},
-		{"PUSH32", PUSH32},
-		{"INVALID", INVALID},
-		{"0x00ad", OpCode(0xAD)},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if got := test.opcode.String(); got != test.name {
-				t.Errorf("expected %s, got %s", test.name, got)
-			}
-		})
+	for i := 0; i < 256; i++ {
+		op := OpCode(i)
+		want, found := op_to_string[op]
+		got := op.String()
+		if !found {
+			want = fmt.Sprintf("0x%04x", byte(op))
+		}
+		if got != want {
+			t.Errorf("expected %s, got %s", want, got)
+		}
 	}
 }
 
@@ -48,5 +43,4 @@ func TestOpcode_HasArgument(t *testing.T) {
 			t.Errorf("failed to recognized arguments for opcode %v", op)
 		}
 	}
-
 }

--- a/go/interpreter/lfvm/opcode_test.go
+++ b/go/interpreter/lfvm/opcode_test.go
@@ -14,20 +14,73 @@ import (
 	"fmt"
 	"slices"
 	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/tosca/vm"
 )
 
 func TestOpcode_String(t *testing.T) {
+
+	special_op_str := map[OpCode]string{
+		JUMP_TO: "JUMP_TO",
+
+		SWAP2_SWAP1_POP_JUMP:  "SWAP2_SWAP1_POP_JUMP",
+		SWAP1_POP_SWAP2_SWAP1: "SWAP1_POP_SWAP2_SWAP1",
+		POP_SWAP2_SWAP1_POP:   "POP_SWAP2_SWAP1_POP",
+		PUSH2_JUMP:            "PUSH2_JUMP",
+		PUSH2_JUMPI:           "PUSH2_JUMPI",
+		DUP2_MSTORE:           "DUP2_MSTORE",
+		DUP2_LT:               "DUP2_LT",
+
+		SWAP1_POP:   "SWAP1_POP",
+		POP_JUMP:    "POP_JUMP",
+		SWAP2_SWAP1: "SWAP2_SWAP1",
+		SWAP2_POP:   "SWAP2_POP",
+		PUSH1_PUSH1: "PUSH1_PUSH1",
+		PUSH1_ADD:   "PUSH1_ADD",
+		PUSH1_DUP1:  "PUSH1_DUP1",
+		POP_POP:     "POP_POP",
+		PUSH1_SHL:   "PUSH1_SHL",
+
+		ISZERO_PUSH2_JUMPI:        "ISZERO_PUSH2_JUMPI",
+		PUSH1_PUSH4_DUP3:          "PUSH1_PUSH4_DUP3",
+		AND_SWAP1_POP_SWAP2_SWAP1: "AND_SWAP1_POP_SWAP2_SWAP1",
+		PUSH1_PUSH1_PUSH1_SHL_SUB: "PUSH1_PUSH1_PUSH1_SHL_SUB",
+
+		DATA:    "DATA",
+		NOOP:    "NOOP",
+		INVALID: "INVALID",
+	}
+
 	for i := 0; i < 256; i++ {
 		op := OpCode(i)
-		want, found := op_to_string[op]
-		got := op.String()
-		if !found {
-			want = fmt.Sprintf("0x%04x", byte(op))
+		want := ""
+		found := false
+		toscaOp := findIndex(op_2_op, op)
+		if PUSH1 <= op && op <= PUSH32 {
+			toscaOp = int(vm.PUSH1) + int(op) - 2
 		}
+		if toscaOp < 256 && vm.IsValid(vm.OpCode(toscaOp)) {
+			want = vm.OpCode(toscaOp).String()
+		} else {
+			want, found = special_op_str[op]
+			if !found {
+				want = fmt.Sprintf("0x%04x", byte(op))
+			}
+		}
+		got := op.String()
 		if got != want {
 			t.Errorf("expected %s, got %s", want, got)
 		}
 	}
+}
+
+func findIndex(slice []OpCode, element OpCode) int {
+	for i, v := range slice {
+		if v == element {
+			return i
+		}
+	}
+	return 256
 }
 
 func TestOpcode_HasArgument(t *testing.T) {

--- a/go/interpreter/lfvm/opcode_test.go
+++ b/go/interpreter/lfvm/opcode_test.go
@@ -55,11 +55,12 @@ func TestOpcode_String(t *testing.T) {
 		op := OpCode(i)
 		want := ""
 		found := false
-		toscaOp := findIndex(op_2_op, op)
+		toscaOp := slices.Index(op_2_op, op)
 		if PUSH1 <= op && op <= PUSH32 {
 			toscaOp = int(vm.PUSH1) + int(op) - 2
 		}
-		if toscaOp < 256 && vm.IsValid(vm.OpCode(toscaOp)) {
+		// check for >= 0 because slices.Index returns -1 if not found
+		if toscaOp >= 0 && vm.IsValid(vm.OpCode(toscaOp)) {
 			want = vm.OpCode(toscaOp).String()
 		} else {
 			want, found = special_op_str[op]
@@ -74,18 +75,9 @@ func TestOpcode_String(t *testing.T) {
 	}
 }
 
-func findIndex(slice []OpCode, element OpCode) int {
-	for i, v := range slice {
-		if v == element {
-			return i
-		}
-	}
-	return 256
-}
-
 func TestOpcode_HasArgument(t *testing.T) {
 
-	haveArgument := []OpCode{DATA, JUMP_TO, PUSH2_JUMP, PUSH2_JUMPI, PUSH1_PUSH4_DUP3}
+	haveArgument := []OpCode{PC, DATA, JUMP_TO, PUSH2_JUMP, PUSH2_JUMPI, PUSH1_PUSH4_DUP3}
 	for i := PUSH1; i <= PUSH32; i++ {
 		haveArgument = append(haveArgument, i)
 	}

--- a/go/interpreter/lfvm/opcode_test.go
+++ b/go/interpreter/lfvm/opcode_test.go
@@ -11,66 +11,17 @@
 package lfvm
 
 import (
-	"fmt"
+	"regexp"
 	"slices"
 	"testing"
-
-	"github.com/Fantom-foundation/Tosca/go/tosca/vm"
 )
 
 func TestOpcode_String(t *testing.T) {
-
-	special_op_str := map[OpCode]string{
-		JUMP_TO: "JUMP_TO",
-
-		SWAP2_SWAP1_POP_JUMP:  "SWAP2_SWAP1_POP_JUMP",
-		SWAP1_POP_SWAP2_SWAP1: "SWAP1_POP_SWAP2_SWAP1",
-		POP_SWAP2_SWAP1_POP:   "POP_SWAP2_SWAP1_POP",
-		PUSH2_JUMP:            "PUSH2_JUMP",
-		PUSH2_JUMPI:           "PUSH2_JUMPI",
-		DUP2_MSTORE:           "DUP2_MSTORE",
-		DUP2_LT:               "DUP2_LT",
-
-		SWAP1_POP:   "SWAP1_POP",
-		POP_JUMP:    "POP_JUMP",
-		SWAP2_SWAP1: "SWAP2_SWAP1",
-		SWAP2_POP:   "SWAP2_POP",
-		PUSH1_PUSH1: "PUSH1_PUSH1",
-		PUSH1_ADD:   "PUSH1_ADD",
-		PUSH1_DUP1:  "PUSH1_DUP1",
-		POP_POP:     "POP_POP",
-		PUSH1_SHL:   "PUSH1_SHL",
-
-		ISZERO_PUSH2_JUMPI:        "ISZERO_PUSH2_JUMPI",
-		PUSH1_PUSH4_DUP3:          "PUSH1_PUSH4_DUP3",
-		AND_SWAP1_POP_SWAP2_SWAP1: "AND_SWAP1_POP_SWAP2_SWAP1",
-		PUSH1_PUSH1_PUSH1_SHL_SUB: "PUSH1_PUSH1_PUSH1_SHL_SUB",
-
-		DATA:    "DATA",
-		NOOP:    "NOOP",
-		INVALID: "INVALID",
-	}
-
+	validName := regexp.MustCompile(`^0x00[0-9A-Fa-f]{2}$`)
 	for i := 0; i < 256; i++ {
 		op := OpCode(i)
-		want := ""
-		found := false
-		toscaOp := slices.Index(op_2_op, op)
-		if PUSH1 <= op && op <= PUSH32 {
-			toscaOp = int(vm.PUSH1) + int(op) - 2
-		}
-		// check for >= 0 because slices.Index returns -1 if not found
-		if toscaOp >= 0 && vm.IsValid(vm.OpCode(toscaOp)) {
-			want = vm.OpCode(toscaOp).String()
-		} else {
-			want, found = special_op_str[op]
-			if !found {
-				want = fmt.Sprintf("0x%04x", byte(op))
-			}
-		}
-		got := op.String()
-		if got != want {
-			t.Errorf("expected %s, got %s", want, got)
+		if !validName.MatchString(op.String()) && op > NUM_OPCODES {
+			t.Errorf("Invalid print for op %v (%d)", op, i)
 		}
 	}
 }


### PR DESCRIPTION
This PR adds:
- tests for basic cases of `VM.Run` 
- tests for `HasArguments` function and `opcodes.Strings`