### PR TITLE
LFVM: stats mode panics with non-terminal code

### DIFF
--- a/go/integration_test/interpreter/test_config.go
+++ b/go/integration_test/interpreter/test_config.go
@@ -25,6 +25,7 @@ var (
 		"lfvm-no-sha-cache",
 		"lfvm-no-code-cache",
 		"lfvm-logging",
+		"lfvm-stats",
 		"evmone",
 		"evmone-basic",
 		"evmone-advanced",

--- a/go/interpreter/lfvm/instruction_statistics.go
+++ b/go/interpreter/lfvm/instruction_statistics.go
@@ -27,7 +27,9 @@ type statisticRunner struct {
 func (s *statisticRunner) run(c *context) {
 	stats := statsCollector{stats: newStatistics()}
 	for c.status == statusRunning {
-		stats.nextOp(c.code[c.pc].opcode)
+		if c.pc < int32(len(c.code)) {
+			stats.nextOp(c.code[c.pc].opcode)
+		}
 		step(c)
 	}
 	s.mutex.Lock()


### PR DESCRIPTION
during integration testing, it was found that "lfvm-stat" panic when feed incorrect code (aka code that did not end in status `STOPPED`, `REVERTED`, `RETURNED`.

This case is made into a test to verify all variants handle this case properly without producing a panic, and fixed in `lfvm-stat`

This Fixes #650 