### PR TITLE
Clean-up of LFVM interpreter infrastructure

### DIFF
--- a/go/interpreter/lfvm/gas.go
+++ b/go/interpreter/lfvm/gas.go
@@ -87,8 +87,8 @@ func initBerlinGasPrice() {
 	static_gas_prices_berlin[SELFDESTRUCT] = 5000
 }
 
-func getStaticGasPrices(isBerlin bool) []tosca.Gas {
-	if isBerlin {
+func getStaticGasPrices(revision tosca.Revision) []tosca.Gas {
+	if revision >= tosca.R09_Berlin {
 		return static_gas_prices_berlin[:]
 	}
 	return static_gas_prices[:]

--- a/go/interpreter/lfvm/instruction_statistcs_test.go
+++ b/go/interpreter/lfvm/instruction_statistcs_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package lfvm
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+	"github.com/Fantom-foundation/Tosca/go/tosca/vm"
+)
+
+func TestStatisticsRunner_RunWithStatistics(t *testing.T) {
+	// Get tosca.Parameters
+	params := tosca.Parameters{
+		Input:  []byte{},
+		Static: true,
+		Gas:    10,
+		Code:   []byte{byte(STOP), 0},
+	}
+	code := []Instruction{{STOP, 0}}
+
+	statsRunner := &statisticRunner{
+		stats: newStatistics(),
+	}
+	// Run testing code
+	_, err := run(interpreterConfig{
+		runner: statsRunner,
+	}, params, code)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if got := statsRunner.stats.singleCount[uint64(STOP)]; got != 1 {
+		t.Errorf("unexpected statistics: want 1 stop, got %v", got)
+	}
+}
+
+func TestStatisticsRunner_DumpProfilePrintsExpectedOutput(t *testing.T) {
+
+	tests := map[string]struct {
+		code         tosca.Code
+		findInOutput []string
+	}{
+		"singles": {tosca.Code{byte(vm.STOP)},
+			[]string{
+				"Steps: 1",
+				"STOP                          : 1 (100.00%)",
+			}},
+		"pairs": {tosca.Code{byte(vm.PUSH1), 0x01, byte(vm.STOP)},
+			[]string{
+				"Steps: 2",
+				"PUSH1                         : 1 (50.00%)",
+				"STOP                          : 1 (50.00%)",
+				"PUSH1                         STOP                          : 1"}},
+		"triples": {tosca.Code{byte(vm.PUSH1), 0x01, byte(vm.PUSH1), 0x01, byte(vm.STOP)},
+			[]string{
+				"Steps: 3",
+				"PUSH1                         : 2 (66.67%)",
+				"STOP                          : 1 (33.33%)",
+				"PUSH1                         PUSH1                         STOP                          : 1"}},
+		"quads": {tosca.Code{byte(vm.PUSH1), 0x01, byte(vm.PUSH1), 0x01, byte(vm.PUSH1), 0x01, byte(vm.STOP)},
+			[]string{
+				"Steps: 4",
+				"PUSH1                         : 3 (75.00%)",
+				"STOP                          : 1 (25.00%)",
+				"PUSH1                         PUSH1                         PUSH1                         : 1 (25.00%)",
+				"PUSH1                         PUSH1                         STOP                          : 1 (25.00%)",
+				"PUSH1                         PUSH1                         PUSH1                         STOP                          : 1 (25.00%)",
+			}},
+	}
+
+	for name, test := range tests {
+		t.Run(fmt.Sprintf("%v", name), func(t *testing.T) {
+			statsRunner := &statisticRunner{
+				stats: newStatistics(),
+			}
+
+			instance, err := NewVm(Config{
+				runner: statsRunner,
+			})
+			if err != nil {
+				t.Fatalf("Failed to create VM: %v", err)
+			}
+			instance.ResetProfile()
+			//run code
+			instance.Run(tosca.Parameters{Input: []byte{}, Static: true, Gas: 10,
+				Code: test.code})
+
+			// Run testing code
+			instance.DumpProfile()
+
+			out := statsRunner.stats.print()
+			for _, s := range test.findInOutput {
+				if !strings.Contains(string(out), s) {
+					t.Errorf("did not find occurrences of %v in %v", s, string(out))
+				}
+			}
+		})
+	}
+}

--- a/go/interpreter/lfvm/instruction_statistics.go
+++ b/go/interpreter/lfvm/instruction_statistics.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package lfvm
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// statisticRunner is a runner that collects statistics about the instruction
+// sequence of the executed code.
+type statisticRunner struct {
+	mutex sync.Mutex
+	stats *statistics
+}
+
+func (s *statisticRunner) run(c *context) {
+	stats := statsCollector{stats: newStatistics()}
+	for c.status == statusRunning {
+		stats.nextOp(c.code[c.pc].opcode)
+		step(c)
+	}
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.stats == nil {
+		s.stats = newStatistics()
+	}
+	s.stats.insert(stats.stats)
+}
+
+// getSummary returns a summary of the collected statistics in a human-readable
+// format.
+func (s *statisticRunner) getSummary() string {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.stats == nil {
+		s.stats = newStatistics()
+	}
+	return s.stats.print()
+}
+
+// reset clears the collected statistics.
+func (s *statisticRunner) reset() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.stats = newStatistics()
+}
+
+// statistics contains the instruction sequence statistics of a code execution.
+// It counts the number of times each instruction is executed, as well as the
+// number of times each pair, triple, and quad of instructions are executed.
+type statistics struct {
+	count       uint64
+	singleCount map[uint64]uint64
+	pairCount   map[uint64]uint64
+	tripleCount map[uint64]uint64
+	quadCount   map[uint64]uint64
+}
+
+func newStatistics() *statistics {
+	return &statistics{
+		singleCount: map[uint64]uint64{},
+		pairCount:   map[uint64]uint64{},
+		tripleCount: map[uint64]uint64{},
+		quadCount:   map[uint64]uint64{},
+	}
+}
+
+// insert adds the instruction counts of the given statistics to this instance.
+func (s *statistics) insert(src *statistics) {
+	s.count += src.count
+	for k, v := range src.singleCount {
+		s.singleCount[k] += v
+	}
+	for k, v := range src.pairCount {
+		s.pairCount[k] += v
+	}
+	for k, v := range src.tripleCount {
+		s.tripleCount[k] += v
+	}
+	for k, v := range src.quadCount {
+		s.quadCount[k] += v
+	}
+}
+
+// print returns a human-readable summary of the collected statistics.
+func (s *statistics) print() string {
+
+	type entry struct {
+		value uint64
+		count uint64
+	}
+
+	getTopN := func(data map[uint64]uint64, n int) []entry {
+		list := make([]entry, 0, len(data))
+		for k, c := range data {
+			list = append(list, entry{k, c})
+		}
+		sort.Slice(list, func(i, j int) bool {
+			return list[i].count > list[j].count
+		})
+		if len(list) < n {
+			return list
+		}
+		return list[0:n]
+	}
+
+	builder := strings.Builder{}
+	write := func(format string, args ...interface{}) {
+		builder.WriteString(fmt.Sprintf(format, args...))
+	}
+
+	write("\n----- Statistics ------\n")
+	write("\nSteps: %d\n", s.count)
+	write("\nSingles:\n")
+	for _, e := range getTopN(s.singleCount, 5) {
+		write("\t%-30v: %d (%.2f%%)\n", OpCode(e.value), e.count, float32(e.count*100)/float32(s.count))
+	}
+	write("\nPairs:\n")
+	for _, e := range getTopN(s.pairCount, 5) {
+		write("\t%-30v%-30v: %d (%.2f%%)\n", OpCode(e.value>>16), OpCode(e.value), e.count, float32(e.count*100)/float32(s.count))
+	}
+	write("\nTriples:\n")
+	for _, e := range getTopN(s.tripleCount, 5) {
+		write("\t%-30v%-30v%-30v: %d (%.2f%%)\n", OpCode(e.value>>32), OpCode(e.value>>16), OpCode(e.value), e.count, float32(e.count*100)/float32(s.count))
+	}
+
+	write("\nQuads:\n")
+	for _, e := range getTopN(s.quadCount, 5) {
+		write("\t%-30v%-30v%-30v%-30v: %d (%.2f%%)\n", OpCode(e.value>>48), OpCode(e.value>>32), OpCode(e.value>>16), OpCode(e.value), e.count, float32(e.count*100)/float32(s.count))
+	}
+	write("\n")
+
+	return builder.String()
+}
+
+// statsCollector is a helper struct that keeps track of the resent history of
+// instructions executed by the VM to collect instruction sequence statistics.
+type statsCollector struct {
+	stats *statistics
+
+	last       uint64
+	secondLast uint64
+	thirdLast  uint64
+}
+
+func (s *statsCollector) nextOp(op OpCode) {
+	if op > 255 {
+		panic("Instruction sequence statistics does not support opcodes > 255")
+	}
+	cur := uint64(op)
+	s.stats.count++
+	s.stats.singleCount[cur]++
+	if s.stats.count == 1 {
+		s.last, s.secondLast, s.thirdLast = cur, s.last, s.secondLast
+		return
+	}
+	s.stats.pairCount[s.last<<16|cur]++
+	if s.stats.count == 2 {
+		s.last, s.secondLast, s.thirdLast = cur, s.last, s.secondLast
+		return
+	}
+	s.stats.tripleCount[s.secondLast<<32|s.last<<16|cur]++
+	if s.stats.count == 3 {
+		s.last, s.secondLast, s.thirdLast = cur, s.last, s.secondLast
+		return
+	}
+	s.stats.quadCount[s.thirdLast<<48|s.secondLast<<32|s.last<<16|cur]++
+	s.last, s.secondLast, s.thirdLast = cur, s.last, s.secondLast
+}


### PR DESCRIPTION
This PR performs a clean-up pass on the interpreter implementation by
- cleaning up the interpreter `run` function signature by eliminating boolean flags and invalid flag combinations (e.g. logging and statistic can not be enabled at the same time)
- factoring out the instruction statistics run feature into its own file
- eliminating the global statistics instance; it is now associated to a VM instance
- rearranging code to fit a more logical order in the files

For the reviewers: this PR does not add or remove features; it is re-arranging code, which makes the diffs look quite convoluted; I would suggest to have a look at the new code structure by checking out this branch instead of solely focusing on the diffs.