### PR TITLE
LFVM: add free standing keccak

### DIFF
--- a/go/interpreter/lfvm/keccak.go
+++ b/go/interpreter/lfvm/keccak.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package lfvm
+
+/*
+#include "keccak.h"
+*/
+import "C"
+
+import (
+	"sync"
+	"unsafe"
+
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+	"golang.org/x/crypto/sha3"
+)
+
+func Keccak256(data []byte) tosca.Hash {
+	return keccak256_C(data)
+}
+
+func Keccak256ForKey(key tosca.Key) tosca.Hash {
+	return keccak256_C_Key(key)
+}
+
+var keccakHasherPool = sync.Pool{New: func() any { return sha3.NewLegacyKeccak256() }}
+
+func keccak256_Go(data []byte) tosca.Hash {
+	hasher := keccakHasherPool.Get().(keccakHasher)
+	hasher.Reset()
+	hasher.Write(data)
+	var res tosca.Hash
+	hasher.Read(res[:])
+	keccakHasherPool.Put(hasher)
+	return res
+}
+
+type keccakHasher interface {
+	Reset()
+	Write(in []byte) (int, error)
+	Read(out []byte) (int, error)
+}
+
+var emptyKeccak256Hash = keccak256_Go([]byte{})
+
+func keccak256_C(data []byte) tosca.Hash {
+	if len(data) == 0 {
+		return emptyKeccak256Hash
+	}
+	res := C.tosca_lfvm_keccak256(unsafe.Pointer(&data[0]), C.size_t(len(data)))
+	return tosca.Hash(res)
+}
+
+func keccak256_C_Key(key tosca.Key) tosca.Hash {
+	// The address is passed as 4x 64-bit integer values through the stack to
+	// avoid the need of allocating heap memory for the key.
+	return tosca.Hash(C.tosca_lfvm_keccak256_32byte(
+		C.uint64_t(
+			uint64(key[7])<<56|uint64(key[6])<<48|uint64(key[5])<<40|uint64(key[4])<<32|
+				uint64(key[3])<<24|uint64(key[2])<<16|uint64(key[1])<<8|uint64(key[0])<<0),
+		C.uint64_t(
+			uint64(key[15])<<56|uint64(key[14])<<48|uint64(key[13])<<40|uint64(key[12])<<32|
+				uint64(key[11])<<24|uint64(key[10])<<16|uint64(key[9])<<8|uint64(key[8])<<0),
+		C.uint64_t(
+			uint64(key[23])<<56|uint64(key[22])<<48|uint64(key[21])<<40|uint64(key[20])<<32|
+				uint64(key[19])<<24|uint64(key[18])<<16|uint64(key[17])<<8|uint64(key[16])<<0),
+		C.uint64_t(
+			uint64(key[31])<<56|uint64(key[30])<<48|uint64(key[29])<<40|uint64(key[28])<<32|
+				uint64(key[27])<<24|uint64(key[26])<<16|uint64(key[25])<<8|uint64(key[24])<<0),
+	))
+}

--- a/go/interpreter/lfvm/keccak.h
+++ b/go/interpreter/lfvm/keccak.h
@@ -1,0 +1,451 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+// This header file is based on the chfast/ethash project:
+//
+//  source:
+//  https://github.com/chfast/ethash/tree/8e18c3d715d3d759f44ac10f70f9c93b227e18c2
+//  License: Apache-2.0 license
+//  (https://github.com/chfast/ethash/blob/8e18c3d715d3d759f44ac10f70f9c93b227e18c2/LICENSE)
+//
+// This file merges extracts of codes from the project and adds Tosca specific
+// modifications to facilitate the adaption in the Tosca project.
+//
+// ethash: C/C++ implementation of Ethash, the Ethereum Proof of Work algorithm.
+// Copyright 2018 Pawel Bylica.
+// SPDX-License-Identifier: Apache-2.0
+
+// Provide __has_attribute macro if not defined.
+#ifndef __has_attribute
+#define __has_attribute(name) 0
+#endif
+
+// [[always_inline]]
+#if defined(_MSC_VER)
+#define ALWAYS_INLINE __forceinline
+#elif __has_attribute(always_inline)
+#define ALWAYS_INLINE __attribute__((always_inline))
+#else
+#define ALWAYS_INLINE
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef __cplusplus
+#define noexcept // Ignore noexcept in C code.
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+union ethash_hash256 {
+  uint64_t word64s[4];
+  uint32_t word32s[8];
+  uint8_t bytes[32];
+  char str[32];
+};
+
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define to_le64(X) __builtin_bswap64(X)
+#else
+#define to_le64(X) X
+#endif
+
+/// Loads 64-bit integer from given memory location as little-endian number.
+static inline ALWAYS_INLINE uint64_t load_le(const uint8_t *data) {
+  /* memcpy is the best way of expressing the intention. Every compiler will
+     optimize is to single load instruction if the target architecture
+     supports unaligned memory access (GCC and clang even in O0).
+     This is great trick because we are violating C/C++ memory alignment
+     restrictions with no performance penalty. */
+  uint64_t word;
+  __builtin_memcpy(&word, data, sizeof(word));
+  return to_le64(word);
+}
+
+/// Rotates the bits of x left by the count value specified by s.
+/// The s must be in range <0, 64> exclusively, otherwise the result is
+/// undefined.
+static inline uint64_t rol(uint64_t x, unsigned s) {
+  return (x << s) | (x >> (64 - s));
+}
+
+static const uint64_t round_constants[24] = { //
+    0x0000000000000001, 0x0000000000008082, 0x800000000000808a,
+    0x8000000080008000, 0x000000000000808b, 0x0000000080000001,
+    0x8000000080008081, 0x8000000000008009, 0x000000000000008a,
+    0x0000000000000088, 0x0000000080008009, 0x000000008000000a,
+    0x000000008000808b, 0x800000000000008b, 0x8000000000008089,
+    0x8000000000008003, 0x8000000000008002, 0x8000000000000080,
+    0x000000000000800a, 0x800000008000000a, 0x8000000080008081,
+    0x8000000000008080, 0x0000000080000001, 0x8000000080008008};
+
+/// The Keccak-f[1600] function.
+///
+/// The implementation of the Keccak-f function with 1600-bit width of the
+/// permutation (b). The size of the state is also 1600 bit what gives 25 64-bit
+/// words.
+///
+/// @param state  The state of 25 64-bit words on which the permutation is to be
+/// performed.
+///
+/// The implementation based on:
+/// - "simple" implementation by Ronny Van Keer, included in "Reference and
+/// optimized code in C",
+///   https://keccak.team/archives.html, CC0-1.0 / Public Domain.
+static inline ALWAYS_INLINE void
+keccakf1600_implementation(uint64_t state[25]) {
+  uint64_t Aba, Abe, Abi, Abo, Abu;
+  uint64_t Aga, Age, Agi, Ago, Agu;
+  uint64_t Aka, Ake, Aki, Ako, Aku;
+  uint64_t Ama, Ame, Ami, Amo, Amu;
+  uint64_t Asa, Ase, Asi, Aso, Asu;
+
+  uint64_t Eba, Ebe, Ebi, Ebo, Ebu;
+  uint64_t Ega, Ege, Egi, Ego, Egu;
+  uint64_t Eka, Eke, Eki, Eko, Eku;
+  uint64_t Ema, Eme, Emi, Emo, Emu;
+  uint64_t Esa, Ese, Esi, Eso, Esu;
+
+  uint64_t Ba, Be, Bi, Bo, Bu;
+
+  uint64_t Da, De, Di, Do, Du;
+
+  Aba = state[0];
+  Abe = state[1];
+  Abi = state[2];
+  Abo = state[3];
+  Abu = state[4];
+  Aga = state[5];
+  Age = state[6];
+  Agi = state[7];
+  Ago = state[8];
+  Agu = state[9];
+  Aka = state[10];
+  Ake = state[11];
+  Aki = state[12];
+  Ako = state[13];
+  Aku = state[14];
+  Ama = state[15];
+  Ame = state[16];
+  Ami = state[17];
+  Amo = state[18];
+  Amu = state[19];
+  Asa = state[20];
+  Ase = state[21];
+  Asi = state[22];
+  Aso = state[23];
+  Asu = state[24];
+
+  for (size_t n = 0; n < 24; n += 2) {
+    // Round (n + 0): Axx -> Exx
+
+    Ba = Aba ^ Aga ^ Aka ^ Ama ^ Asa;
+    Be = Abe ^ Age ^ Ake ^ Ame ^ Ase;
+    Bi = Abi ^ Agi ^ Aki ^ Ami ^ Asi;
+    Bo = Abo ^ Ago ^ Ako ^ Amo ^ Aso;
+    Bu = Abu ^ Agu ^ Aku ^ Amu ^ Asu;
+
+    Da = Bu ^ rol(Be, 1);
+    De = Ba ^ rol(Bi, 1);
+    Di = Be ^ rol(Bo, 1);
+    Do = Bi ^ rol(Bu, 1);
+    Du = Bo ^ rol(Ba, 1);
+
+    Ba = Aba ^ Da;
+    Be = rol(Age ^ De, 44);
+    Bi = rol(Aki ^ Di, 43);
+    Bo = rol(Amo ^ Do, 21);
+    Bu = rol(Asu ^ Du, 14);
+    Eba = Ba ^ (~Be & Bi) ^ round_constants[n];
+    Ebe = Be ^ (~Bi & Bo);
+    Ebi = Bi ^ (~Bo & Bu);
+    Ebo = Bo ^ (~Bu & Ba);
+    Ebu = Bu ^ (~Ba & Be);
+
+    Ba = rol(Abo ^ Do, 28);
+    Be = rol(Agu ^ Du, 20);
+    Bi = rol(Aka ^ Da, 3);
+    Bo = rol(Ame ^ De, 45);
+    Bu = rol(Asi ^ Di, 61);
+    Ega = Ba ^ (~Be & Bi);
+    Ege = Be ^ (~Bi & Bo);
+    Egi = Bi ^ (~Bo & Bu);
+    Ego = Bo ^ (~Bu & Ba);
+    Egu = Bu ^ (~Ba & Be);
+
+    Ba = rol(Abe ^ De, 1);
+    Be = rol(Agi ^ Di, 6);
+    Bi = rol(Ako ^ Do, 25);
+    Bo = rol(Amu ^ Du, 8);
+    Bu = rol(Asa ^ Da, 18);
+    Eka = Ba ^ (~Be & Bi);
+    Eke = Be ^ (~Bi & Bo);
+    Eki = Bi ^ (~Bo & Bu);
+    Eko = Bo ^ (~Bu & Ba);
+    Eku = Bu ^ (~Ba & Be);
+
+    Ba = rol(Abu ^ Du, 27);
+    Be = rol(Aga ^ Da, 36);
+    Bi = rol(Ake ^ De, 10);
+    Bo = rol(Ami ^ Di, 15);
+    Bu = rol(Aso ^ Do, 56);
+    Ema = Ba ^ (~Be & Bi);
+    Eme = Be ^ (~Bi & Bo);
+    Emi = Bi ^ (~Bo & Bu);
+    Emo = Bo ^ (~Bu & Ba);
+    Emu = Bu ^ (~Ba & Be);
+
+    Ba = rol(Abi ^ Di, 62);
+    Be = rol(Ago ^ Do, 55);
+    Bi = rol(Aku ^ Du, 39);
+    Bo = rol(Ama ^ Da, 41);
+    Bu = rol(Ase ^ De, 2);
+    Esa = Ba ^ (~Be & Bi);
+    Ese = Be ^ (~Bi & Bo);
+    Esi = Bi ^ (~Bo & Bu);
+    Eso = Bo ^ (~Bu & Ba);
+    Esu = Bu ^ (~Ba & Be);
+
+    // Round (n + 1): Exx -> Axx
+
+    Ba = Eba ^ Ega ^ Eka ^ Ema ^ Esa;
+    Be = Ebe ^ Ege ^ Eke ^ Eme ^ Ese;
+    Bi = Ebi ^ Egi ^ Eki ^ Emi ^ Esi;
+    Bo = Ebo ^ Ego ^ Eko ^ Emo ^ Eso;
+    Bu = Ebu ^ Egu ^ Eku ^ Emu ^ Esu;
+
+    Da = Bu ^ rol(Be, 1);
+    De = Ba ^ rol(Bi, 1);
+    Di = Be ^ rol(Bo, 1);
+    Do = Bi ^ rol(Bu, 1);
+    Du = Bo ^ rol(Ba, 1);
+
+    Ba = Eba ^ Da;
+    Be = rol(Ege ^ De, 44);
+    Bi = rol(Eki ^ Di, 43);
+    Bo = rol(Emo ^ Do, 21);
+    Bu = rol(Esu ^ Du, 14);
+    Aba = Ba ^ (~Be & Bi) ^ round_constants[n + 1];
+    Abe = Be ^ (~Bi & Bo);
+    Abi = Bi ^ (~Bo & Bu);
+    Abo = Bo ^ (~Bu & Ba);
+    Abu = Bu ^ (~Ba & Be);
+
+    Ba = rol(Ebo ^ Do, 28);
+    Be = rol(Egu ^ Du, 20);
+    Bi = rol(Eka ^ Da, 3);
+    Bo = rol(Eme ^ De, 45);
+    Bu = rol(Esi ^ Di, 61);
+    Aga = Ba ^ (~Be & Bi);
+    Age = Be ^ (~Bi & Bo);
+    Agi = Bi ^ (~Bo & Bu);
+    Ago = Bo ^ (~Bu & Ba);
+    Agu = Bu ^ (~Ba & Be);
+
+    Ba = rol(Ebe ^ De, 1);
+    Be = rol(Egi ^ Di, 6);
+    Bi = rol(Eko ^ Do, 25);
+    Bo = rol(Emu ^ Du, 8);
+    Bu = rol(Esa ^ Da, 18);
+    Aka = Ba ^ (~Be & Bi);
+    Ake = Be ^ (~Bi & Bo);
+    Aki = Bi ^ (~Bo & Bu);
+    Ako = Bo ^ (~Bu & Ba);
+    Aku = Bu ^ (~Ba & Be);
+
+    Ba = rol(Ebu ^ Du, 27);
+    Be = rol(Ega ^ Da, 36);
+    Bi = rol(Eke ^ De, 10);
+    Bo = rol(Emi ^ Di, 15);
+    Bu = rol(Eso ^ Do, 56);
+    Ama = Ba ^ (~Be & Bi);
+    Ame = Be ^ (~Bi & Bo);
+    Ami = Bi ^ (~Bo & Bu);
+    Amo = Bo ^ (~Bu & Ba);
+    Amu = Bu ^ (~Ba & Be);
+
+    Ba = rol(Ebi ^ Di, 62);
+    Be = rol(Ego ^ Do, 55);
+    Bi = rol(Eku ^ Du, 39);
+    Bo = rol(Ema ^ Da, 41);
+    Bu = rol(Ese ^ De, 2);
+    Asa = Ba ^ (~Be & Bi);
+    Ase = Be ^ (~Bi & Bo);
+    Asi = Bi ^ (~Bo & Bu);
+    Aso = Bo ^ (~Bu & Ba);
+    Asu = Bu ^ (~Ba & Be);
+  }
+
+  state[0] = Aba;
+  state[1] = Abe;
+  state[2] = Abi;
+  state[3] = Abo;
+  state[4] = Abu;
+  state[5] = Aga;
+  state[6] = Age;
+  state[7] = Agi;
+  state[8] = Ago;
+  state[9] = Agu;
+  state[10] = Aka;
+  state[11] = Ake;
+  state[12] = Aki;
+  state[13] = Ako;
+  state[14] = Aku;
+  state[15] = Ama;
+  state[16] = Ame;
+  state[17] = Ami;
+  state[18] = Amo;
+  state[19] = Amu;
+  state[20] = Asa;
+  state[21] = Ase;
+  state[22] = Asi;
+  state[23] = Aso;
+  state[24] = Asu;
+}
+
+static void keccakf1600_generic(uint64_t state[25]) {
+  keccakf1600_implementation(state);
+}
+
+/// The pointer to the best Keccak-f[1600] function implementation,
+/// selected during runtime initialization.
+static void (*keccakf1600_best)(uint64_t[25]) = keccakf1600_generic;
+
+#if !defined(_MSC_VER) && defined(__x86_64__) && __has_attribute(target)
+__attribute__((target("bmi,bmi2"))) static void
+keccakf1600_bmi(uint64_t state[25]) {
+  keccakf1600_implementation(state);
+}
+
+__attribute__((constructor)) static void
+select_keccakf1600_implementation(void) {
+  // Init CPU information.
+  // This is needed on macOS because of the bug:
+  // https://bugs.llvm.org/show_bug.cgi?id=48459.
+  __builtin_cpu_init();
+
+  // Check if both BMI and BMI2 are supported. Some CPUs like Intel E5-2697 v2
+  // incorrectly report BMI2 but not BMI being available.
+  if (__builtin_cpu_supports("bmi") && __builtin_cpu_supports("bmi2"))
+    keccakf1600_best = keccakf1600_bmi;
+}
+#endif
+
+static inline ALWAYS_INLINE void keccak(uint64_t *out, size_t bits,
+                                        const uint8_t *data, size_t size) {
+  static const size_t word_size = sizeof(uint64_t);
+  const size_t hash_size = bits / 8;
+  const size_t block_size = (1600 - bits * 2) / 8;
+
+  size_t i;
+  uint64_t *state_iter;
+  uint64_t last_word = 0;
+  uint8_t *last_word_iter = (uint8_t *)&last_word;
+
+  uint64_t state[25] = {0};
+
+  while (size >= block_size) {
+    for (i = 0; i < (block_size / word_size); ++i) {
+      state[i] ^= load_le(data);
+      data += word_size;
+    }
+
+    keccakf1600_best(state);
+
+    size -= block_size;
+  }
+
+  state_iter = state;
+
+  while (size >= word_size) {
+    *state_iter ^= load_le(data);
+    ++state_iter;
+    data += word_size;
+    size -= word_size;
+  }
+
+  while (size > 0) {
+    *last_word_iter = *data;
+    ++last_word_iter;
+    ++data;
+    --size;
+  }
+  *last_word_iter = 0x01;
+  *state_iter ^= to_le64(last_word);
+
+  state[(block_size / word_size) - 1] ^= 0x8000000000000000;
+
+  keccakf1600_best(state);
+
+  for (i = 0; i < (hash_size / word_size); ++i)
+    out[i] = to_le64(state[i]);
+}
+
+union ethash_hash256 tosca_lfvm_keccak256(const void *in,
+                                          size_t size) noexcept {
+  union ethash_hash256 hash;
+  keccak(hash.word64s, 256, (const uint8_t *)in, size);
+  return hash;
+}
+
+static inline ALWAYS_INLINE union ethash_hash256 keccak_32(const uint64_t a,
+                                                           const uint64_t b,
+                                                           const uint64_t c,
+                                                           const uint64_t d) {
+  static const size_t word_size = sizeof(uint64_t);
+  const size_t hash_size = 256 / 8;
+  const size_t block_size = (1600 - 256 * 2) / 8;
+
+  size_t i;
+  uint64_t *state_iter;
+  uint64_t last_word = 0;
+  uint8_t *last_word_iter = (uint8_t *)&last_word;
+
+  uint64_t state[25] = {0};
+
+  state_iter = state;
+
+  *state_iter = a;
+  ++state_iter;
+  *state_iter = b;
+  ++state_iter;
+  *state_iter = c;
+  ++state_iter;
+  *state_iter = d;
+  ++state_iter;
+
+  last_word = 0x01;
+  *state_iter ^= to_le64(last_word);
+
+  state[(block_size / word_size) - 1] ^= 0x8000000000000000;
+
+  keccakf1600_best(state);
+
+  union ethash_hash256 res;
+  res.word64s[0] = state[0];
+  res.word64s[1] = state[1];
+  res.word64s[2] = state[2];
+  res.word64s[3] = state[3];
+  return res;
+}
+
+union ethash_hash256 tosca_lfvm_keccak256_32byte(const uint64_t a,
+                                                 const uint64_t b,
+                                                 const uint64_t c,
+                                                 const uint64_t d) noexcept {
+  return keccak_32(a, b, c, d);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/go/interpreter/lfvm/keccak_test.go
+++ b/go/interpreter/lfvm/keccak_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package lfvm
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+)
+
+func TestKeccakC_ProducesSameHashAsGo(t *testing.T) {
+	tests := [][]byte{
+		nil,
+		{},
+		{1, 2, 3},
+		{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		make([]byte, 128),
+		make([]byte, 1024),
+	}
+	for _, test := range tests {
+		want := keccak256_Go(test)
+		got := keccak256_C(test)
+		if want != got {
+			t.Errorf("unexpected hash for %v, wanted %v, got %v", test, want, got)
+		}
+	}
+}
+
+func TestKeccakC_KeySpecializationProducesSameHashAsGenericVersion(t *testing.T) {
+	tests := []tosca.Key{
+		{},
+		{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2},
+	}
+
+	// Test each individual bit.
+	for i := 0; i < 32*8; i++ {
+		key := tosca.Key{}
+		key[i/8] = 1 << i % 8
+		tests = append(tests, key)
+	}
+
+	// Add some random inputs as well.
+	r := rand.New(rand.NewSource(99))
+	for i := 0; i < 10; i++ {
+		key := tosca.Key{}
+		r.Read(key[:])
+		tests = append(tests, key)
+	}
+
+	t.Run("keccak256_C_Key", func(t *testing.T) {
+		t.Parallel()
+		for _, test := range tests {
+			want := keccak256_Go(test[:])
+			got := keccak256_C_Key(test)
+			if want != got {
+				t.Errorf("unexpected hash for %v, wanted %v, got %v", test, want, got)
+			}
+		}
+	})
+
+	t.Run("Keccak256ForKey", func(t *testing.T) {
+		t.Parallel()
+		for _, test := range tests {
+			want := keccak256_Go(test[:])
+			got := Keccak256ForKey(test)
+			if want != got {
+				t.Errorf("unexpected hash for %v, wanted %v, got %v", test, want, got)
+			}
+		}
+	})
+}
+
+func benchmark(b *testing.B, hasher func([]byte)) {
+	lengths := []int{1, 8, 32}
+	for i := 64; i < 1<<19; i <<= 2 {
+		lengths = append(lengths, i)
+	}
+	for _, i := range lengths {
+		b.Run(fmt.Sprintf("size=%d", i), func(b *testing.B) {
+			data := make([]byte, i)
+			for i := 0; i < b.N; i++ {
+				hasher(data)
+			}
+		})
+	}
+}
+
+func BenchmarkKeccakGo(b *testing.B) {
+	benchmark(b, func(data []byte) {
+		keccak256_Go(data)
+	})
+}
+
+func BenchmarkKeccakC(b *testing.B) {
+	benchmark(b, func(data []byte) {
+		keccak256_C(data)
+	})
+}
+
+func BenchmarkKeccakGoKeyGeneric(b *testing.B) {
+	key := tosca.Key{}
+	for i := 0; i < b.N; i++ {
+		keccak256_Go(key[:])
+	}
+}
+
+func BenchmarkKeccakCKeyGeneric(b *testing.B) {
+	key := tosca.Key{}
+	for i := 0; i < b.N; i++ {
+		keccak256_C(key[:])
+	}
+}
+
+func BenchmarkKeccakCKeySpecialized(b *testing.B) {
+	key := tosca.Key{}
+	for i := 0; i < b.N; i++ {
+		keccak256_C_Key(key)
+	}
+}


### PR DESCRIPTION
This PR solves #685
This PR adds a free standing keccack hashing function, with implementations in C and Go, comparing them in benchamarks. The results of these benchmarks are presented here:
```
Running tool: go test -benchmem -run=^$ -coverprofile=/tmp/vscode-goIfEKT8/go-code-cover -bench . github.com/Fantom-foundation/Tosca/go/interpreter/lfvm -cover -count=1

goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Tosca/go/interpreter/lfvm
cpu: AMD Ryzen 7 PRO 7840U w/ Radeon 780M Graphics  
BenchmarkConvertLongExampleCode-16        	   16884	     72424 ns/op	   98416 B/op	       2 allocs/op
BenchmarkConversionCacheLookupSpeed-16    	61557667	        17.22 ns/op	       0 B/op	       0 allocs/op
BenchmarkConversionCacheUpdateSpeed-16    	 4395886	       229.8 ns/op	     123 B/op	       1 allocs/op
BenchmarkLfvmStackToCtStack-16            	  788272	      1513 ns/op	       0 B/op	       0 allocs/op
BenchmarkFib10-16                         	    7497	    164373 ns/op	      38 B/op	       1 allocs/op
BenchmarkFib10_SI-16                      	   12506	     95819 ns/op	      36 B/op	       1 allocs/op
BenchmarkIsWriteInstruction-16            	1000000000	         1.214 ns/op	       0 B/op	       0 allocs/op
BenchmarkKeccakGo/size=1-16               	 3087798	       386.1 ns/op	      32 B/op	       1 allocs/op
BenchmarkKeccakGo/size=8-16               	 3051104	       397.3 ns/op	      32 B/op	       1 allocs/op
BenchmarkKeccakGo/size=32-16              	 3084180	       390.1 ns/op	      32 B/op	       1 allocs/op
BenchmarkKeccakGo/size=64-16              	 3334960	       371.5 ns/op	      32 B/op	       1 allocs/op
BenchmarkKeccakGo/size=256-16             	 1861438	       637.7 ns/op	      32 B/op	       1 allocs/op
BenchmarkKeccakGo/size=1024-16            	  522801	      2240 ns/op	      32 B/op	       1 allocs/op
BenchmarkKeccakGo/size=4096-16            	  144151	      8355 ns/op	      32 B/op	       1 allocs/op
BenchmarkKeccakGo/size=16384-16           	   37585	     32506 ns/op	      32 B/op	       1 allocs/op
BenchmarkKeccakGo/size=65536-16           	    9782	    127715 ns/op	      38 B/op	       1 allocs/op
BenchmarkKeccakGo/size=262144-16          	    2370	    532860 ns/op	     143 B/op	       1 allocs/op
BenchmarkKeccakC/size=1-16                	 4364023	       276.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkKeccakC/size=8-16                	 4328673	       275.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkKeccakC/size=32-16               	 4291477	       277.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkKeccakC/size=64-16               	 4081466	       309.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkKeccakC/size=256-16              	 2341485	       529.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkKeccakC/size=1024-16             	  647142	      1847 ns/op	       0 B/op	       0 allocs/op
BenchmarkKeccakC/size=4096-16             	  177854	      6937 ns/op	       0 B/op	       0 allocs/op
BenchmarkKeccakC/size=16384-16            	   44540	     27092 ns/op	       0 B/op	       0 allocs/op
BenchmarkKeccakC/size=65536-16            	   10000	    108213 ns/op	       6 B/op	       0 allocs/op
BenchmarkKeccakC/size=262144-16           	    2719	    442694 ns/op	      96 B/op	       0 allocs/op
BenchmarkKeccakGoKeyGeneric-16            	 2942601	       401.8 ns/op	      32 B/op	       1 allocs/op
BenchmarkKeccakCKeyGeneric-16             	 4230362	       280.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkKeccakCKeySpecialized-16         	 4407334	       275.3 ns/op	       0 B/op	       0 allocs/op
PASS
coverage: 37.3% of statements
ok  	github.com/Fantom-foundation/Tosca/go/interpreter/lfvm	44.560s
```
