### PR TITLE
Remove hash buffer in LFVM context

### DIFF
--- a/go/interpreter/lfvm/hash_cache.go
+++ b/go/interpreter/lfvm/hash_cache.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 
 	"github.com/Fantom-foundation/Tosca/go/tosca"
-	"golang.org/x/crypto/sha3"
 )
 
 // hashCacheEntry32 is an entry of a cache for hashes of 32-byte long inputs.
@@ -70,32 +69,19 @@ func newHashCache(capacity32 int, capacity64 int) *HashCache {
 	// in every lookup operation we initialize the cache with one value.
 	// Since values are never removed, just evicted to make space for another,
 	// the cache will never be empty.
-	hasher := sha3.NewLegacyKeccak256().(keccakState)
 
 	// Insert first 32-byte element (all zeros).
 	res.head32 = res.getFree32()
 	res.tail32 = res.head32
-
-	hasher.Reset()
 	var data32 [32]byte
-	_, _ = hasher.Write(data32[:]) // hash.Hash.Write() never returns an error
-	var hash32 tosca.Hash
-	_, _ = hasher.Read(hash32[:]) // sha3.state.Read() never returns an error
-	res.head32.hash = hash32
-
+	res.head32.hash = Keccak256For32byte(data32)
 	res.index32[data32] = res.head32
 
 	// Insert first 64-byte element (all zeros).
 	res.head64 = res.getFree64()
 	res.tail64 = res.head64
-
-	hasher.Reset()
 	var data64 [64]byte
-	_, _ = hasher.Write(data64[:]) // hash.Hash.Write() never returns an error
-	var hash64 tosca.Hash
-	_, _ = hasher.Read(hash64[:]) // sha3.state.Read() never returns an error
-	res.head64.hash = hash64
-
+	res.head64.hash = Keccak256(data64[:])
 	res.index64[data64] = res.head64
 
 	return res

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 	"github.com/holiman/uint256"
-	"golang.org/x/crypto/sha3"
 )
 
 func opStop(c *context) {
@@ -601,20 +600,15 @@ func opSha3(c *context) {
 	if !c.UseGas(price) {
 		return
 	}
+	var hash tosca.Hash
 	if c.shaCache {
 		// Cache hashes since identical values are frequently re-hashed.
-		c.hasherBuf = hashCache.hash(data)
+		hash = hashCache.hash(data)
 	} else {
-		if c.hasher == nil {
-			c.hasher = sha3.NewLegacyKeccak256().(keccakState)
-		} else {
-			c.hasher.Reset()
-		}
-		_, _ = c.hasher.Write(data)          // hash.Hash.Write() never returns an error
-		_, _ = c.hasher.Read(c.hasherBuf[:]) // sha3.state.Read() never returns an error
+		hash = Keccak256(data)
 	}
 
-	size.SetBytes32(c.hasherBuf[:])
+	size.SetBytes32(hash[:])
 }
 
 func opGas(c *context) {

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -12,7 +12,6 @@ package lfvm
 
 import (
 	"fmt"
-	"hash"
 	"log"
 	"sort"
 	"sync"
@@ -35,14 +34,6 @@ const (
 	ERROR
 )
 
-// keccakState wraps sha3.state. In addition to the usual hash methods, it also supports
-// Read to get a variable amount of data from the hash state. Read is faster than Sum
-// because it doesn't copy the internal state, but also modifies the internal state.
-type keccakState interface {
-	hash.Hash
-	Read([]byte) (int, error)
-}
-
 type context struct {
 	// Context instances
 	params  tosca.Parameters
@@ -63,8 +54,6 @@ type context struct {
 
 	// Intermediate data
 	return_data []byte
-	hasher      keccakState // Keccak256 hasher instance shared across opcodes
-	hasherBuf   tosca.Hash
 
 	// Outputs
 	result_offset uint256.Int


### PR DESCRIPTION
This PR removes the hash instance retained in an execution context for hashing input data. After #685 has been added, this is no longer needed.