### PR TITLE
Clean up LFVM stack implementation

### DIFF
--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -184,7 +184,7 @@ func convertLfvmStatusToCtStatus(status status) (st.StatusCode, error) {
 	}
 }
 
-func convertCtStackToLfvmStack(stack *st.Stack) *Stack {
+func convertCtStackToLfvmStack(stack *st.Stack) *stack {
 	result := NewStack()
 	for i := stack.Size() - 1; i >= 0; i-- {
 		val := stack.Get(i).Uint256()
@@ -193,11 +193,11 @@ func convertCtStackToLfvmStack(stack *st.Stack) *Stack {
 	return result
 }
 
-func convertLfvmStackToCtStack(stack *Stack, result *st.Stack) *st.Stack {
+func convertLfvmStackToCtStack(stack *stack, result *st.Stack) *st.Stack {
 	len := stack.len()
 	result.Resize(len)
 	for i := 0; i < len; i++ {
-		result.Set(len-i-1, common.NewU256FromUint256(&stack.Data()[i]))
+		result.Set(len-i-1, common.NewU256FromUint256(stack.get(i)))
 	}
 	return result
 }

--- a/go/interpreter/lfvm/ct_test.go
+++ b/go/interpreter/lfvm/ct_test.go
@@ -327,7 +327,7 @@ func TestConvertToLfvm_CodeWithSuperInstructions(t *testing.T) {
 }
 
 func TestConvertToLfvm_Stack(t *testing.T) {
-	newLfvmStack := func(values ...cc.U256) *Stack {
+	newLfvmStack := func(values ...cc.U256) *stack {
 		stack := NewStack()
 		for i := 0; i < len(values); i++ {
 			value := values[i].Uint256()
@@ -338,7 +338,7 @@ func TestConvertToLfvm_Stack(t *testing.T) {
 
 	tests := map[string][]struct {
 		ctStack   *st.Stack
-		lfvmStack *Stack
+		lfvmStack *stack
 	}{
 		"empty": {{
 			st.NewStack(),
@@ -364,8 +364,8 @@ func TestConvertToLfvm_Stack(t *testing.T) {
 				}
 
 				for i := 0; i < stack.len(); i++ {
-					want := cur.lfvmStack.Data()[i]
-					got := stack.Data()[i]
+					want := *cur.lfvmStack.get(i)
+					got := *stack.get(i)
 					if want != got {
 						t.Errorf("unexpected stack value, wanted %v, got %v", want, got)
 					}
@@ -414,7 +414,7 @@ func TestConvertToCt_Pc(t *testing.T) {
 }
 
 func TestConvertToCt_Stack(t *testing.T) {
-	newLfvmStack := func(values ...cc.U256) *Stack {
+	newLfvmStack := func(values ...cc.U256) *stack {
 		stack := NewStack()
 		for i := 0; i < len(values); i++ {
 			value := values[i].Uint256()
@@ -424,7 +424,7 @@ func TestConvertToCt_Stack(t *testing.T) {
 	}
 
 	tests := map[string][]struct {
-		lfvmStack *Stack
+		lfvmStack *stack
 		ctStack   *st.Stack
 	}{
 		"empty": {{
@@ -461,7 +461,7 @@ func TestConvertToCt_Stack(t *testing.T) {
 func BenchmarkLfvmStackToCtStack(b *testing.B) {
 	stack := NewStack()
 	for i := 0; i < MAX_STACK_SIZE/2; i++ {
-		stack.pushEmpty().SetUint64(uint64(i))
+		stack.pushUndefined().SetUint64(uint64(i))
 	}
 	ctStack := st.NewStack()
 	for i := 0; i < b.N; i++ {

--- a/go/interpreter/lfvm/gas.go
+++ b/go/interpreter/lfvm/gas.go
@@ -343,8 +343,8 @@ func gasSStoreEIP2200(c *context) (tosca.Gas, error) {
 	// Gas sentry honoured, do the actual gas calculation based on the stored value
 	var (
 		zero    = tosca.Word{}
-		key     = tosca.Key(c.stack.Back(0).Bytes32())
-		value   = tosca.Word(c.stack.Back(1).Bytes32())
+		key     = tosca.Key(c.stack.peekN(0).Bytes32())
+		value   = tosca.Word(c.stack.peekN(1).Bytes32())
 		current = c.context.GetStorage(c.params.Recipient, key)
 	)
 
@@ -394,7 +394,7 @@ func gasSStoreEIP2929(c *context) (tosca.Gas, error) {
 	// Gas sentry honoured, do the actual gas calculation based on the stored value
 	var (
 		zero    = tosca.Word{}
-		y, x    = c.stack.Back(1), c.stack.peek()
+		y, x    = c.stack.peekN(1), c.stack.peek()
 		slot    = tosca.Key(x.Bytes32())
 		current = c.context.GetStorage(c.params.Recipient, slot)
 		cost    = tosca.Gas(0)
@@ -460,7 +460,7 @@ func gasEip2929AccountCheck(c *context, address tosca.Address) error {
 func addressInAccessList(c *context) (warmAccess bool, coldCost tosca.Gas, err error) {
 	warmAccess = true
 	if c.isAtLeast(tosca.R09_Berlin) {
-		addr := tosca.Address(c.stack.Back(1).Bytes20())
+		addr := tosca.Address(c.stack.peekN(1).Bytes20())
 		// Check slot presence in the access list
 		//lint:ignore SA1019 deprecated functions to be migrated in #616
 		warmAccess = c.context.IsAddressInAccessList(addr)
@@ -481,7 +481,7 @@ func addressInAccessList(c *context) (warmAccess bool, coldCost tosca.Gas, err e
 
 func gasSelfdestruct(c *context) tosca.Gas {
 	gas := SelfdestructGasEIP150
-	var address = tosca.Address(c.stack.Back(0).Bytes20())
+	var address = tosca.Address(c.stack.peekN(0).Bytes20())
 
 	// if beneficiary needs to be created
 	if !c.context.AccountExists(address) && c.context.GetBalance(c.params.Recipient) != (tosca.Value{}) {
@@ -497,7 +497,7 @@ func gasSelfdestruct(c *context) tosca.Gas {
 func gasSelfdestructEIP2929(c *context) tosca.Gas {
 	var (
 		gas     tosca.Gas
-		address = tosca.Address(c.stack.Back(0).Bytes20())
+		address = tosca.Address(c.stack.peekN(0).Bytes20())
 	)
 	//lint:ignore SA1019 deprecated functions to be migrated in #616
 	if !c.context.IsAddressInAccessList(address) {

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -151,11 +151,11 @@ func opPush32(c *context) {
 }
 
 func opDup(c *context, pos int) {
-	c.stack.dup(pos)
+	c.stack.dup(pos - 1)
 }
 
 func opSwap(c *context, pos int) {
-	c.stack.swap(pos + 1)
+	c.stack.swap(pos)
 }
 
 func opMstore(c *context) {
@@ -1196,7 +1196,7 @@ func genericCall(c *context, kind tosca.CallKind) {
 }
 
 func opCall(c *context) {
-	value := c.stack.data[c.stack.stackPointer-3]
+	value := c.stack.peekN(3)
 	// In a static call, no value must be transferred.
 	if c.params.Static && !value.IsZero() {
 		c.signalError()

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -35,7 +35,7 @@ func opReturn(c *context) {
 }
 
 func opPc(c *context) {
-	c.stack.pushEmpty().SetUint64(uint64(c.code[c.pc].arg))
+	c.stack.pushUndefined().SetUint64(uint64(c.code[c.pc].arg))
 }
 
 func checkJumpDest(c *context) {
@@ -81,7 +81,7 @@ func opPop(c *context) {
 }
 
 func opPush(c *context, n int) {
-	z := c.stack.pushEmpty()
+	z := c.stack.pushUndefined()
 	num_instructions := int32(n/2 + n%2)
 	data := c.code[c.pc : c.pc+num_instructions]
 
@@ -100,7 +100,7 @@ func opPush(c *context, n int) {
 
 func opPush0(c *context) {
 	if c.isAtLeast(tosca.R12_Shanghai) {
-		z := c.stack.pushEmpty()
+		z := c.stack.pushUndefined()
 		z[3], z[2], z[1], z[0] = 0, 0, 0, 0
 	} else {
 		c.status = statusInvalidInstruction
@@ -108,19 +108,19 @@ func opPush0(c *context) {
 }
 
 func opPush1(c *context) {
-	z := c.stack.pushEmpty()
+	z := c.stack.pushUndefined()
 	z[3], z[2], z[1] = 0, 0, 0
 	z[0] = uint64(c.code[c.pc].arg >> 8)
 }
 
 func opPush2(c *context) {
-	z := c.stack.pushEmpty()
+	z := c.stack.pushUndefined()
 	z[3], z[2], z[1] = 0, 0, 0
 	z[0] = uint64(c.code[c.pc].arg)
 }
 
 func opPush3(c *context) {
-	z := c.stack.pushEmpty()
+	z := c.stack.pushUndefined()
 	z[3], z[2], z[1] = 0, 0, 0
 	data := c.code[c.pc : c.pc+2]
 	_ = data[1]
@@ -129,7 +129,7 @@ func opPush3(c *context) {
 }
 
 func opPush4(c *context) {
-	z := c.stack.pushEmpty()
+	z := c.stack.pushUndefined()
 	z[3], z[2], z[1] = 0, 0, 0
 
 	data := c.code[c.pc : c.pc+2]
@@ -139,7 +139,7 @@ func opPush4(c *context) {
 }
 
 func opPush32(c *context) {
-	z := c.stack.pushEmpty()
+	z := c.stack.pushUndefined()
 
 	data := c.code[c.pc : c.pc+16]
 	_ = data[15] // causes bound check to be performed only once (may become unneded in the future)
@@ -240,7 +240,7 @@ func opMload(c *context) {
 }
 
 func opMsize(c *context) {
-	c.stack.pushEmpty().SetUint64(uint64(c.memory.Len()))
+	c.stack.pushUndefined().SetUint64(uint64(c.memory.Len()))
 }
 
 func opSstore(c *context) {
@@ -310,16 +310,16 @@ func opTload(c *context) {
 }
 
 func opCaller(c *context) {
-	c.stack.pushEmpty().SetBytes20(c.params.Sender[:])
+	c.stack.pushUndefined().SetBytes20(c.params.Sender[:])
 }
 
 func opCallvalue(c *context) {
-	c.stack.pushEmpty().SetBytes32(c.params.Value[:])
+	c.stack.pushUndefined().SetBytes32(c.params.Value[:])
 }
 
 func opCallDatasize(c *context) {
 	size := len(c.params.Input)
-	c.stack.pushEmpty().SetUint64(uint64(size))
+	c.stack.pushUndefined().SetUint64(uint64(size))
 }
 
 func opCallDataload(c *context) {
@@ -612,38 +612,38 @@ func opSha3(c *context) {
 }
 
 func opGas(c *context) {
-	c.stack.pushEmpty().SetUint64(uint64(c.gas))
+	c.stack.pushUndefined().SetUint64(uint64(c.gas))
 }
 
 // opPrevRandao / opDifficulty
 func opPrevRandao(c *context) {
 	prevRandao := c.params.PrevRandao
-	c.stack.pushEmpty().SetBytes32(prevRandao[:])
+	c.stack.pushUndefined().SetBytes32(prevRandao[:])
 }
 
 func opTimestamp(c *context) {
 	time := c.params.Timestamp
-	c.stack.pushEmpty().SetUint64(uint64(time))
+	c.stack.pushUndefined().SetUint64(uint64(time))
 }
 
 func opNumber(c *context) {
 	number := c.params.BlockNumber
-	c.stack.pushEmpty().SetUint64(uint64(number))
+	c.stack.pushUndefined().SetUint64(uint64(number))
 }
 
 func opCoinbase(c *context) {
 	coinbase := c.params.Coinbase
-	c.stack.pushEmpty().SetBytes20(coinbase[:])
+	c.stack.pushUndefined().SetBytes20(coinbase[:])
 }
 
 func opGasLimit(c *context) {
 	limit := c.params.GasLimit
-	c.stack.pushEmpty().SetUint64(uint64(limit))
+	c.stack.pushUndefined().SetUint64(uint64(limit))
 }
 
 func opGasPrice(c *context) {
 	price := c.params.GasPrice
-	c.stack.pushEmpty().SetBytes32(price[:])
+	c.stack.pushUndefined().SetBytes32(price[:])
 }
 
 func opBalance(c *context) {
@@ -659,13 +659,13 @@ func opBalance(c *context) {
 
 func opSelfbalance(c *context) {
 	balance := c.context.GetBalance(c.params.Recipient)
-	c.stack.pushEmpty().SetBytes32(balance[:])
+	c.stack.pushUndefined().SetBytes32(balance[:])
 }
 
 func opBaseFee(c *context) {
 	if c.isAtLeast(tosca.R10_London) {
 		fee := c.params.BaseFee
-		c.stack.pushEmpty().SetBytes32(fee[:])
+		c.stack.pushUndefined().SetBytes32(fee[:])
 	} else {
 		c.status = statusInvalidInstruction
 		return
@@ -681,7 +681,7 @@ func opBlobHash(c *context) {
 	index := c.stack.pop()
 	blobHashesLength := uint64(len(c.params.BlobHashes))
 	if index.IsUint64() && index.Uint64() < blobHashesLength {
-		c.stack.pushEmpty().SetBytes32(c.params.BlobHashes[index.Uint64()][:])
+		c.stack.pushUndefined().SetBytes32(c.params.BlobHashes[index.Uint64()][:])
 	} else {
 		c.stack.push(uint256.NewInt(0))
 	}
@@ -690,7 +690,7 @@ func opBlobHash(c *context) {
 func opBlobBaseFee(c *context) {
 	if c.isAtLeast(tosca.R13_Cancun) {
 		fee := c.params.BlobBaseFee
-		c.stack.pushEmpty().SetBytes32(fee[:])
+		c.stack.pushUndefined().SetBytes32(fee[:])
 	} else {
 		c.status = statusInvalidInstruction
 		return
@@ -713,7 +713,7 @@ func opSelfdestruct(c *context) {
 
 func opChainId(c *context) {
 	id := c.params.ChainID
-	c.stack.pushEmpty().SetBytes32(id[:])
+	c.stack.pushUndefined().SetBytes32(id[:])
 }
 
 func opBlockhash(c *context) {
@@ -740,17 +740,17 @@ func opBlockhash(c *context) {
 }
 
 func opAddress(c *context) {
-	c.stack.pushEmpty().SetBytes20(c.params.Recipient[:])
+	c.stack.pushUndefined().SetBytes20(c.params.Recipient[:])
 }
 
 func opOrigin(c *context) {
 	origin := c.params.Origin
-	c.stack.pushEmpty().SetBytes20(origin[:])
+	c.stack.pushUndefined().SetBytes20(origin[:])
 }
 
 func opCodeSize(c *context) {
 	size := len(c.params.Code)
-	c.stack.pushEmpty().SetUint64(uint64(size))
+	c.stack.pushUndefined().SetUint64(uint64(size))
 }
 
 func opCodeCopy(c *context) {
@@ -857,7 +857,7 @@ func opCreate(c *context) {
 		balanceU256 := new(uint256.Int).SetBytes(balance[:])
 
 		if value.Gt(balanceU256) {
-			c.stack.pushEmpty().Clear()
+			c.stack.pushUndefined().Clear()
 			c.returnData = nil
 			return
 		}
@@ -882,7 +882,7 @@ func opCreate(c *context) {
 	c.gas += res.GasLeft
 	c.refund += res.GasRefund
 
-	success := c.stack.pushEmpty()
+	success := c.stack.pushUndefined()
 	if !res.Success || err != nil {
 		success.Clear()
 	} else {
@@ -927,7 +927,7 @@ func opCreate2(c *context) {
 		balanceU256 := new(uint256.Int).SetBytes(balance[:])
 
 		if value.Gt(balanceU256) {
-			c.stack.pushEmpty().Clear()
+			c.stack.pushUndefined().Clear()
 			c.returnData = nil
 			return
 		}
@@ -951,7 +951,7 @@ func opCreate2(c *context) {
 	})
 
 	// Push item on the stack based on the returned error.
-	success := c.stack.pushEmpty()
+	success := c.stack.pushUndefined()
 	if !res.Success || err != nil {
 		success.Clear()
 	} else {
@@ -1133,7 +1133,7 @@ func genericCall(c *context, kind tosca.CallKind) {
 		balance := c.context.GetBalance(c.params.Recipient)
 		balanceU256 := new(uint256.Int).SetBytes32(balance[:])
 		if balanceU256.Lt(value) {
-			c.stack.pushEmpty().Clear()
+			c.stack.pushUndefined().Clear()
 			c.returnData = nil
 			c.gas += cost // the gas send to the nested contract is returned
 			return
@@ -1184,7 +1184,7 @@ func genericCall(c *context, kind tosca.CallKind) {
 		}
 	}
 
-	success := stack.pushEmpty()
+	success := stack.pushUndefined()
 	if err != nil || !ret.Success {
 		success.Clear()
 	} else {
@@ -1196,7 +1196,7 @@ func genericCall(c *context, kind tosca.CallKind) {
 }
 
 func opCall(c *context) {
-	value := c.stack.data[c.stack.stack_ptr-3]
+	value := c.stack.data[c.stack.stackPointer-3]
 	// In a static call, no value must be transferred.
 	if c.params.Static && !value.IsZero() {
 		c.signalError()
@@ -1218,7 +1218,7 @@ func opDelegateCall(c *context) {
 }
 
 func opReturnDataSize(c *context) {
-	c.stack.pushEmpty().SetUint64(uint64(len(c.returnData)))
+	c.stack.pushUndefined().SetUint64(uint64(len(c.returnData)))
 }
 
 func opReturnDataCopy(c *context) {

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -225,7 +225,7 @@ func TestCallChecksBalances(t *testing.T) {
 	}
 
 	// Prepare stack arguments.
-	ctxt.stack.stack_ptr = 7
+	ctxt.stack.stackPointer = 7
 	ctxt.stack.data[4].Set(uint256.NewInt(1)) // < the value to be transferred
 	ctxt.stack.data[5].SetBytes(target[:])    // < the target address for the call
 
@@ -265,7 +265,7 @@ func TestCreateChecksBalance(t *testing.T) {
 	}
 
 	// Prepare stack arguments.
-	ctxt.stack.stack_ptr = 3
+	ctxt.stack.stackPointer = 3
 	ctxt.stack.data[2].Set(uint256.NewInt(1)) // < the value to be transferred
 
 	// The source account should have enough funds.
@@ -351,14 +351,14 @@ func TestBlobHash(t *testing.T) {
 	hash := tosca.Hash{1}
 
 	tests := map[string]struct {
-		setup    func(*tosca.Parameters, *Stack)
+		setup    func(*tosca.Parameters, *stack)
 		gas      tosca.Gas
 		revision tosca.Revision
 		status   status
 		want     tosca.Hash
 	}{
 		"regular": {
-			setup: func(params *tosca.Parameters, stack *Stack) {
+			setup: func(params *tosca.Parameters, stack *stack) {
 				stack.push(uint256.NewInt(0))
 				params.BlobHashes = []tosca.Hash{hash}
 			},
@@ -368,14 +368,14 @@ func TestBlobHash(t *testing.T) {
 			want:     hash,
 		},
 		"old-revision": {
-			setup:    func(params *tosca.Parameters, stack *Stack) {},
+			setup:    func(params *tosca.Parameters, stack *stack) {},
 			gas:      2,
 			revision: tosca.R12_Shanghai,
 			status:   statusInvalidInstruction,
 			want:     tosca.Hash{},
 		},
 		"no-hashes": {
-			setup: func(params *tosca.Parameters, stack *Stack) {
+			setup: func(params *tosca.Parameters, stack *stack) {
 				stack.push(uint256.NewInt(0))
 			},
 			gas:      2,
@@ -384,7 +384,7 @@ func TestBlobHash(t *testing.T) {
 			want:     tosca.Hash{},
 		},
 		"target-non-existent": {
-			setup: func(params *tosca.Parameters, stack *Stack) {
+			setup: func(params *tosca.Parameters, stack *stack) {
 				stack.push(uint256.NewInt(1))
 			},
 			gas:      2,
@@ -646,7 +646,7 @@ func TestCreateShanghaiInitCodeSize(t *testing.T) {
 			}
 
 			// Prepare stack arguments.
-			ctxt.stack.stack_ptr = 3
+			ctxt.stack.stackPointer = 3
 			ctxt.stack.data[0].Set(uint256.NewInt(test.init_code_size))
 
 			if test.expected == statusRunning {
@@ -714,7 +714,7 @@ func TestCreateShanghaiDeploymentCost(t *testing.T) {
 		}
 
 		// Prepare stack arguments.
-		ctxt.stack.stack_ptr = 3
+		ctxt.stack.stackPointer = 3
 		ctxt.stack.data[0].Set(uint256.NewInt(test.initCodeSize))
 
 		runContext.EXPECT().Call(tosca.Create, gomock.Any()).Return(tosca.CallResult{}, nil)
@@ -789,7 +789,7 @@ func TestTransientStorageOperations(t *testing.T) {
 			runContext := tosca.NewMockRunContext(ctrl)
 			test.setup(runContext)
 			ctxt.context = runContext
-			ctxt.stack.stack_ptr = test.stackPtr
+			ctxt.stack.stackPointer = test.stackPtr
 
 			test.op(&ctxt)
 
@@ -862,7 +862,7 @@ func TestExpansionCostOverflow(t *testing.T) {
 						context: runContext,
 						gas:     12884901899,
 					}
-					ctxt.stack.stack_ptr = test.stackSize
+					ctxt.stack.stackPointer = test.stackSize
 					ctxt.stack.data[memIndex].Set(uint256.NewInt(memValue))
 					for i := range test.memIndexes {
 						if i != memIndex {

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -46,7 +46,7 @@ type context struct {
 	pc     int32
 	gas    tosca.Gas
 	refund tosca.Gas
-	stack  *Stack
+	stack  *stack
 	memory *Memory
 
 	// Intermediate data
@@ -266,7 +266,7 @@ func steps(c *context, oneStepOnly bool) {
 		// for a call operation is the value. Transferring value from one
 		// account to the others means the state is modified and should also
 		// return with an error.
-		if c.params.Static && (isWriteInstruction(op) || (op == CALL && c.stack.Back(2).Sign() != 0)) {
+		if c.params.Static && (isWriteInstruction(op) || (op == CALL && c.stack.peekN(2).Sign() != 0)) {
 			c.signalError()
 			return
 		}

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -148,7 +148,7 @@ func getContext(code Code, data []byte, runContext tosca.RunContext, stackPtr in
 	// For the tests using the resulting context the actual
 	// stack content is not relevant. It is merely used for
 	// checking stack over- or under-flows.
-	ctxt.stack.stack_ptr = stackPtr
+	ctxt.stack.stackPointer = stackPtr
 
 	return ctxt
 }
@@ -268,7 +268,7 @@ func TestStackMinBoundry(t *testing.T) {
 		// Create execution context.
 		ctxt := getEmptyContext()
 		ctxt.code = test.code
-		ctxt.stack.stack_ptr = test.stackPtrPos
+		ctxt.stack.stackPointer = test.stackPtrPos
 
 		// Run testing code
 		vanillaRunner{}.run(&ctxt)
@@ -290,7 +290,7 @@ func TestStackMaxBoundry(t *testing.T) {
 		// Create execution context.
 		ctxt := getEmptyContext()
 		ctxt.code = test.code
-		ctxt.stack.stack_ptr = test.stackPtrPos
+		ctxt.stack.stackPointer = test.stackPtrPos
 
 		// Run testing code
 		vanillaRunner{}.run(&ctxt)
@@ -886,7 +886,7 @@ func benchmarkFib(b *testing.B, arg int, with_super_instructions bool) {
 		ctxt.pc = 0
 		ctxt.status = statusRunning
 		ctxt.gas = 1 << 31
-		ctxt.stack.stack_ptr = 0
+		ctxt.stack.stackPointer = 0
 
 		// Run the code (actual benchmark).
 		vanillaRunner{}.run(&ctxt)

--- a/go/interpreter/lfvm/stack.go
+++ b/go/interpreter/lfvm/stack.go
@@ -59,7 +59,7 @@ func (s *stack) pushUndefined() *uint256.Int {
 
 // pop removes the top element from the stack and returns a pointer to it. The
 // obtained pointer is only valid until the next push operation. The pointer
-// can be used to obtain the pushed element without the need to copy it.
+// can be used to obtain the popped element without the need to copy it.
 func (s *stack) pop() *uint256.Int {
 	s.stackPointer--
 	return &s.data[s.stackPointer]
@@ -84,15 +84,15 @@ func (s *stack) len() int {
 }
 
 // swap exchanges the top element with the n-th element from the top. The top
-// element is at index 1. Thus, swap(1) is a no-op.
+// element is at index 0. Thus, swap(0) is a no-op.
 func (s *stack) swap(n int) {
-	s.data[s.len()-n], s.data[s.len()-1] = s.data[s.len()-1], s.data[s.len()-n]
+	s.data[s.len()-n-1], s.data[s.len()-1] = s.data[s.len()-1], s.data[s.len()-n-1]
 }
 
 // dup duplicates the n-th element from the top and pushes it to the top of the
-// stack. The top element is at index 1. Thus, dup(1) duplicates the top element.
+// stack. The top element is at index 0. Thus, dup(0) duplicates the top element.
 func (s *stack) dup(n int) {
-	s.data[s.stackPointer] = s.data[s.stackPointer-n]
+	s.data[s.stackPointer] = s.data[s.stackPointer-n-1]
 	s.stackPointer++
 }
 

--- a/go/interpreter/lfvm/stack.go
+++ b/go/interpreter/lfvm/stack.go
@@ -11,85 +11,113 @@
 package lfvm
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/holiman/uint256"
 )
 
-var staticStackBoundary = [NUM_OPCODES]InstructionStack{}
+const maxStackSize = 1024 // Maximum size of VM stack allowed.
 
-const stackLimit = 1024 // Maximum size of VM stack allowed.
-
-type Stack struct {
-	data      [1024]uint256.Int
-	stack_ptr int
+// stack is the 1024-element 256-bit word-wide stack used by the VM.
+// It is a fixed-size stack to prevent memory reallocation during execution.
+// Check boundaries are not checked. Users of the stack must prevent over- and
+// underflow situations.
+//
+// Each stack consumes 1024 * 32 bytes = 32KB of memory. Thus, creating and
+// destroying stacks could incur significant overhead. To mitigate this, a
+// stack pool is provided to reuse stack instances. To obtain an empty stack
+// from the pool, use NewStack(). To return a stack to the pool, use
+// ReturnStack(s).
+//
+// Example usage:
+//
+//	s := NewStack()
+//	defer ReturnStack(s)
+//	<use the stack in your local scope>
+//
+// The stack is not thread-safe. NewStack() and ReturnStack() are thread-safe.
+type stack struct {
+	data         [maxStackSize]uint256.Int
+	stackPointer int
 }
 
-func init() {
-	for i := 0; i < int(NUM_OPCODES); i++ {
-		staticStackBoundary[OpCode(i)] = getStaticStackInternal(OpCode(i))
-	}
+// push adds a copy of the given value to the top of the stack.
+func (s *stack) push(d *uint256.Int) {
+	s.data[s.stackPointer] = *d
+	s.stackPointer++
 }
 
-func (s *Stack) Data() []uint256.Int {
-	return s.data[:s.stack_ptr]
+// push adds a value with an undefined value to the top of the stack and returns
+// a pointer to this element. Use this function if the element on the top stack
+// should be modified directly using the returned pointer.
+func (s *stack) pushUndefined() *uint256.Int {
+	s.stackPointer++
+	return &s.data[s.stackPointer-1]
 }
 
-func (s *Stack) push(d *uint256.Int) {
-	s.data[s.stack_ptr] = *d
-	s.stack_ptr++
+// pop removes the top element from the stack and returns a pointer to it. The
+// obtained pointer is only valid until the next push operation. The pointer
+// can be used to obtain the pushed element without the need to copy it.
+func (s *stack) pop() *uint256.Int {
+	s.stackPointer--
+	return &s.data[s.stackPointer]
 }
 
-func (s *Stack) pushEmpty() *uint256.Int {
-	s.stack_ptr++
-	return &s.data[s.stack_ptr-1]
-}
-
-func (s *Stack) pop() *uint256.Int {
-	s.stack_ptr--
-	return &s.data[s.stack_ptr]
-}
-
-func (s *Stack) len() int {
-	return s.stack_ptr
-}
-
-func (s *Stack) swap(n int) {
-	s.data[s.len()-n], s.data[s.len()-1] = s.data[s.len()-1], s.data[s.len()-n]
-}
-
-func (s *Stack) dup(n int) {
-	s.data[s.stack_ptr] = s.data[s.stack_ptr-n]
-	s.stack_ptr++
-}
-
-func (s *Stack) peek() *uint256.Int {
+// peek returns a pointer to the top element of the stack without removing it.
+// The returned pointer is only valid until the next operation on the stack.
+func (s *stack) peek() *uint256.Int {
 	return &s.data[s.len()-1]
 }
 
-func (s *Stack) Back(n int) *uint256.Int {
+// peekN returns a pointer to the n-th element from the top of the stack without
+// removing it. The top element is at index 0 Thus, peekN(0) is equivalent to
+// peek().
+func (s *stack) peekN(n int) *uint256.Int {
 	return &s.data[s.len()-n-1]
 }
 
-func ToHex(z *uint256.Int) string {
-	var b bytes.Buffer
-	b.WriteString("0x")
-	bytes := z.Bytes32()
-	for i, cur := range bytes {
-		b.WriteString(fmt.Sprintf("%02x", cur))
-		if (i+1)%8 == 0 {
-			b.WriteString(" ")
-		}
-	}
-	return b.String()
+// len returns the number of elements on the stack.
+func (s *stack) len() int {
+	return s.stackPointer
 }
 
-func (s *Stack) String() string {
-	var b bytes.Buffer
+// swap exchanges the top element with the n-th element from the top. The top
+// element is at index 1. Thus, swap(1) is a no-op.
+func (s *stack) swap(n int) {
+	s.data[s.len()-n], s.data[s.len()-1] = s.data[s.len()-1], s.data[s.len()-n]
+}
+
+// dup duplicates the n-th element from the top and pushes it to the top of the
+// stack. The top element is at index 1. Thus, dup(1) duplicates the top element.
+func (s *stack) dup(n int) {
+	s.data[s.stackPointer] = s.data[s.stackPointer-n]
+	s.stackPointer++
+}
+
+// get returns the element at the given index. The bottom element is at index 0.
+func (s *stack) get(i int) *uint256.Int {
+	return &s.data[i]
+}
+
+func (s *stack) String() string {
+	toHex := func(z *uint256.Int) string {
+		b := strings.Builder{}
+		b.WriteString("0x")
+		bytes := z.Bytes32()
+		for i, cur := range bytes {
+			b.WriteString(fmt.Sprintf("%02x", cur))
+			if (i+1)%8 == 0 {
+				b.WriteString(" ")
+			}
+		}
+		return b.String()
+	}
+
+	b := strings.Builder{}
 	for i := 0; i < s.len(); i++ {
-		b.WriteString(fmt.Sprintf("    [%2d] %v\n", s.len()-i-1, ToHex(s.Back(i))))
+		b.WriteString(fmt.Sprintf("    [%4d] %v\n", s.len()-i-1, toHex(s.peekN(i))))
 	}
 	return b.String()
 }
@@ -98,26 +126,40 @@ func (s *Stack) String() string {
 
 var stackPool = sync.Pool{
 	New: func() interface{} {
-		return &Stack{}
+		return &stack{}
 	},
 }
 
-func NewStack() *Stack {
-	return stackPool.Get().(*Stack)
+// NewStack returns a new stack instance from the a reuse pool. Heavy stack
+// users should use this function to prevent memory reallocation overhead.
+// This function is thread-safe.
+func NewStack() *stack {
+	return stackPool.Get().(*stack)
 }
 
-func ReturnStack(s *Stack) {
-	s.stack_ptr = 0
+// ReturnStack returns the stack to the reuse pool. Any stack may only be
+// returned once to avoid concurrent re-use. This is not checked internally.
+// This function is thread-safe.
+func ReturnStack(s *stack) {
+	s.stackPointer = 0
 	stackPool.Put(s)
 }
 
-// ------------------ Stack Boundry ------------------
+// ------------------ Stack Boundary ------------------
+
+var staticStackBoundary = [NUM_OPCODES]InstructionStack{}
+
+func init() {
+	for i := 0; i < int(NUM_OPCODES); i++ {
+		staticStackBoundary[OpCode(i)] = getStaticStackInternal(OpCode(i))
+	}
+}
 
 // min is number of pop and max is pop - push
 func newInstructionStack(min, max, _increase int) InstructionStack {
 	return InstructionStack{
 		stackMin: min,
-		stackMax: stackLimit - max,
+		stackMax: maxStackSize - max,
 		increase: _increase,
 	}
 }

--- a/go/interpreter/lfvm/stack_test.go
+++ b/go/interpreter/lfvm/stack_test.go
@@ -118,11 +118,11 @@ func TestStack_peekN_ObtainsNthElementFromTop(t *testing.T) {
 func TestStack_swap_ExchangesTopElementWithSelectedElement(t *testing.T) {
 	// n => expected order after swap(n)
 	tests := map[int][]uint64{
-		1: {0, 1, 2, 3, 4},
-		2: {1, 0, 2, 3, 4},
-		3: {2, 1, 0, 3, 4},
-		4: {3, 1, 2, 0, 4},
-		5: {4, 1, 2, 3, 0},
+		0: {0, 1, 2, 3, 4},
+		1: {1, 0, 2, 3, 4},
+		2: {2, 1, 0, 3, 4},
+		3: {3, 1, 2, 0, 4},
+		4: {4, 1, 2, 3, 0},
 	}
 
 	for n, result := range tests {
@@ -146,9 +146,9 @@ func TestStack_swap_ExchangesTopElementWithSelectedElement(t *testing.T) {
 	}
 }
 
-func TestStack_swap_WorksForAnyValueBiggerThanOne(t *testing.T) {
+func TestStack_swap_WorksForAnyIntegerValue(t *testing.T) {
 	for _, size := range []int{2, 128, maxStackSize - 1} {
-		for i := 1; i < size; i++ {
+		for i := 0; i < size; i++ {
 			t.Run(fmt.Sprintf("size=%d_swap%d", size, i), func(t *testing.T) {
 				stack := NewStack()
 				defer ReturnStack(stack)
@@ -157,7 +157,7 @@ func TestStack_swap_WorksForAnyValueBiggerThanOne(t *testing.T) {
 					stack.push(uint256.NewInt(uint64(i)))
 				}
 
-				want := stack.peekN(i - 1).Uint64()
+				want := stack.peekN(i).Uint64()
 				stack.swap(i)
 				got := stack.peek().Uint64()
 
@@ -172,11 +172,11 @@ func TestStack_swap_WorksForAnyValueBiggerThanOne(t *testing.T) {
 func TestStack_dup_DuplicatesSelectedElementFromStack(t *testing.T) {
 	// n => expected content after dup(n)
 	tests := map[int][]uint64{
-		1: {0, 0, 1, 2, 3, 4},
-		2: {1, 0, 1, 2, 3, 4},
-		3: {2, 0, 1, 2, 3, 4},
-		4: {3, 0, 1, 2, 3, 4},
-		5: {4, 0, 1, 2, 3, 4},
+		0: {0, 0, 1, 2, 3, 4},
+		1: {1, 0, 1, 2, 3, 4},
+		2: {2, 0, 1, 2, 3, 4},
+		3: {3, 0, 1, 2, 3, 4},
+		4: {4, 0, 1, 2, 3, 4},
 	}
 
 	for n, result := range tests {
@@ -200,9 +200,9 @@ func TestStack_dup_DuplicatesSelectedElementFromStack(t *testing.T) {
 	}
 }
 
-func TestStack_dup_WorksForAnyValueBiggerThanOne(t *testing.T) {
+func TestStack_dup_WorksForAnyIntegerValue(t *testing.T) {
 	for _, size := range []int{2, 128, maxStackSize - 1} {
-		for i := 1; i < size; i++ {
+		for i := 0; i < size; i++ {
 			t.Run(fmt.Sprintf("size=%d_dup%d", size, i), func(t *testing.T) {
 				stack := NewStack()
 				defer ReturnStack(stack)
@@ -211,7 +211,7 @@ func TestStack_dup_WorksForAnyValueBiggerThanOne(t *testing.T) {
 					stack.push(uint256.NewInt(uint64(i)))
 				}
 
-				want := stack.peekN(i - 1).Uint64()
+				want := stack.peekN(i).Uint64()
 				stack.dup(i)
 				got := stack.peek().Uint64()
 

--- a/go/interpreter/lfvm/stack_test.go
+++ b/go/interpreter/lfvm/stack_test.go
@@ -1,0 +1,297 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package lfvm
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/holiman/uint256"
+)
+
+func TestStack_ZeroStackIsEmpty(t *testing.T) {
+	var stack stack
+	if want, got := 0, stack.len(); want != got {
+		t.Errorf("expected stack to be empty, but got %d elements", got)
+	}
+}
+
+func TestStack_pushAndPop_CanUseFullCapacity(t *testing.T) {
+	var stack stack
+
+	for i := 0; i < maxStackSize; i++ {
+		if want, got := i, stack.len(); want != got {
+			t.Errorf("expected stack to have %d elements, but got %d", want, got)
+		}
+		val := uint256.NewInt(uint64(i))
+		stack.push(val)
+	}
+
+	if want, got := maxStackSize, stack.len(); want != got {
+		t.Errorf("expected stack to have %d elements, but got %d", want, got)
+	}
+
+	for i := maxStackSize - 1; i >= 0; i-- {
+		val := stack.pop()
+		if want, got := uint256.NewInt(uint64(i)), val; want.Cmp(got) != 0 {
+			t.Errorf("expected popped value to be %d, but got %d", want, got)
+		}
+		if want, got := i, stack.len(); want != got {
+			t.Errorf("expected stack to have %d elements, but got %d", want, got)
+		}
+	}
+}
+
+func TestStack_push_AddsProvidedElementToStack(t *testing.T) {
+	values := []*uint256.Int{
+		uint256.NewInt(0),
+		uint256.NewInt(1),
+		new(uint256.Int).Lsh(uint256.NewInt(1), 64),
+		new(uint256.Int).Lsh(uint256.NewInt(1), 128),
+		new(uint256.Int).Lsh(uint256.NewInt(1), 192),
+	}
+
+	stack := NewStack()
+	defer ReturnStack(stack)
+
+	for _, val := range values {
+		stack.push(val)
+		if want, got := val, stack.peek(); want.Cmp(got) != 0 {
+			t.Errorf("expected top element to be %d, but got %d", want, got)
+		}
+	}
+}
+
+func TestStack_pushUndefined_ResultCanBeUsedToManipulatePeek(t *testing.T) {
+	values := []*uint256.Int{
+		uint256.NewInt(0),
+		uint256.NewInt(1),
+		new(uint256.Int).Lsh(uint256.NewInt(1), 64),
+		new(uint256.Int).Lsh(uint256.NewInt(1), 128),
+		new(uint256.Int).Lsh(uint256.NewInt(1), 192),
+	}
+
+	stack := NewStack()
+	defer ReturnStack(stack)
+
+	for _, val := range values {
+		peek := stack.pushUndefined()
+		peek.Set(val)
+		if want, got := val, stack.peek(); want.Cmp(got) != 0 {
+			t.Errorf("expected top element to be %d, but got %d", want, got)
+		}
+	}
+}
+
+func TestStack_peekN_ObtainsNthElementFromTop(t *testing.T) {
+	stack := NewStack()
+	defer ReturnStack(stack)
+
+	for i := 0; i < 10; i++ {
+		val := uint256.NewInt(uint64(i))
+		stack.push(val)
+	}
+
+	if want, got := stack.peek(), stack.peekN(0); want != got {
+		t.Errorf("expected peekN(0) to be the same as peek(), but got %d and %d", want, got)
+	}
+
+	for i := 0; i < 10; i++ {
+		want := uint256.NewInt(uint64(9 - i))
+		got := stack.peekN(i)
+		if want.Cmp(got) != 0 {
+			t.Errorf("expected %d-th element from top to be %d, but got %d", i, want, got)
+		}
+	}
+}
+
+func TestStack_swap_ExchangesTopElementWithSelectedElement(t *testing.T) {
+	// n => expected order after swap(n)
+	tests := map[int][]uint64{
+		1: {0, 1, 2, 3, 4},
+		2: {1, 0, 2, 3, 4},
+		3: {2, 1, 0, 3, 4},
+		4: {3, 1, 2, 0, 4},
+		5: {4, 1, 2, 3, 0},
+	}
+
+	for n, result := range tests {
+		t.Run(fmt.Sprintf("swap%d", n), func(t *testing.T) {
+			stack := NewStack()
+			defer ReturnStack(stack)
+
+			for i := 4; i >= 0; i-- {
+				stack.push(uint256.NewInt(uint64(i)))
+			}
+
+			stack.swap(n)
+
+			for i, want := range result {
+				got := stack.peekN(i).Uint64()
+				if want != got {
+					t.Errorf("expected %d-th element to be %d, but got %d", i, want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestStack_swap_WorksForAnyValueBiggerThanOne(t *testing.T) {
+	for _, size := range []int{2, 128, maxStackSize - 1} {
+		for i := 1; i < size; i++ {
+			t.Run(fmt.Sprintf("size=%d_swap%d", size, i), func(t *testing.T) {
+				stack := NewStack()
+				defer ReturnStack(stack)
+
+				for i := 0; i < size; i++ {
+					stack.push(uint256.NewInt(uint64(i)))
+				}
+
+				want := stack.peekN(i - 1).Uint64()
+				stack.swap(i)
+				got := stack.peek().Uint64()
+
+				if want != got {
+					t.Errorf("expected top element to be %d, but got %d", want, got)
+				}
+			})
+		}
+	}
+}
+
+func TestStack_dup_DuplicatesSelectedElementFromStack(t *testing.T) {
+	// n => expected content after dup(n)
+	tests := map[int][]uint64{
+		1: {0, 0, 1, 2, 3, 4},
+		2: {1, 0, 1, 2, 3, 4},
+		3: {2, 0, 1, 2, 3, 4},
+		4: {3, 0, 1, 2, 3, 4},
+		5: {4, 0, 1, 2, 3, 4},
+	}
+
+	for n, result := range tests {
+		t.Run(fmt.Sprintf("dup%d", n), func(t *testing.T) {
+			stack := NewStack()
+			defer ReturnStack(stack)
+
+			for i := 4; i >= 0; i-- {
+				stack.push(uint256.NewInt(uint64(i)))
+			}
+
+			stack.dup(n)
+
+			for i, want := range result {
+				got := stack.peekN(i).Uint64()
+				if want != got {
+					t.Errorf("expected %d-th element to be %d, but got %d", i, want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestStack_dup_WorksForAnyValueBiggerThanOne(t *testing.T) {
+	for _, size := range []int{2, 128, maxStackSize - 1} {
+		for i := 1; i < size; i++ {
+			t.Run(fmt.Sprintf("size=%d_dup%d", size, i), func(t *testing.T) {
+				stack := NewStack()
+				defer ReturnStack(stack)
+
+				for i := 0; i < size; i++ {
+					stack.push(uint256.NewInt(uint64(i)))
+				}
+
+				want := stack.peekN(i - 1).Uint64()
+				stack.dup(i)
+				got := stack.peek().Uint64()
+
+				if want != got {
+					t.Errorf("expected top element to be %d, but got %d", want, got)
+				}
+			})
+		}
+	}
+}
+
+func TestStack_get_IndexesElementsBottomUp(t *testing.T) {
+	stack := NewStack()
+	defer ReturnStack(stack)
+
+	for i := 0; i < maxStackSize; i++ {
+		stack.push(uint256.NewInt(uint64(i)))
+	}
+
+	for i := 0; i < maxStackSize; i++ {
+		want := uint256.NewInt(uint64(i))
+		got := stack.get(i)
+		if want.Cmp(got) != 0 {
+			t.Errorf("expected %d-th element to be %d, but got %d", i, want, got)
+		}
+	}
+}
+
+func TestStack_String_PrintsContentUsingFormattedHex(t *testing.T) {
+	stack := NewStack()
+	defer ReturnStack(stack)
+
+	for i := 0; i < 256; i++ {
+		top := stack.pushUndefined()
+		top.Lsh(uint256.NewInt(1), uint(i))
+	}
+
+	print := stack.String()
+
+	wanted := []string{
+		"[   0] 0x0000000000000000 0000000000000000 0000000000000000 0000000000000001",
+		"[   1] 0x0000000000000000 0000000000000000 0000000000000000 0000000000000002",
+		"[   2] 0x0000000000000000 0000000000000000 0000000000000000 0000000000000004",
+		"[  16] 0x0000000000000000 0000000000000000 0000000000000000 0000000000010000",
+		"[  64] 0x0000000000000000 0000000000000000 0000000000000001 0000000000000000",
+		"[ 128] 0x0000000000000000 0000000000000001 0000000000000000 0000000000000000",
+		"[ 255] 0x8000000000000000 0000000000000000 0000000000000000 0000000000000000",
+	}
+
+	for _, want := range wanted {
+		if !strings.Contains(print, want) {
+			t.Errorf("expected output to contain %q, but got %q", want, print)
+		}
+	}
+}
+
+func TestStack_NewStack_IsEmpty(t *testing.T) {
+	stack := NewStack()
+	defer ReturnStack(stack)
+
+	if want, got := 0, stack.len(); want != got {
+		t.Errorf("expected stack to be empty, but got %d elements", got)
+	}
+}
+
+func TestStack_NewStackAndReturnStack_AreThreadSafe(t *testing.T) {
+	// this test assumes to be executed using the --race flag.
+	const parallelism = 10
+	const iterations = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(parallelism)
+	for i := 0; i < parallelism; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				stack := NewStack()
+				defer ReturnStack(stack)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/go/interpreter/lfvm/super_instructions.go
+++ b/go/interpreter/lfvm/super_instructions.go
@@ -26,14 +26,14 @@ func opSwap1_Pop(c *context) {
 
 func opSwap2_Pop(c *context) {
 	a1 := c.stack.pop()
-	*c.stack.Back(1) = *a1
+	*c.stack.peekN(1) = *a1
 }
 
 func opPush1_Push1(c *context) {
 	arg := c.code[c.pc].arg
-	c.stack.stack_ptr += 2
-	c.stack.Back(0).SetUint64(uint64(arg & 0xFF))
-	c.stack.Back(1).SetUint64(uint64(arg >> 8))
+	c.stack.stackPointer += 2
+	c.stack.peekN(0).SetUint64(uint64(arg & 0xFF))
+	c.stack.peekN(1).SetUint64(uint64(arg >> 8))
 }
 
 func opPush1_Add(c *context) {
@@ -54,9 +54,9 @@ func opPush1_Shl(c *context) {
 
 func opPush1_Dup1(c *context) {
 	arg := c.code[c.pc].arg
-	c.stack.stack_ptr += 2
-	c.stack.Back(0).SetUint64(uint64(arg))
-	c.stack.Back(1).SetUint64(uint64(arg))
+	c.stack.stackPointer += 2
+	c.stack.peekN(0).SetUint64(uint64(arg))
+	c.stack.peekN(1).SetUint64(uint64(arg))
 }
 
 func opPush2_Jump(c *context) {
@@ -75,9 +75,9 @@ func opPush2_Jumpi(c *context) {
 }
 
 func opSwap2_Swap1(c *context) {
-	a1 := c.stack.Back(0)
-	a2 := c.stack.Back(1)
-	a3 := c.stack.Back(2)
+	a1 := c.stack.peekN(0)
+	a2 := c.stack.peekN(1)
+	a3 := c.stack.peekN(2)
 	*a1, *a2, *a3 = *a2, *a3, *a1
 }
 
@@ -92,8 +92,8 @@ func opDup2_Mstore(c *context) {
 }
 
 func opDup2_Lt(c *context) {
-	b := c.stack.Back(0)
-	a := c.stack.Back(1)
+	b := c.stack.peekN(0)
+	a := c.stack.peekN(1)
 	if a.Lt(b) {
 		b.SetOne()
 	} else {
@@ -102,7 +102,7 @@ func opDup2_Lt(c *context) {
 }
 
 func opPopPop(c *context) {
-	c.stack.stack_ptr -= 2
+	c.stack.stackPointer -= 2
 }
 
 func opPop_Jump(c *context) {
@@ -128,17 +128,17 @@ func opSwap2_Swap1_Pop_Jump(c *context) {
 
 func opSwap1_Pop_Swap2_Swap1(c *context) {
 	a1 := c.stack.pop()
-	a2 := c.stack.Back(0)
-	a3 := c.stack.Back(1)
-	a4 := c.stack.Back(2)
+	a2 := c.stack.peekN(0)
+	a3 := c.stack.peekN(1)
+	a4 := c.stack.peekN(2)
 	*a2, *a3, *a4 = *a3, *a4, *a1
 }
 
 func opPop_Swap2_Swap1_Pop(c *context) {
 	c.stack.pop()
 	a2 := c.stack.pop()
-	a3 := c.stack.Back(0)
-	a4 := c.stack.Back(1)
+	a3 := c.stack.peekN(0)
+	a4 := c.stack.peekN(1)
 	*a3, *a4 = *a4, *a2
 }
 
@@ -160,7 +160,7 @@ func opPush1_Push1_Push1_Shl_Sub(c *context) {
 	shift := uint8(arg2)
 	value := uint8(arg1 & 0xFF)
 	delta := uint8(arg1 >> 8)
-	trg := c.stack.pushEmpty()
+	trg := c.stack.pushUndefined()
 	trg.SetUint64(uint64(value))
 	trg.Lsh(trg, uint(shift))
 	trg.Sub(trg, uint256.NewInt(uint64(delta)))


### PR DESCRIPTION
This PR performs a clean-up pass over LFVM's stack implementation by
- fixing visibility
- aligning the naming of member functions (`Back` => `peekN`, `Data` => `get`)
- adding documentation
- adding unit test coverage


Note to reviewer: this PR does not cover the stack boundary infrastructure that happens to be located in the `stack.go` file but should be moved since it is much closer related to instructions than to the `stack`. This will be covered in a follow-up.