### PR TITLE
Add test case checking for a thread-safe code cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,6 +92,12 @@ pipeline {
             }
         }
 
+        stage('LFVM race condition tests') {
+            steps {
+                sh 'GORACE="halt_on_error=1" go test --race ./go/interpreter/lfvm/...'
+            }
+        }
+
         stage('Run C++ tests') {
             steps {
                 sh 'make test-cpp'


### PR DESCRIPTION
This PR adds a unit test running concurrent conversion steps on the code cache in an attempt to detect concurrency issues in the implementation. 

Such issues would be identified using Go's [data race detector](https://go.dev/doc/articles/race_detector) which is enabled using the `--race` when running tests. In order to detect such issues in PRs, a corresponding pass build step was added to the CI script running on Jenkins.