### PR TITLE
Fix Differential fuzzing error found in nightly builds

### DIFF
--- a/go/ct/evm_fuzz_test.go
+++ b/go/ct/evm_fuzz_test.go
@@ -72,10 +72,10 @@ func differentialFuzz(f *testing.F, testeeVm, referenceVm ct.Evm) {
 	f.Fuzz(func(t *testing.T, opCodes []byte, gas int64, revision byte, stackBytes []byte) {
 
 		state, err := corpusEntryToCtState(opCodes, gas, revision, stackBytes)
-		defer state.Release()
 		if err != nil {
 			t.Skip(err)
 		}
+		defer state.Release()
 
 		testeeResultState, err := testeeVm.StepN(state.Clone(), 1)
 		if err != nil {


### PR DESCRIPTION
Memory release was releasing a nil reference in scenarios that should be skipped. 