### PR TITLE
CT: run uses random seed by default

### DIFF
--- a/go/ct/driver/cli/flags.go
+++ b/go/ct/driver/cli/flags.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"runtime"
 	"runtime/pprof"
+	"time"
 
 	"github.com/urfave/cli/v2"
 )
@@ -62,12 +63,16 @@ var SeedFlag = &seedFlagType{
 	cli.Uint64Flag{
 		Name:    "seed",
 		Aliases: []string{"s"},
-		Usage:   "seed for the random number generator",
+		Usage:   "seed for the random number generator. If not provided, the seed is the current time stamp",
 	},
 }
 
 func (f *seedFlagType) Fetch(context *cli.Context) uint64 {
-	return context.Uint64(f.Name)
+	if context.IsSet(f.Name) {
+		return context.Uint64(f.Name)
+	} else {
+		return uint64(time.Now().UnixNano())
+	}
 }
 
 type cpuProfileType struct {

--- a/go/ct/driver/cli/flags.go
+++ b/go/ct/driver/cli/flags.go
@@ -63,16 +63,13 @@ var SeedFlag = &seedFlagType{
 	cli.Uint64Flag{
 		Name:    "seed",
 		Aliases: []string{"s"},
+		Value:   uint64(time.Now().UnixNano()),
 		Usage:   "seed for the random number generator. If not provided, the seed is the current time stamp",
 	},
 }
 
 func (f *seedFlagType) Fetch(context *cli.Context) uint64 {
-	if context.IsSet(f.Name) {
-		return context.Uint64(f.Name)
-	} else {
-		return uint64(time.Now().UnixNano())
-	}
+	return context.Uint64(f.Name)
 }
 
 type cpuProfileType struct {

--- a/go/ct/driver/run.go
+++ b/go/ct/driver/run.go
@@ -82,6 +82,8 @@ func doRun(context *cli.Context) error {
 		return fmt.Errorf("invalid EVM identifier, use one of: %v", maps.Keys(evms))
 	}
 
+	defer fmt.Printf("Seed Used: %d\n", seed)
+
 	issuesCollector := cliUtils.IssuesCollector{}
 	var skippedCount atomic.Int32
 	var numUnsupportedTests atomic.Int32
@@ -118,8 +120,6 @@ func doRun(context *cli.Context) error {
 
 		return rlz.ConsumeContinue
 	}
-
-	fmt.Printf("Starting Conformance Tests with seed %d ...\n", seed)
 
 	rules := spc.FilterRules(spc.Spec.GetRules(), filter)
 


### PR DESCRIPTION
Since CT runs nightly or every other night, we do not want to test for exactly the same set of states each run. To fix this issue, this PR changes the seed flag `Fetch` method, so that when `--seed` or `-s` are not set, it uses time as a seed. 
This PR fixes #707 