### PR TITLE
Fix github actions rust file syntax.

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -8,12 +8,12 @@ on:
   push:
     branches: [ main, evmrs ]
     paths:
-      - '**.rs''
+      - '**.rs'
       - 'Cargo.*'
   pull_request:
     branches: [ main ]
     paths:
-      - '**.rs''
+      - '**.rs'
       - 'Cargo.*'
 
 env:


### PR DESCRIPTION
The existing script contains a superfluous `'`.
