### PR TITLE
LFVM: remove context from hash cache

### DIFF
--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -603,7 +603,7 @@ func opSha3(c *context) {
 	}
 	if c.shaCache {
 		// Cache hashes since identical values are frequently re-hashed.
-		c.hasherBuf = hashCache.hash(c, data)
+		c.hasherBuf = hashCache.hash(data)
 	} else {
 		if c.hasher == nil {
 			c.hasher = sha3.NewLegacyKeccak256().(keccakState)


### PR DESCRIPTION
This PR removes the context from the `hash_cache.hash` calls, and replaces the old `getHash` for corresponding calls to the new `keccak256` hash function. 
This PR contributes to #686