### PR TITLE
Add ExecutionTxContext and RunResult

### DIFF
--- a/rust/src/interpreter/mod.rs
+++ b/rust/src/interpreter/mod.rs
@@ -3,5 +3,9 @@
 mod code_state;
 mod gas;
 mod memory;
+mod run_result;
 mod stack;
+mod tx_context;
 mod utils;
+
+pub use crate::interpreter::{code_state::CodeState, memory::Memory, stack::Stack};

--- a/rust/src/interpreter/run_result.rs
+++ b/rust/src/interpreter/run_result.rs
@@ -1,0 +1,68 @@
+use std::mem;
+
+use evmc_vm::{Revision, StatusCode, StepResult, StepStatusCode, Uint256};
+
+use crate::{
+    interpreter::{CodeState, Memory, Stack},
+    types::u256,
+};
+
+#[derive(Debug)]
+pub struct RunResult<'a> {
+    pub step_status_code: StepStatusCode,
+    pub status_code: StatusCode,
+    pub revision: Revision,
+    pub code_state: CodeState<'a>,
+    pub gas_left: u64,
+    pub gas_refund: i64,
+    pub output: Option<Vec<u8>>,
+    pub stack: Stack,
+    pub memory: Memory,
+    pub last_call_return_data: Option<Vec<u8>>,
+}
+
+impl<'a> From<StatusCode> for RunResult<'a> {
+    fn from(status_code: StatusCode) -> Self {
+        let step_status_code = match status_code {
+            StatusCode::EVMC_SUCCESS => StepStatusCode::EVMC_STEP_RUNNING,
+            StatusCode::EVMC_REVERT => StepStatusCode::EVMC_STEP_REVERTED,
+            _ => StepStatusCode::EVMC_STEP_FAILED,
+        };
+        Self {
+            step_status_code,
+            status_code,
+            revision: Revision::EVMC_FRONTIER,
+            code_state: CodeState::new(&[], 0),
+            gas_left: 0,
+            gas_refund: 0,
+            output: None,
+            stack: Stack::new(Vec::new()),
+            memory: Memory::new(Vec::new()),
+            last_call_return_data: None,
+        }
+    }
+}
+
+impl<'a> From<RunResult<'a>> for StepResult {
+    fn from(value: RunResult) -> Self {
+        let stack = value.stack.into_inner();
+        let stack = unsafe {
+            // SAFETY
+            // u256 is a newtype of Uint256 with repr(transparent) which guarantees the same memory
+            // layout.
+            mem::transmute::<Vec<u256>, Vec<Uint256>>(stack)
+        };
+        StepResult::new(
+            value.step_status_code,
+            value.status_code,
+            value.revision,
+            value.code_state.pc() as u64,
+            value.gas_left as i64,
+            value.gas_refund,
+            value.output,
+            stack,
+            value.memory.into_inner(),
+            value.last_call_return_data,
+        )
+    }
+}

--- a/rust/src/interpreter/stack.rs
+++ b/rust/src/interpreter/stack.rs
@@ -6,11 +6,7 @@ use crate::types::u256;
 pub struct Stack(Vec<u256>);
 
 impl Stack {
-    pub fn new() -> Self {
-        Self(Vec::new())
-    }
-
-    pub fn from_vec(inner: Vec<u256>) -> Self {
+    pub fn new(inner: Vec<u256>) -> Self {
         Self(inner)
     }
 
@@ -72,32 +68,32 @@ mod tests {
 
     #[test]
     fn push() {
-        let mut stack = Stack::new();
+        let mut stack = Stack::new(Vec::new());
         assert_eq!(stack.push(u256::MAX), Ok(()));
         assert_eq!(stack.into_inner().pop(), Some(u256::MAX));
 
-        let mut stack = Stack::from_vec(vec![u256::ZERO; 1024]);
+        let mut stack = Stack::new(vec![u256::ZERO; 1024]);
         assert_eq!(stack.push(u256::ZERO), Err(StatusCode::EVMC_STACK_OVERFLOW));
     }
 
     #[test]
     fn pop() {
-        let mut stack = Stack::from_vec(vec![u256::MAX]);
+        let mut stack = Stack::new(vec![u256::MAX]);
         assert_eq!(stack.pop::<1>(), Ok([u256::MAX]));
 
-        let mut stack = Stack::from_vec(vec![]);
+        let mut stack = Stack::new(vec![]);
         assert_eq!(stack.pop::<1>(), Err(StatusCode::EVMC_STACK_UNDERFLOW));
 
-        let mut stack = Stack::from_vec(vec![u256::MAX, u256::MAX]);
+        let mut stack = Stack::new(vec![u256::MAX, u256::MAX]);
         assert_eq!(stack.pop::<2>(), Ok([u256::MAX, u256::MAX]));
 
-        let mut stack = Stack::from_vec(vec![u256::MAX]);
+        let mut stack = Stack::new(vec![u256::MAX]);
         assert_eq!(stack.pop::<2>(), Err(StatusCode::EVMC_STACK_UNDERFLOW));
     }
 
     #[test]
     fn nth() {
-        let stack = Stack::from_vec(vec![u256::MAX, u256::ZERO]);
+        let stack = Stack::new(vec![u256::MAX, u256::ZERO]);
         assert_eq!(stack.nth(0), Ok(u256::ZERO));
         assert_eq!(stack.nth(1), Ok(u256::MAX));
         assert_eq!(stack.nth(2), Err(StatusCode::EVMC_STACK_UNDERFLOW));
@@ -105,7 +101,7 @@ mod tests {
 
     #[test]
     fn swap_with_top() {
-        let mut stack = Stack::from_vec(vec![u256::MAX, u256::ZERO]);
+        let mut stack = Stack::new(vec![u256::MAX, u256::ZERO]);
         assert_eq!(stack.swap_with_top(0), Ok(()));
         assert_eq!(stack.swap_with_top(1), Ok(()));
         assert_eq!(

--- a/rust/src/interpreter/tx_context.rs
+++ b/rust/src/interpreter/tx_context.rs
@@ -1,0 +1,77 @@
+//! This module holds the [ExecutionTxContext].
+//! This type is the same as [evmc_vm::ExecutionTxContext] except that the pointer and length fields
+//! are converted to slices.
+//!
+//! Ideally this would be done already in [evmc_vm].
+use std::slice;
+
+use evmc_vm::{
+    ffi::{evmc_tx_context, evmc_tx_initcode},
+    Address, Uint256,
+};
+
+/// EVMC transaction context.
+#[derive(Debug, Copy, Clone, Hash, PartialEq)]
+pub struct ExecutionTxContext<'a> {
+    /// The transaction gas price.
+    pub tx_gas_price: Uint256,
+    /// The transaction origin account.
+    pub tx_origin: Address,
+    /// The miner of the block.
+    pub block_coinbase: Address,
+    /// The block number.
+    pub block_number: i64,
+    /// The block timestamp.
+    pub block_timestamp: i64,
+    /// The block gas limit.
+    pub block_gas_limit: i64,
+    /// The block previous RANDAO (EIP-4399).
+    pub block_prev_randao: Uint256,
+    /// The blockchain's ChainID.
+    pub chain_id: Uint256,
+    /// The block base fee per gas (EIP-1559, EIP-3198).
+    pub block_base_fee: Uint256,
+    /// The blob base fee (EIP-7516).
+    pub blob_base_fee: Uint256,
+    /// The array of blob hashes (EIP-4844).
+    pub blob_hashes: &'a [Uint256],
+    /// The array of transaction initcodes (TXCREATE).
+    pub initcodes: &'a [evmc_tx_initcode],
+}
+
+impl<'a> From<&'a evmc_vm::ExecutionTxContext> for ExecutionTxContext<'a> {
+    fn from(context: &'a evmc_tx_context) -> Self {
+        let blob_hashes = if context.blob_hashes.is_null() || context.blob_hashes_count == 0 {
+            &[]
+        } else {
+            unsafe {
+                // SAFETY:
+                // `context.blob_hashes` is not null an `context.blob_hashes_count > 0`
+                slice::from_raw_parts(context.blob_hashes, context.blob_hashes_count)
+            }
+        };
+        let initcodes = if context.initcodes.is_null() || context.initcodes_count == 0 {
+            &[]
+        } else {
+            unsafe {
+                // SAFETY:
+                // `context.initcodes` is not null an `context.initcodes_count > 0`
+                slice::from_raw_parts(context.initcodes, context.initcodes_count)
+            }
+        };
+        ExecutionTxContext {
+            tx_gas_price: context.tx_gas_price,
+            tx_origin: context.tx_origin,
+            block_coinbase: context.block_coinbase,
+            block_number: context.block_number,
+            block_timestamp: context.block_timestamp,
+            block_gas_limit: context.block_gas_limit,
+            block_prev_randao: context.block_prev_randao,
+            chain_id: context.chain_id,
+            block_base_fee: context.block_base_fee,
+            blob_base_fee: context.blob_base_fee,
+            blob_hashes,
+            initcodes,
+        }
+    }
+}


### PR DESCRIPTION
- add `ExecutionTxContext` (like `evmc::ExecutionTxContext` but with pointer and length fields converted to slices)
- add `RunResult`