### PR TITLE
lfvm: introduce CT sub package

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -64,6 +64,8 @@ override:
   - threshold: 0
     path: go/interpreter/lfvm/lfvm.go
   - threshold: 0
+    path: go/interpreter/lfvm/memory.go
+  - threshold: 0
     path: go/interpreter/lfvm/opcode.go
   - threshold: 0
     path: go/interpreter/lfvm/super_instructions.go
@@ -93,7 +95,7 @@ override:
     path: go/integration_test/processor
   - threshold: 0
     path: go/interpreter/evmc
-  - threshold: 73
+  - threshold: 77
     path: go/interpreter/lfvm
   - threshold: 0
     path: go/processor/floria

--- a/go/ct/driver/run.go
+++ b/go/ct/driver/run.go
@@ -26,7 +26,7 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"github.com/Fantom-foundation/Tosca/go/interpreter/evmzero"
 	"github.com/Fantom-foundation/Tosca/go/interpreter/geth"
-	"github.com/Fantom-foundation/Tosca/go/interpreter/lfvm"
+	lfvm "github.com/Fantom-foundation/Tosca/go/interpreter/lfvm/ct"
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 	"github.com/dsnet/golib/unitconv"
 	"github.com/urfave/cli/v2"

--- a/go/ct/evm_fuzz_test.go
+++ b/go/ct/evm_fuzz_test.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"github.com/Fantom-foundation/Tosca/go/interpreter/geth"
-	"github.com/Fantom-foundation/Tosca/go/interpreter/lfvm"
+	lfvm "github.com/Fantom-foundation/Tosca/go/interpreter/lfvm/ct"
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 )
 

--- a/go/ct/evm_test.go
+++ b/go/ct/evm_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/ct/spc"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"github.com/Fantom-foundation/Tosca/go/interpreter/evmzero"
-	"github.com/Fantom-foundation/Tosca/go/interpreter/lfvm"
+	lfvm "github.com/Fantom-foundation/Tosca/go/interpreter/lfvm/ct"
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 	"github.com/Fantom-foundation/Tosca/go/tosca/vm"
 )

--- a/go/interpreter/lfvm/converter.go
+++ b/go/interpreter/lfvm/converter.go
@@ -132,12 +132,12 @@ func (b *codeBuilder) toCode() Code {
 }
 
 func convert(code []byte, options ConversionConfig) Code {
-	return convertWithObserver(code, options, func(int, int) {})
+	return ConvertWithObserver(code, options, func(int, int) {})
 }
 
-// convertWithObserver converts EVM code to LFVM code and calls the observer
+// ConvertWithObserver converts EVM code to LFVM code and calls the observer
 // with the code position of every pair of instructions converted.
-func convertWithObserver(
+func ConvertWithObserver(
 	code []byte,
 	options ConversionConfig,
 	observer func(evmPc int, lfvmPc int),

--- a/go/interpreter/lfvm/converter_fuzz_test.go
+++ b/go/interpreter/lfvm/converter_fuzz_test.go
@@ -41,7 +41,7 @@ func FuzzLfvmConverter(f *testing.F) {
 			originalPos, lfvmPos int
 		}
 		var pairs []pair
-		lfvmCode := convertWithObserver(toscaCode, ConversionConfig{}, func(evm, lfvm int) {
+		lfvmCode := ConvertWithObserver(toscaCode, ConversionConfig{}, func(evm, lfvm int) {
 			pairs = append(pairs, pair{evm, lfvm})
 		})
 

--- a/go/interpreter/lfvm/converter_test.go
+++ b/go/interpreter/lfvm/converter_test.go
@@ -205,7 +205,7 @@ func TestConvertWithObserver_MapsEvmToLfvmPositions(t *testing.T) {
 		evm, lfvm int
 	}
 	var pairs []pair
-	res := convertWithObserver(code, ConversionConfig{}, func(evm, lfvm int) {
+	res := ConvertWithObserver(code, ConversionConfig{}, func(evm, lfvm int) {
 		pairs = append(pairs, pair{evm, lfvm})
 	})
 
@@ -245,7 +245,7 @@ func TestConvertWithObserver_PreservesJumpDestLocations(t *testing.T) {
 			evm, lfvm int
 		}
 		var pairs []pair
-		res := convertWithObserver(code, ConversionConfig{}, func(evm, lfvm int) {
+		res := ConvertWithObserver(code, ConversionConfig{}, func(evm, lfvm int) {
 			pairs = append(pairs, pair{evm, lfvm})
 		})
 

--- a/go/interpreter/lfvm/converter_test.go
+++ b/go/interpreter/lfvm/converter_test.go
@@ -12,6 +12,7 @@ package lfvm
 
 import (
 	"math/rand"
+	"reflect"
 	"slices"
 	"sync"
 	"testing"
@@ -270,6 +271,107 @@ func TestConvertWithObserver_PreservesJumpDestLocations(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestConvertToLfvm_CodeWithSuperInstructions(t *testing.T) {
+	tests := map[string]struct {
+		evmCode []byte
+		want    Code
+	}{
+		"PUSH1PUSH4DUP3": {
+			[]byte{byte(vm.PUSH1), 0x01,
+				byte(vm.PUSH4), 0x01, 0x02, 0x03, 0x04,
+				byte(vm.DUP3)},
+			Code{Instruction{PUSH1_PUSH4_DUP3, 0x0100},
+				Instruction{DATA, 0x0102},
+				Instruction{DATA, 0x0304},
+			}},
+		"PUSH1_PUSH1_PUSH1_SHL_SUB": {
+			[]byte{byte(vm.PUSH1), 0x01,
+				byte(vm.PUSH1), 0x01,
+				byte(vm.PUSH1), 0x01,
+				byte(vm.SHL),
+				byte(vm.SUB)},
+			Code{Instruction{PUSH1_PUSH1_PUSH1_SHL_SUB, 0x0101},
+				Instruction{DATA, 0x0001},
+			}},
+		"AND_SWAP1_POP_SWAP2_SWAP1": {
+			[]byte{byte(vm.AND), byte(vm.SWAP1), byte(vm.POP),
+				byte(vm.SWAP2), byte(vm.SWAP1)},
+			Code{Instruction{AND_SWAP1_POP_SWAP2_SWAP1, 0x0000}}},
+		"ISZERO_PUSH2_JUMPI": {
+			[]byte{byte(vm.ISZERO),
+				byte(vm.PUSH2), 0x01, 0x02,
+				byte(vm.JUMPI)},
+			Code{Instruction{ISZERO_PUSH2_JUMPI, 0x0102}}},
+		"SWAP2_SWAP1_POP_JUMP": {
+			[]byte{byte(vm.SWAP2), byte(vm.SWAP1), byte(vm.POP),
+				byte(vm.JUMP)},
+			Code{Instruction{SWAP2_SWAP1_POP_JUMP, 0x0000}}},
+		"SWAP1_POP_SWAP2_SWAP1": {
+			[]byte{byte(vm.SWAP1), byte(vm.POP), byte(vm.SWAP2),
+				byte(vm.SWAP1)},
+			Code{Instruction{SWAP1_POP_SWAP2_SWAP1, 0x0000}}},
+		"POP_SWAP2_SWAP1_POP": {
+			[]byte{byte(vm.POP), byte(vm.SWAP2), byte(vm.SWAP1),
+				byte(vm.POP)},
+			Code{Instruction{POP_SWAP2_SWAP1_POP, 0x0000}}},
+		"PUSH2_JUMP": {
+			[]byte{byte(vm.PUSH2), 0x01, 0x02,
+				byte(vm.JUMP)},
+			Code{Instruction{PUSH2_JUMP, 0x0102}}},
+		"PUSH2_JUMPI": {
+			[]byte{byte(vm.PUSH2), 0x01, 0x02,
+				byte(vm.JUMPI)},
+			Code{Instruction{PUSH2_JUMPI, 0x0102}}},
+		"PUSH1_PUSH1": {
+			[]byte{byte(vm.PUSH1), 0x01,
+				byte(vm.PUSH1), 0x01},
+			Code{Instruction{PUSH1_PUSH1, 0x0101}}},
+		"PUSH1_ADD": {
+			[]byte{byte(vm.PUSH1), 0x01,
+				byte(vm.ADD)},
+			Code{Instruction{PUSH1_ADD, 0x0001}}},
+		"PUSH1_SHL": {
+			[]byte{byte(vm.PUSH1), 0x01,
+				byte(vm.SHL)},
+			Code{Instruction{PUSH1_SHL, 0x0001}}},
+		"PUSH1_DUP1": {
+			[]byte{byte(vm.PUSH1), 0x01,
+				byte(vm.DUP1)},
+			Code{Instruction{PUSH1_DUP1, 0x0001}}},
+		"SWAP1_POP": {
+			[]byte{byte(vm.SWAP1), byte(vm.POP)},
+			Code{Instruction{SWAP1_POP, 0x0000}}},
+		"POP_JUMP": {
+			[]byte{byte(vm.POP), byte(vm.JUMP)},
+			Code{Instruction{POP_JUMP, 0x0000}}},
+		"POP_POP": {
+			[]byte{byte(vm.POP), byte(vm.POP)},
+			Code{Instruction{POP_POP, 0x0000}}},
+		"SWAP2_SWAP1": {
+			[]byte{byte(vm.SWAP2), byte(vm.SWAP1)},
+			Code{Instruction{SWAP2_SWAP1, 0x0000}}},
+		"SWAP2_POP": {
+			[]byte{byte(vm.SWAP2), byte(vm.POP)},
+			Code{Instruction{SWAP2_POP, 0x0000}}},
+		"DUP2_MSTORE": {
+			[]byte{byte(vm.DUP2), byte(vm.MSTORE)},
+			Code{Instruction{DUP2_MSTORE, 0x0000}}},
+		"DUP2_LT": {
+			[]byte{byte(vm.DUP2), byte(vm.LT)},
+			Code{Instruction{DUP2_LT, 0x0000}}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			options := ConversionConfig{WithSuperInstructions: true}
+			got := convert(test.evmCode, options)
+			if !reflect.DeepEqual(test.want, got) {
+				t.Fatalf("unexpected code, wanted %v, got %v", test.want, got)
+			}
+		})
 	}
 }
 

--- a/go/interpreter/lfvm/ct/ct_test.go
+++ b/go/interpreter/lfvm/ct/ct_test.go
@@ -11,7 +11,6 @@
 package ct
 
 import (
-	"reflect"
 	"slices"
 	"testing"
 
@@ -222,107 +221,6 @@ func TestConvertToLfvm_Code(t *testing.T) {
 						t.Errorf("unexpected instruction, wanted %v, got %v", wantInst, gotInst)
 					}
 				}
-			}
-		})
-	}
-}
-
-func TestConvertToLfvm_CodeWithSuperInstructions(t *testing.T) {
-	tests := map[string]struct {
-		evmCode []byte
-		want    lfvm.Code
-	}{
-		"PUSH1PUSH4DUP3": {
-			[]byte{byte(vm.PUSH1), 0x01,
-				byte(vm.PUSH4), 0x01, 0x02, 0x03, 0x04,
-				byte(vm.DUP3)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.PUSH1_PUSH4_DUP3, 0x0100),
-				lfvm.NewInstruction(lfvm.DATA, 0x0102),
-				lfvm.NewInstruction(lfvm.DATA, 0x0304),
-			}},
-		"PUSH1_PUSH1_PUSH1_SHL_SUB": {
-			[]byte{byte(vm.PUSH1), 0x01,
-				byte(vm.PUSH1), 0x01,
-				byte(vm.PUSH1), 0x01,
-				byte(vm.SHL),
-				byte(vm.SUB)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.PUSH1_PUSH1_PUSH1_SHL_SUB, 0x0101),
-				lfvm.NewInstruction(lfvm.DATA, 0x0001),
-			}},
-		"AND_SWAP1_POP_SWAP2_SWAP1": {
-			[]byte{byte(vm.AND), byte(vm.SWAP1), byte(vm.POP),
-				byte(vm.SWAP2), byte(vm.SWAP1)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.AND_SWAP1_POP_SWAP2_SWAP1, 0x0000)}},
-		"ISZERO_PUSH2_JUMPI": {
-			[]byte{byte(vm.ISZERO),
-				byte(vm.PUSH2), 0x01, 0x02,
-				byte(vm.JUMPI)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.ISZERO_PUSH2_JUMPI, 0x0102)}},
-		"SWAP2_SWAP1_POP_JUMP": {
-			[]byte{byte(vm.SWAP2), byte(vm.SWAP1), byte(vm.POP),
-				byte(vm.JUMP)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.SWAP2_SWAP1_POP_JUMP, 0x0000)}},
-		"SWAP1_POP_SWAP2_SWAP1": {
-			[]byte{byte(vm.SWAP1), byte(vm.POP), byte(vm.SWAP2),
-				byte(vm.SWAP1)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.SWAP1_POP_SWAP2_SWAP1, 0x0000)}},
-		"POP_SWAP2_SWAP1_POP": {
-			[]byte{byte(vm.POP), byte(vm.SWAP2), byte(vm.SWAP1),
-				byte(vm.POP)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.POP_SWAP2_SWAP1_POP, 0x0000)}},
-		"PUSH2_JUMP": {
-			[]byte{byte(vm.PUSH2), 0x01, 0x02,
-				byte(vm.JUMP)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.PUSH2_JUMP, 0x0102)}},
-		"PUSH2_JUMPI": {
-			[]byte{byte(vm.PUSH2), 0x01, 0x02,
-				byte(vm.JUMPI)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.PUSH2_JUMPI, 0x0102)}},
-		"PUSH1_PUSH1": {
-			[]byte{byte(vm.PUSH1), 0x01,
-				byte(vm.PUSH1), 0x01},
-			lfvm.Code{lfvm.NewInstruction(lfvm.PUSH1_PUSH1, 0x0101)}},
-		"PUSH1_ADD": {
-			[]byte{byte(vm.PUSH1), 0x01,
-				byte(vm.ADD)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.PUSH1_ADD, 0x0001)}},
-		"PUSH1_SHL": {
-			[]byte{byte(vm.PUSH1), 0x01,
-				byte(vm.SHL)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.PUSH1_SHL, 0x0001)}},
-		"PUSH1_DUP1": {
-			[]byte{byte(vm.PUSH1), 0x01,
-				byte(vm.DUP1)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.PUSH1_DUP1, 0x0001)}},
-		"SWAP1_POP": {
-			[]byte{byte(vm.SWAP1), byte(vm.POP)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.SWAP1_POP, 0x0000)}},
-		"POP_JUMP": {
-			[]byte{byte(vm.POP), byte(vm.JUMP)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.POP_JUMP, 0x0000)}},
-		"POP_POP": {
-			[]byte{byte(vm.POP), byte(vm.POP)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.POP_POP, 0x0000)}},
-		"SWAP2_SWAP1": {
-			[]byte{byte(vm.SWAP2), byte(vm.SWAP1)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.SWAP2_SWAP1, 0x0000)}},
-		"SWAP2_POP": {
-			[]byte{byte(vm.SWAP2), byte(vm.POP)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.SWAP2_POP, 0x0000)}},
-		"DUP2_MSTORE": {
-			[]byte{byte(vm.DUP2), byte(vm.MSTORE)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.DUP2_MSTORE, 0x0000)}},
-		"DUP2_LT": {
-			[]byte{byte(vm.DUP2), byte(vm.LT)},
-			lfvm.Code{lfvm.NewInstruction(lfvm.DUP2_LT, 0x0000)}},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			options := lfvm.ConversionConfig{WithSuperInstructions: true}
-			got := lfvm.ConvertWithObserver(test.evmCode, options, func(int, int) {})
-			if !reflect.DeepEqual(test.want, got) {
-				t.Fatalf("unexpected code, wanted %v, got %v", test.want, got)
 			}
 		})
 	}

--- a/go/interpreter/lfvm/gas.go
+++ b/go/interpreter/lfvm/gas.go
@@ -328,7 +328,7 @@ func gasSStore(c *context) (tosca.Gas, error) {
 func gasSStoreEIP2200(c *context) (tosca.Gas, error) {
 	// If we fail the minimum gas availability invariant, fail (0)
 	if c.gas <= SstoreSentryGasEIP2200 {
-		c.status = StatusOutOfGas
+		c.SignalOutOfGas()
 		return 0, errors.New("not enough gas for reentrancy sentry")
 	}
 	// Gas sentry honoured, do the actual gas calculation based on the stored value
@@ -379,7 +379,7 @@ func gasSStoreEIP2929(c *context) (tosca.Gas, error) {
 
 	// If we fail the minimum gas availability invariant, fail (0)
 	if c.gas <= SstoreSentryGasEIP2200 {
-		c.status = StatusOutOfGas
+		c.SignalOutOfGas()
 		return 0, errors.New("not enough gas for reentrancy sentry")
 	}
 	// Gas sentry honoured, do the actual gas calculation based on the stored value

--- a/go/interpreter/lfvm/gas.go
+++ b/go/interpreter/lfvm/gas.go
@@ -328,7 +328,7 @@ func gasSStore(c *context) (tosca.Gas, error) {
 func gasSStoreEIP2200(c *context) (tosca.Gas, error) {
 	// If we fail the minimum gas availability invariant, fail (0)
 	if c.gas <= SstoreSentryGasEIP2200 {
-		c.status = statusOutOfGas
+		c.status = StatusOutOfGas
 		return 0, errors.New("not enough gas for reentrancy sentry")
 	}
 	// Gas sentry honoured, do the actual gas calculation based on the stored value
@@ -379,7 +379,7 @@ func gasSStoreEIP2929(c *context) (tosca.Gas, error) {
 
 	// If we fail the minimum gas availability invariant, fail (0)
 	if c.gas <= SstoreSentryGasEIP2200 {
-		c.status = statusOutOfGas
+		c.status = StatusOutOfGas
 		return 0, errors.New("not enough gas for reentrancy sentry")
 	}
 	// Gas sentry honoured, do the actual gas calculation based on the stored value
@@ -394,7 +394,7 @@ func gasSStoreEIP2929(c *context) (tosca.Gas, error) {
 	//lint:ignore SA1019 deprecated functions to be migrated in #616
 	if addrPresent, slotPresent := c.context.IsSlotInAccessList(c.params.Recipient, slot); !slotPresent {
 		if !addrPresent {
-			c.status = statusError
+			c.status = StatusError
 			return 0, errors.New("address was not present in access list during sstore op")
 		}
 		cost = ColdSloadCostEIP2929

--- a/go/interpreter/lfvm/instruction.go
+++ b/go/interpreter/lfvm/instruction.go
@@ -23,6 +23,11 @@ type Instruction struct {
 	arg uint16
 }
 
+// NewInstruction returns a new instruction with the given opcode and argument.
+func NewInstruction(op OpCode, arg uint16) Instruction {
+	return Instruction{opcode: op, arg: arg}
+}
+
 // Instruction stack boundaries for execution
 type InstructionStack struct {
 	// Minimum stack height because of pop or peek operations
@@ -36,6 +41,14 @@ type InstructionStack struct {
 
 // Code for the macro EVM is a slice of instructions
 type Code []Instruction
+
+func (c Code) IsIndexOp(index int, op OpCode) bool {
+	return c[index].opcode == JUMP_TO
+}
+
+func (c Code) GetArgOf(index int) uint16 {
+	return c[index].arg
+}
 
 func (i Instruction) String() string {
 	if i.opcode.HasArgument() {

--- a/go/interpreter/lfvm/instruction.go
+++ b/go/interpreter/lfvm/instruction.go
@@ -43,7 +43,7 @@ type InstructionStack struct {
 type Code []Instruction
 
 func (c Code) IsIndexOp(index int, op OpCode) bool {
-	return c[index].opcode == JUMP_TO
+	return c[index].opcode == op
 }
 
 func (c Code) GetArgOf(index int) uint16 {

--- a/go/interpreter/lfvm/instruction_statistics.go
+++ b/go/interpreter/lfvm/instruction_statistics.go
@@ -26,7 +26,7 @@ type statisticRunner struct {
 
 func (s *statisticRunner) run(c *context) {
 	stats := statsCollector{stats: newStatistics()}
-	for c.status == StatusRunning {
+	for c.IsRunning() {
 		stats.nextOp(c.code[c.pc].opcode)
 		Step(c)
 	}

--- a/go/interpreter/lfvm/instruction_statistics.go
+++ b/go/interpreter/lfvm/instruction_statistics.go
@@ -26,9 +26,9 @@ type statisticRunner struct {
 
 func (s *statisticRunner) run(c *context) {
 	stats := statsCollector{stats: newStatistics()}
-	for c.status == statusRunning {
+	for c.status == StatusRunning {
 		stats.nextOp(c.code[c.pc].opcode)
-		step(c)
+		Step(c)
 	}
 	s.mutex.Lock()
 	defer s.mutex.Unlock()

--- a/go/interpreter/lfvm/instruction_test.go
+++ b/go/interpreter/lfvm/instruction_test.go
@@ -12,6 +12,43 @@ package lfvm
 
 import "testing"
 
+func TestInstruction_NewInstruction(t *testing.T) {
+
+	instruction := NewInstruction(STOP, 0x0000)
+	if got, want := instruction.opcode, STOP; got != want {
+		t.Errorf("unexpected opcode, want %v, got = %v", want, got)
+	}
+	if got, want := instruction.arg, uint16(0x0000); got != want {
+		t.Errorf("unexpected arg, want %v, got %v", want, got)
+	}
+}
+
+func TestCode_IsIndexOp(t *testing.T) {
+	code := Code{
+		Instruction{opcode: STOP, arg: 0x0000},
+		Instruction{opcode: PUSH1, arg: 0x0001},
+	}
+	if want, got := STOP, code[0].opcode; !code.IsIndexOp(0, STOP) {
+		t.Errorf("unexpected code at position 0, want %v got %v", want, got)
+	}
+	if want, got := PUSH1, code[1]; code.IsIndexOp(1, STOP) {
+		t.Errorf("unexpected code at position 1, want %v got %v", want, got)
+	}
+}
+
+func TestCode_GetArgOf(t *testing.T) {
+	code := Code{
+		Instruction{opcode: STOP, arg: 0x0002},
+		Instruction{opcode: PUSH1, arg: 0x0001},
+	}
+	if want, got := uint16(0x0002), code.GetArgOf(0); got != want {
+		t.Errorf("unexpected arg at position 0, want %v, got %v", want, got)
+	}
+	if want, got := uint16(0x0001), code.GetArgOf(1); got != want {
+		t.Errorf("unexpected arg at position 1, want %v, got %v", want, got)
+	}
+}
+
 func TestInstruction_String(t *testing.T) {
 	instruction := Instruction{opcode: STOP, arg: 0x0000}
 	if got, want := instruction.String(), "STOP"; got != want {

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -19,23 +19,23 @@ import (
 )
 
 func opStop(c *context) {
-	c.status = statusStopped
+	c.status = StatusStopped
 }
 
 func opRevert(c *context) {
 	c.resultOffset = *c.stack.pop()
 	c.resultSize = *c.stack.pop()
-	c.status = statusReverted
+	c.status = StatusReverted
 }
 
 func opReturn(c *context) {
 	c.resultOffset = *c.stack.pop()
 	c.resultSize = *c.stack.pop()
-	c.status = statusReturned
+	c.status = StatusReturned
 }
 
 func opPc(c *context) {
-	c.stack.pushEmpty().SetUint64(uint64(c.code[c.pc].arg))
+	c.stack.PushEmpty().SetUint64(uint64(c.code[c.pc].arg))
 }
 
 func checkJumpDest(c *context) {
@@ -81,7 +81,7 @@ func opPop(c *context) {
 }
 
 func opPush(c *context, n int) {
-	z := c.stack.pushEmpty()
+	z := c.stack.PushEmpty()
 	num_instructions := int32(n/2 + n%2)
 	data := c.code[c.pc : c.pc+num_instructions]
 
@@ -100,27 +100,27 @@ func opPush(c *context, n int) {
 
 func opPush0(c *context) {
 	if c.isAtLeast(tosca.R12_Shanghai) {
-		z := c.stack.pushEmpty()
+		z := c.stack.PushEmpty()
 		z[3], z[2], z[1], z[0] = 0, 0, 0, 0
 	} else {
-		c.status = statusInvalidInstruction
+		c.status = StatusInvalidInstruction
 	}
 }
 
 func opPush1(c *context) {
-	z := c.stack.pushEmpty()
+	z := c.stack.PushEmpty()
 	z[3], z[2], z[1] = 0, 0, 0
 	z[0] = uint64(c.code[c.pc].arg >> 8)
 }
 
 func opPush2(c *context) {
-	z := c.stack.pushEmpty()
+	z := c.stack.PushEmpty()
 	z[3], z[2], z[1] = 0, 0, 0
 	z[0] = uint64(c.code[c.pc].arg)
 }
 
 func opPush3(c *context) {
-	z := c.stack.pushEmpty()
+	z := c.stack.PushEmpty()
 	z[3], z[2], z[1] = 0, 0, 0
 	data := c.code[c.pc : c.pc+2]
 	_ = data[1]
@@ -129,7 +129,7 @@ func opPush3(c *context) {
 }
 
 func opPush4(c *context) {
-	z := c.stack.pushEmpty()
+	z := c.stack.PushEmpty()
 	z[3], z[2], z[1] = 0, 0, 0
 
 	data := c.code[c.pc : c.pc+2]
@@ -139,7 +139,7 @@ func opPush4(c *context) {
 }
 
 func opPush32(c *context) {
-	z := c.stack.pushEmpty()
+	z := c.stack.PushEmpty()
 
 	data := c.code[c.pc : c.pc+16]
 	_ = data[15] // causes bound check to be performed only once (may become unneded in the future)
@@ -164,7 +164,7 @@ func opMstore(c *context) {
 
 	offset, overflow := addr.Uint64WithOverflow()
 	if overflow {
-		c.status = statusError
+		c.status = StatusError
 		return
 	}
 	if err := c.memory.SetWord(offset, value, c); err != nil {
@@ -178,7 +178,7 @@ func opMstore8(c *context) {
 
 	offset, overflow := addr.Uint64WithOverflow()
 	if overflow {
-		c.status = statusError
+		c.status = StatusError
 		return
 	}
 	if err := c.memory.SetByte(offset, byte(value.Uint64()), c); err != nil {
@@ -189,7 +189,7 @@ func opMstore8(c *context) {
 func opMcopy(c *context) {
 
 	if !c.isAtLeast(tosca.R13_Cancun) {
-		c.status = statusInvalidInstruction
+		c.status = StatusInvalidInstruction
 		c.gas = 0
 		return
 	}
@@ -206,7 +206,7 @@ func opMcopy(c *context) {
 	destOffset, destOverflow := destAddr.Uint64WithOverflow()
 	srcOffset, srcOverflow := srcAddr.Uint64WithOverflow()
 	if destOverflow || srcOverflow || !sizeU256.IsUint64() {
-		c.status = statusError
+		c.status = StatusError
 		return
 	}
 
@@ -240,7 +240,7 @@ func opMload(c *context) {
 }
 
 func opMsize(c *context) {
-	c.stack.pushEmpty().SetUint64(uint64(c.memory.Len()))
+	c.stack.PushEmpty().SetUint64(uint64(c.memory.Len()))
 }
 
 func opSstore(c *context) {
@@ -288,7 +288,7 @@ func opSload(c *context) {
 
 func opTstore(c *context) {
 	if !c.isAtLeast(tosca.R13_Cancun) {
-		c.status = statusInvalidInstruction
+		c.status = StatusInvalidInstruction
 		return
 	}
 
@@ -299,7 +299,7 @@ func opTstore(c *context) {
 
 func opTload(c *context) {
 	if !c.isAtLeast(tosca.R13_Cancun) {
-		c.status = statusInvalidInstruction
+		c.status = StatusInvalidInstruction
 		return
 	}
 
@@ -310,16 +310,16 @@ func opTload(c *context) {
 }
 
 func opCaller(c *context) {
-	c.stack.pushEmpty().SetBytes20(c.params.Sender[:])
+	c.stack.PushEmpty().SetBytes20(c.params.Sender[:])
 }
 
 func opCallvalue(c *context) {
-	c.stack.pushEmpty().SetBytes32(c.params.Value[:])
+	c.stack.PushEmpty().SetBytes32(c.params.Value[:])
 }
 
 func opCallDatasize(c *context) {
 	size := len(c.params.Input)
-	c.stack.pushEmpty().SetUint64(uint64(size))
+	c.stack.PushEmpty().SetUint64(uint64(size))
 }
 
 func opCallDataload(c *context) {
@@ -365,7 +365,7 @@ func opCallDataCopy(c *context) {
 
 	length64, overflow := length.Uint64WithOverflow()
 	if overflow || length64+31 < length64 {
-		c.status = statusOutOfGas
+		c.status = StatusOutOfGas
 		return
 	}
 
@@ -612,38 +612,38 @@ func opSha3(c *context) {
 }
 
 func opGas(c *context) {
-	c.stack.pushEmpty().SetUint64(uint64(c.gas))
+	c.stack.PushEmpty().SetUint64(uint64(c.gas))
 }
 
 // opPrevRandao / opDifficulty
 func opPrevRandao(c *context) {
 	prevRandao := c.params.PrevRandao
-	c.stack.pushEmpty().SetBytes32(prevRandao[:])
+	c.stack.PushEmpty().SetBytes32(prevRandao[:])
 }
 
 func opTimestamp(c *context) {
 	time := c.params.Timestamp
-	c.stack.pushEmpty().SetUint64(uint64(time))
+	c.stack.PushEmpty().SetUint64(uint64(time))
 }
 
 func opNumber(c *context) {
 	number := c.params.BlockNumber
-	c.stack.pushEmpty().SetUint64(uint64(number))
+	c.stack.PushEmpty().SetUint64(uint64(number))
 }
 
 func opCoinbase(c *context) {
 	coinbase := c.params.Coinbase
-	c.stack.pushEmpty().SetBytes20(coinbase[:])
+	c.stack.PushEmpty().SetBytes20(coinbase[:])
 }
 
 func opGasLimit(c *context) {
 	limit := c.params.GasLimit
-	c.stack.pushEmpty().SetUint64(uint64(limit))
+	c.stack.PushEmpty().SetUint64(uint64(limit))
 }
 
 func opGasPrice(c *context) {
 	price := c.params.GasPrice
-	c.stack.pushEmpty().SetBytes32(price[:])
+	c.stack.PushEmpty().SetBytes32(price[:])
 }
 
 func opBalance(c *context) {
@@ -659,40 +659,40 @@ func opBalance(c *context) {
 
 func opSelfbalance(c *context) {
 	balance := c.context.GetBalance(c.params.Recipient)
-	c.stack.pushEmpty().SetBytes32(balance[:])
+	c.stack.PushEmpty().SetBytes32(balance[:])
 }
 
 func opBaseFee(c *context) {
 	if c.isAtLeast(tosca.R10_London) {
 		fee := c.params.BaseFee
-		c.stack.pushEmpty().SetBytes32(fee[:])
+		c.stack.PushEmpty().SetBytes32(fee[:])
 	} else {
-		c.status = statusInvalidInstruction
+		c.status = StatusInvalidInstruction
 		return
 	}
 }
 
 func opBlobHash(c *context) {
 	if !c.isAtLeast(tosca.R13_Cancun) {
-		c.status = statusInvalidInstruction
+		c.status = StatusInvalidInstruction
 		return
 	}
 
 	index := c.stack.pop()
 	blobHashesLength := uint64(len(c.params.BlobHashes))
 	if index.IsUint64() && index.Uint64() < blobHashesLength {
-		c.stack.pushEmpty().SetBytes32(c.params.BlobHashes[index.Uint64()][:])
+		c.stack.PushEmpty().SetBytes32(c.params.BlobHashes[index.Uint64()][:])
 	} else {
-		c.stack.push(uint256.NewInt(0))
+		c.stack.Push(uint256.NewInt(0))
 	}
 }
 
 func opBlobBaseFee(c *context) {
 	if c.isAtLeast(tosca.R13_Cancun) {
 		fee := c.params.BlobBaseFee
-		c.stack.pushEmpty().SetBytes32(fee[:])
+		c.stack.PushEmpty().SetBytes32(fee[:])
 	} else {
-		c.status = statusInvalidInstruction
+		c.status = StatusInvalidInstruction
 		return
 	}
 }
@@ -708,12 +708,12 @@ func opSelfdestruct(c *context) {
 	}
 	beneficiary := tosca.Address(c.stack.pop().Bytes20())
 	c.context.SelfDestruct(c.params.Recipient, beneficiary)
-	c.status = statusSelfDestructed
+	c.status = StatusSelfDestructed
 }
 
 func opChainId(c *context) {
 	id := c.params.ChainID
-	c.stack.pushEmpty().SetBytes32(id[:])
+	c.stack.PushEmpty().SetBytes32(id[:])
 }
 
 func opBlockhash(c *context) {
@@ -740,17 +740,17 @@ func opBlockhash(c *context) {
 }
 
 func opAddress(c *context) {
-	c.stack.pushEmpty().SetBytes20(c.params.Recipient[:])
+	c.stack.PushEmpty().SetBytes20(c.params.Recipient[:])
 }
 
 func opOrigin(c *context) {
 	origin := c.params.Origin
-	c.stack.pushEmpty().SetBytes20(origin[:])
+	c.stack.PushEmpty().SetBytes20(origin[:])
 }
 
 func opCodeSize(c *context) {
 	size := len(c.params.Code)
-	c.stack.pushEmpty().SetUint64(uint64(size))
+	c.stack.PushEmpty().SetUint64(uint64(size))
 }
 
 func opCodeCopy(c *context) {
@@ -826,7 +826,7 @@ func checkInitCodeSize(c *context, size *uint256.Int) bool {
 		return false
 	}
 	if !c.useGas(tosca.Gas(InitCodeWordGas * tosca.SizeInWords(size.Uint64()))) {
-		c.status = statusOutOfGas
+		c.status = StatusOutOfGas
 		return false
 	}
 
@@ -857,7 +857,7 @@ func opCreate(c *context) {
 		balanceU256 := new(uint256.Int).SetBytes(balance[:])
 
 		if value.Gt(balanceU256) {
-			c.stack.pushEmpty().Clear()
+			c.stack.PushEmpty().Clear()
 			c.returnData = nil
 			return
 		}
@@ -882,7 +882,7 @@ func opCreate(c *context) {
 	c.gas += res.GasLeft
 	c.refund += res.GasRefund
 
-	success := c.stack.pushEmpty()
+	success := c.stack.PushEmpty()
 	if !res.Success || err != nil {
 		success.Clear()
 	} else {
@@ -927,7 +927,7 @@ func opCreate2(c *context) {
 		balanceU256 := new(uint256.Int).SetBytes(balance[:])
 
 		if value.Gt(balanceU256) {
-			c.stack.pushEmpty().Clear()
+			c.stack.PushEmpty().Clear()
 			c.returnData = nil
 			return
 		}
@@ -951,7 +951,7 @@ func opCreate2(c *context) {
 	})
 
 	// Push item on the stack based on the returned error.
-	success := c.stack.pushEmpty()
+	success := c.stack.PushEmpty()
 	if !res.Success || err != nil {
 		success.Clear()
 	} else {
@@ -1084,7 +1084,7 @@ func genericCall(c *context, kind tosca.CallKind) {
 		return 0 <= cost && cost <= c.gas
 	}
 	if !checkGas(baseGas) {
-		c.status = statusOutOfGas
+		c.status = StatusOutOfGas
 		return
 	}
 
@@ -1094,7 +1094,7 @@ func genericCall(c *context, kind tosca.CallKind) {
 		baseGas += CallValueTransferGas
 	}
 	if !checkGas(baseGas) {
-		c.status = statusOutOfGas
+		c.status = StatusOutOfGas
 		return
 	}
 
@@ -1104,7 +1104,7 @@ func genericCall(c *context, kind tosca.CallKind) {
 		baseGas += CallNewAccountGas
 	}
 	if !checkGas(baseGas) {
-		c.status = statusOutOfGas
+		c.status = StatusOutOfGas
 		return
 	}
 
@@ -1133,7 +1133,7 @@ func genericCall(c *context, kind tosca.CallKind) {
 		balance := c.context.GetBalance(c.params.Recipient)
 		balanceU256 := new(uint256.Int).SetBytes32(balance[:])
 		if balanceU256.Lt(value) {
-			c.stack.pushEmpty().Clear()
+			c.stack.PushEmpty().Clear()
 			c.returnData = nil
 			c.gas += cost // the gas send to the nested contract is returned
 			return
@@ -1184,7 +1184,7 @@ func genericCall(c *context, kind tosca.CallKind) {
 		}
 	}
 
-	success := stack.pushEmpty()
+	success := stack.PushEmpty()
 	if err != nil || !ret.Success {
 		success.Clear()
 	} else {
@@ -1218,7 +1218,7 @@ func opDelegateCall(c *context) {
 }
 
 func opReturnDataSize(c *context) {
-	c.stack.pushEmpty().SetUint64(uint64(len(c.returnData)))
+	c.stack.PushEmpty().SetUint64(uint64(len(c.returnData)))
 }
 
 func opReturnDataCopy(c *context) {

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -365,7 +365,7 @@ func opCallDataCopy(c *context) {
 
 	length64, overflow := length.Uint64WithOverflow()
 	if overflow || length64+31 < length64 {
-		c.status = StatusOutOfGas
+		c.SignalOutOfGas()
 		return
 	}
 
@@ -826,7 +826,7 @@ func checkInitCodeSize(c *context, size *uint256.Int) bool {
 		return false
 	}
 	if !c.useGas(tosca.Gas(InitCodeWordGas * tosca.SizeInWords(size.Uint64()))) {
-		c.status = StatusOutOfGas
+		c.SignalOutOfGas()
 		return false
 	}
 
@@ -1084,7 +1084,7 @@ func genericCall(c *context, kind tosca.CallKind) {
 		return 0 <= cost && cost <= c.gas
 	}
 	if !checkGas(baseGas) {
-		c.status = StatusOutOfGas
+		c.SignalOutOfGas()
 		return
 	}
 
@@ -1094,7 +1094,7 @@ func genericCall(c *context, kind tosca.CallKind) {
 		baseGas += CallValueTransferGas
 	}
 	if !checkGas(baseGas) {
-		c.status = StatusOutOfGas
+		c.SignalOutOfGas()
 		return
 	}
 
@@ -1104,7 +1104,7 @@ func genericCall(c *context, kind tosca.CallKind) {
 		baseGas += CallNewAccountGas
 	}
 	if !checkGas(baseGas) {
-		c.status = StatusOutOfGas
+		c.SignalOutOfGas()
 		return
 	}
 

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -41,8 +41,8 @@ func TestPushN(t *testing.T) {
 		opPush(&ctxt, n)
 		ctxt.pc++
 
-		if ctxt.stack.len() != 1 {
-			t.Errorf("expected stack size of 1, got %d", ctxt.stack.len())
+		if ctxt.stack.Len() != 1 {
+			t.Errorf("expected stack size of 1, got %d", ctxt.stack.Len())
 			return
 		}
 
@@ -76,8 +76,8 @@ func TestPush1(t *testing.T) {
 	opPush1(&ctxt)
 	ctxt.pc++
 
-	if ctxt.stack.len() != 1 {
-		t.Errorf("expected stack size of 1, got %d", ctxt.stack.len())
+	if ctxt.stack.Len() != 1 {
+		t.Errorf("expected stack size of 1, got %d", ctxt.stack.Len())
 		return
 	}
 
@@ -107,8 +107,8 @@ func TestPush2(t *testing.T) {
 	opPush2(&ctxt)
 	ctxt.pc++
 
-	if ctxt.stack.len() != 1 {
-		t.Errorf("expected stack size of 1, got %d", ctxt.stack.len())
+	if ctxt.stack.Len() != 1 {
+		t.Errorf("expected stack size of 1, got %d", ctxt.stack.Len())
 		return
 	}
 
@@ -142,8 +142,8 @@ func TestPush3(t *testing.T) {
 	opPush3(&ctxt)
 	ctxt.pc++
 
-	if ctxt.stack.len() != 1 {
-		t.Errorf("expected stack size of 1, got %d", ctxt.stack.len())
+	if ctxt.stack.Len() != 1 {
+		t.Errorf("expected stack size of 1, got %d", ctxt.stack.Len())
 		return
 	}
 
@@ -180,8 +180,8 @@ func TestPush4(t *testing.T) {
 	opPush4(&ctxt)
 	ctxt.pc++
 
-	if ctxt.stack.len() != 1 {
-		t.Errorf("expected stack size of 1, got %d", ctxt.stack.len())
+	if ctxt.stack.Len() != 1 {
+		t.Errorf("expected stack size of 1, got %d", ctxt.stack.Len())
 		return
 	}
 
@@ -214,7 +214,7 @@ func TestCallChecksBalances(t *testing.T) {
 	source := tosca.Address{1}
 	target := tosca.Address{2}
 	ctxt := context{
-		status: statusRunning,
+		status: StatusRunning,
 		params: tosca.Parameters{
 			Recipient: source,
 		},
@@ -235,11 +235,11 @@ func TestCallChecksBalances(t *testing.T) {
 
 	opCall(&ctxt)
 
-	if want, got := statusRunning, ctxt.status; want != got {
+	if want, got := StatusRunning, ctxt.status; want != got {
 		t.Errorf("unexpected status after call, wanted %v, got %v", want, got)
 	}
 
-	if want, got := 1, ctxt.stack.len(); want != got {
+	if want, got := 1, ctxt.stack.Len(); want != got {
 		t.Fatalf("unexpected stack size, wanted %d, got %d", want, got)
 	}
 
@@ -254,7 +254,7 @@ func TestCreateChecksBalance(t *testing.T) {
 
 	source := tosca.Address{1}
 	ctxt := context{
-		status: statusRunning,
+		status: StatusRunning,
 		params: tosca.Parameters{
 			Recipient: source,
 		},
@@ -273,11 +273,11 @@ func TestCreateChecksBalance(t *testing.T) {
 
 	opCreate(&ctxt)
 
-	if want, got := statusRunning, ctxt.status; want != got {
+	if want, got := StatusRunning, ctxt.status; want != got {
 		t.Errorf("unexpected status after call, wanted %v, got %v", want, got)
 	}
 
-	if want, got := 1, ctxt.stack.len(); want != got {
+	if want, got := 1, ctxt.stack.Len(); want != got {
 		t.Fatalf("unexpected stack size, wanted %d, got %d", want, got)
 	}
 
@@ -296,23 +296,23 @@ func TestLogOpSizeOverflow(t *testing.T) {
 		logn     int
 		size     *uint256.Int
 		logCalls int
-		want     status
+		want     Status
 	}{
-		"log0_zero":        {logn: 0, size: zero, logCalls: 1, want: statusRunning},
-		"log1_zero":        {logn: 1, size: zero, logCalls: 1, want: statusRunning},
-		"log2_zero":        {logn: 2, size: zero, logCalls: 1, want: statusRunning},
-		"log3_zero":        {logn: 3, size: zero, logCalls: 1, want: statusRunning},
-		"log4_zero":        {logn: 4, size: zero, logCalls: 1, want: statusRunning},
-		"log0_max":         {logn: 0, size: maxUint64, logCalls: 0, want: statusOutOfGas},
-		"log1_max":         {logn: 1, size: maxUint64, logCalls: 0, want: statusOutOfGas},
-		"log2_max":         {logn: 2, size: maxUint64, logCalls: 0, want: statusOutOfGas},
-		"log3_max":         {logn: 3, size: maxUint64, logCalls: 0, want: statusOutOfGas},
-		"log4_max":         {logn: 4, size: maxUint64, logCalls: 0, want: statusOutOfGas},
-		"log0_much_larger": {logn: 0, size: originalBugValue, logCalls: 0, want: statusOutOfGas},
-		"log1_much_larger": {logn: 1, size: originalBugValue, logCalls: 0, want: statusOutOfGas},
-		"log2_much_larger": {logn: 2, size: originalBugValue, logCalls: 0, want: statusOutOfGas},
-		"log3_much_larger": {logn: 3, size: originalBugValue, logCalls: 0, want: statusOutOfGas},
-		"log4_much_larger": {logn: 4, size: originalBugValue, logCalls: 0, want: statusOutOfGas},
+		"log0_zero":        {logn: 0, size: zero, logCalls: 1, want: StatusRunning},
+		"log1_zero":        {logn: 1, size: zero, logCalls: 1, want: StatusRunning},
+		"log2_zero":        {logn: 2, size: zero, logCalls: 1, want: StatusRunning},
+		"log3_zero":        {logn: 3, size: zero, logCalls: 1, want: StatusRunning},
+		"log4_zero":        {logn: 4, size: zero, logCalls: 1, want: StatusRunning},
+		"log0_max":         {logn: 0, size: maxUint64, logCalls: 0, want: StatusOutOfGas},
+		"log1_max":         {logn: 1, size: maxUint64, logCalls: 0, want: StatusOutOfGas},
+		"log2_max":         {logn: 2, size: maxUint64, logCalls: 0, want: StatusOutOfGas},
+		"log3_max":         {logn: 3, size: maxUint64, logCalls: 0, want: StatusOutOfGas},
+		"log4_max":         {logn: 4, size: maxUint64, logCalls: 0, want: StatusOutOfGas},
+		"log0_much_larger": {logn: 0, size: originalBugValue, logCalls: 0, want: StatusOutOfGas},
+		"log1_much_larger": {logn: 1, size: originalBugValue, logCalls: 0, want: StatusOutOfGas},
+		"log2_much_larger": {logn: 2, size: originalBugValue, logCalls: 0, want: StatusOutOfGas},
+		"log3_much_larger": {logn: 3, size: originalBugValue, logCalls: 0, want: StatusOutOfGas},
+		"log4_much_larger": {logn: 4, size: originalBugValue, logCalls: 0, want: StatusOutOfGas},
 	}
 
 	for name, test := range tests {
@@ -324,13 +324,13 @@ func TestLogOpSizeOverflow(t *testing.T) {
 
 			stack := NewStack()
 			for i := 0; i < test.logn; i++ {
-				stack.push(uint256.NewInt(0))
+				stack.Push(uint256.NewInt(0))
 			}
-			stack.push(test.size)
-			stack.push(uint256.NewInt(0))
+			stack.Push(test.size)
+			stack.Push(uint256.NewInt(0))
 
 			ctxt := context{
-				status:  statusRunning,
+				status:  StatusRunning,
 				gas:     392,
 				context: runContext,
 				stack:   stack,
@@ -354,42 +354,42 @@ func TestBlobHash(t *testing.T) {
 		setup    func(*tosca.Parameters, *Stack)
 		gas      tosca.Gas
 		revision tosca.Revision
-		status   status
+		status   Status
 		want     tosca.Hash
 	}{
 		"regular": {
 			setup: func(params *tosca.Parameters, stack *Stack) {
-				stack.push(uint256.NewInt(0))
+				stack.Push(uint256.NewInt(0))
 				params.BlobHashes = []tosca.Hash{hash}
 			},
 			gas:      2,
 			revision: tosca.R13_Cancun,
-			status:   statusRunning,
+			status:   StatusRunning,
 			want:     hash,
 		},
 		"old-revision": {
 			setup:    func(params *tosca.Parameters, stack *Stack) {},
 			gas:      2,
 			revision: tosca.R12_Shanghai,
-			status:   statusInvalidInstruction,
+			status:   StatusInvalidInstruction,
 			want:     tosca.Hash{},
 		},
 		"no-hashes": {
 			setup: func(params *tosca.Parameters, stack *Stack) {
-				stack.push(uint256.NewInt(0))
+				stack.Push(uint256.NewInt(0))
 			},
 			gas:      2,
 			revision: tosca.R13_Cancun,
-			status:   statusRunning,
+			status:   StatusRunning,
 			want:     tosca.Hash{},
 		},
 		"target-non-existent": {
 			setup: func(params *tosca.Parameters, stack *Stack) {
-				stack.push(uint256.NewInt(1))
+				stack.Push(uint256.NewInt(1))
 			},
 			gas:      2,
 			revision: tosca.R13_Cancun,
-			status:   statusRunning,
+			status:   StatusRunning,
 			want:     tosca.Hash{},
 		},
 	}
@@ -398,7 +398,7 @@ func TestBlobHash(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			ctxt := context{
-				status: statusRunning,
+				status: StatusRunning,
 				params: tosca.Parameters{
 					Recipient: tosca.Address{1},
 				},
@@ -415,7 +415,7 @@ func TestBlobHash(t *testing.T) {
 			if ctxt.status != test.status {
 				t.Fatalf("unexpected status, wanted %v, got %v", test.status, ctxt.status)
 			}
-			if want, got := test.want, ctxt.stack.data[0]; tosca.Hash(got.Bytes32()) != want && ctxt.status == statusRunning {
+			if want, got := test.want, ctxt.stack.data[0]; tosca.Hash(got.Bytes32()) != want && ctxt.status == StatusRunning {
 				t.Fatalf("unexpected value on top of stack, wanted %v, got %v", want, got)
 			}
 		})
@@ -430,7 +430,7 @@ func TestBlobBaseFee(t *testing.T) {
 		setup    func(*tosca.Parameters)
 		gas      tosca.Gas
 		revision tosca.Revision
-		status   status
+		status   Status
 		want     tosca.Value
 	}{
 		"regular": {
@@ -439,14 +439,14 @@ func TestBlobBaseFee(t *testing.T) {
 			},
 			gas:      2,
 			revision: tosca.R13_Cancun,
-			status:   statusRunning,
+			status:   StatusRunning,
 			want:     blobBaseFeeValue,
 		},
 		"old-revision": {
 			setup:    func(*tosca.Parameters) {},
 			gas:      2,
 			revision: tosca.R12_Shanghai,
-			status:   statusInvalidInstruction,
+			status:   StatusInvalidInstruction,
 			want:     tosca.Value{},
 		},
 	}
@@ -455,7 +455,7 @@ func TestBlobBaseFee(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			ctxt := context{
-				status: statusRunning,
+				status: StatusRunning,
 				params: tosca.Parameters{
 					Recipient: tosca.Address{1},
 				},
@@ -472,7 +472,7 @@ func TestBlobBaseFee(t *testing.T) {
 			if ctxt.status != test.status {
 				t.Fatalf("unexpected status, wanted %v, got %v", test.status, ctxt.status)
 			}
-			if want, got := test.want, ctxt.stack.data[0]; got.Cmp(new(uint256.Int).SetBytes(want[:])) != 0 && ctxt.status == statusRunning {
+			if want, got := test.want, ctxt.stack.data[0]; got.Cmp(new(uint256.Int).SetBytes(want[:])) != 0 && ctxt.status == StatusRunning {
 				t.Fatalf("unexpected value on top of stack, wanted %v, got %v", want, got)
 			}
 		})
@@ -488,7 +488,7 @@ func TestMCopy(t *testing.T) {
 		src            uint64
 		size           uint64
 		memSize        uint64
-		expectedStatus status
+		expectedStatus Status
 		memoryBefore   []byte
 		memoryAfter    []byte
 	}{
@@ -499,7 +499,7 @@ func TestMCopy(t *testing.T) {
 			dest:           0,
 			src:            0,
 			size:           0,
-			expectedStatus: statusRunning,
+			expectedStatus: StatusRunning,
 			memoryBefore: []byte{
 				1, 2, 3, 4, 5, 6, 7, 8, // 0-7
 				0, 0, 0, 0, 0, 0, 0, 0, // 8-15
@@ -515,7 +515,7 @@ func TestMCopy(t *testing.T) {
 		},
 		"old-revision": {
 			revision:       tosca.R12_Shanghai,
-			expectedStatus: statusInvalidInstruction,
+			expectedStatus: StatusInvalidInstruction,
 		},
 		"copy": {
 			revision:       tosca.R13_Cancun,
@@ -524,7 +524,7 @@ func TestMCopy(t *testing.T) {
 			dest:           1,
 			src:            0,
 			size:           8,
-			expectedStatus: statusRunning,
+			expectedStatus: StatusRunning,
 			memoryBefore: []byte{
 				1, 2, 3, 4, 5, 6, 7, 8, // 0-7
 				0, 0, 0, 0, 0, 0, 0, 0, // 8-15
@@ -545,7 +545,7 @@ func TestMCopy(t *testing.T) {
 			dest:           32,
 			src:            0,
 			size:           4,
-			expectedStatus: statusRunning,
+			expectedStatus: StatusRunning,
 			memoryBefore: []byte{
 				1, 2, 3, 4, 0, 0, 0, 0, // 0-7
 				0, 0, 0, 0, 0, 0, 0, 0, // 8-15
@@ -569,15 +569,15 @@ func TestMCopy(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			ctxt := context{
-				status: statusRunning,
+				status: StatusRunning,
 				stack:  NewStack(),
 				memory: NewMemory(),
 			}
 			ctxt.params.Revision = test.revision
 			ctxt.gas = test.gasBefore
-			ctxt.stack.push(uint256.NewInt(test.size))
-			ctxt.stack.push(uint256.NewInt(test.src))
-			ctxt.stack.push(uint256.NewInt(test.dest))
+			ctxt.stack.Push(uint256.NewInt(test.size))
+			ctxt.stack.Push(uint256.NewInt(test.src))
+			ctxt.stack.Push(uint256.NewInt(test.dest))
 			ctxt.memory.store = append(ctxt.memory.store, test.memoryBefore...)
 
 			opMcopy(&ctxt)
@@ -604,25 +604,25 @@ func TestCreateShanghaiInitCodeSize(t *testing.T) {
 	tests := map[string]struct {
 		revision       tosca.Revision
 		init_code_size uint64
-		expected       status
+		expected       Status
 	}{
-		"paris-0-running":         {tosca.R11_Paris, 0, statusRunning},
-		"paris-1-running":         {tosca.R11_Paris, 1, statusRunning},
-		"paris-2k-running":        {tosca.R11_Paris, 2000, statusRunning},
-		"paris-max-1-running":     {tosca.R11_Paris, maxInitCodeSize - 1, statusRunning},
-		"paris-max-running":       {tosca.R11_Paris, maxInitCodeSize, statusRunning},
-		"paris-max+1-running":     {tosca.R11_Paris, maxInitCodeSize + 1, statusRunning},
-		"paris-100k-running":      {tosca.R11_Paris, 100000, statusRunning},
-		"paris-maxuint64-running": {tosca.R11_Paris, math.MaxUint64, statusOutOfGas},
+		"paris-0-running":         {tosca.R11_Paris, 0, StatusRunning},
+		"paris-1-running":         {tosca.R11_Paris, 1, StatusRunning},
+		"paris-2k-running":        {tosca.R11_Paris, 2000, StatusRunning},
+		"paris-max-1-running":     {tosca.R11_Paris, maxInitCodeSize - 1, StatusRunning},
+		"paris-max-running":       {tosca.R11_Paris, maxInitCodeSize, StatusRunning},
+		"paris-max+1-running":     {tosca.R11_Paris, maxInitCodeSize + 1, StatusRunning},
+		"paris-100k-running":      {tosca.R11_Paris, 100000, StatusRunning},
+		"paris-maxuint64-running": {tosca.R11_Paris, math.MaxUint64, StatusOutOfGas},
 
-		"shanghai-0-running":         {tosca.R12_Shanghai, 0, statusRunning},
-		"shanghai-1-running":         {tosca.R12_Shanghai, 1, statusRunning},
-		"shanghai-2k-running":        {tosca.R12_Shanghai, 2000, statusRunning},
-		"shanghai-max-1-running":     {tosca.R12_Shanghai, maxInitCodeSize - 1, statusRunning},
-		"shanghai-max-running":       {tosca.R12_Shanghai, maxInitCodeSize, statusRunning},
-		"shanghai-max+1-running":     {tosca.R12_Shanghai, maxInitCodeSize + 1, statusError},
-		"shanghai-100k-running":      {tosca.R12_Shanghai, 100000, statusError},
-		"shanghai-maxuint64-running": {tosca.R12_Shanghai, math.MaxUint64, statusOutOfGas},
+		"shanghai-0-running":         {tosca.R12_Shanghai, 0, StatusRunning},
+		"shanghai-1-running":         {tosca.R12_Shanghai, 1, StatusRunning},
+		"shanghai-2k-running":        {tosca.R12_Shanghai, 2000, StatusRunning},
+		"shanghai-max-1-running":     {tosca.R12_Shanghai, maxInitCodeSize - 1, StatusRunning},
+		"shanghai-max-running":       {tosca.R12_Shanghai, maxInitCodeSize, StatusRunning},
+		"shanghai-max+1-running":     {tosca.R12_Shanghai, maxInitCodeSize + 1, StatusError},
+		"shanghai-100k-running":      {tosca.R12_Shanghai, 100000, StatusError},
+		"shanghai-maxuint64-running": {tosca.R12_Shanghai, math.MaxUint64, StatusOutOfGas},
 	}
 
 	for name, test := range tests {
@@ -632,7 +632,7 @@ func TestCreateShanghaiInitCodeSize(t *testing.T) {
 
 			source := tosca.Address{1}
 			ctxt := context{
-				status: statusRunning,
+				status: StatusRunning,
 				params: tosca.Parameters{
 					BlockParameters: tosca.BlockParameters{
 						Revision: test.revision,
@@ -649,7 +649,7 @@ func TestCreateShanghaiInitCodeSize(t *testing.T) {
 			ctxt.stack.stack_ptr = 3
 			ctxt.stack.data[0].Set(uint256.NewInt(test.init_code_size))
 
-			if test.expected == statusRunning {
+			if test.expected == StatusRunning {
 				runContext.EXPECT().Call(tosca.Create, gomock.Any()).Return(tosca.CallResult{}, nil)
 			}
 
@@ -700,7 +700,7 @@ func TestCreateShanghaiDeploymentCost(t *testing.T) {
 
 		source := tosca.Address{1}
 		ctxt := context{
-			status: statusRunning,
+			status: StatusRunning,
 			params: tosca.Parameters{
 				BlockParameters: tosca.BlockParameters{
 					Revision: test.revision,
@@ -721,7 +721,7 @@ func TestCreateShanghaiDeploymentCost(t *testing.T) {
 
 		opCreate(&ctxt)
 
-		if ctxt.status != statusRunning {
+		if ctxt.status != StatusRunning {
 			t.Errorf("unexpected status after call, wanted RUNNING, got %v", ctxt.status)
 		}
 
@@ -737,7 +737,7 @@ func TestTransientStorageOperations(t *testing.T) {
 		setup    func(*tosca.MockRunContext)
 		stackPtr int
 		revision tosca.Revision
-		status   status
+		status   Status
 	}{
 		"tload-regular": {
 			op: opTload,
@@ -746,14 +746,14 @@ func TestTransientStorageOperations(t *testing.T) {
 			},
 			stackPtr: 1,
 			revision: tosca.R13_Cancun,
-			status:   statusRunning,
+			status:   StatusRunning,
 		},
 		"tload-old-revision": {
 			op:       opTload,
 			setup:    func(runContext *tosca.MockRunContext) {},
 			stackPtr: 1,
 			revision: tosca.R11_Paris,
-			status:   statusInvalidInstruction,
+			status:   StatusInvalidInstruction,
 		},
 		"tstore-regular": {
 			op: opTstore,
@@ -762,14 +762,14 @@ func TestTransientStorageOperations(t *testing.T) {
 			},
 			stackPtr: 2,
 			revision: tosca.R13_Cancun,
-			status:   statusRunning,
+			status:   StatusRunning,
 		},
 		"tstore-old-revision": {
 			op:       opTstore,
 			setup:    func(runContext *tosca.MockRunContext) {},
 			stackPtr: 2,
 			revision: tosca.R11_Paris,
-			status:   statusInvalidInstruction,
+			status:   StatusInvalidInstruction,
 		},
 	}
 
@@ -777,7 +777,7 @@ func TestTransientStorageOperations(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			ctxt := context{
-				status: statusRunning,
+				status: StatusRunning,
 				params: tosca.Parameters{
 					BlockParameters: tosca.BlockParameters{
 						Revision: test.revision,
@@ -856,7 +856,7 @@ func TestExpansionCostOverflow(t *testing.T) {
 								Revision: tosca.R13_Cancun,
 							},
 						},
-						status:  statusRunning,
+						status:  StatusRunning,
 						stack:   NewStack(),
 						memory:  NewMemory(),
 						context: runContext,
@@ -872,7 +872,7 @@ func TestExpansionCostOverflow(t *testing.T) {
 
 					test.op(&ctxt)
 
-					if ctxt.status != statusOutOfGas && ctxt.status != statusError {
+					if ctxt.status != StatusOutOfGas && ctxt.status != StatusError {
 						t.Errorf("unexpected status, wanted not running, got %v, and gas of %v", ctxt.status, ctxt.gas)
 					}
 				})

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -823,6 +823,76 @@ func TestStepsFailsOnTooLittleGas(t *testing.T) {
 	}
 }
 
+func TestNewContextContainsSpecifiedValues(t *testing.T) {
+
+	runCtxt := tosca.NewMockRunContext(gomock.NewController(t))
+	runCtxt.EXPECT().AccountExists(tosca.Address{1}).Return(true)
+
+	wantValue := tosca.NewValue(10)
+	wantCode := Code{NewInstruction(PUSH1, 0), NewInstruction(STOP, 0)}
+	wantStatus := StatusRunning
+	wantPc := int32(1)
+	wantGas := tosca.Gas(10)
+	wantRefund := tosca.Gas(10)
+	wantStack := NewStack()
+	wantStack.Push(uint256.NewInt(10))
+	wantMemory := NewMemory()
+	wantMemory.Set(uint64(1), uint64(1), []byte{0x1})
+	wantReturnData := []byte{0x10}
+
+	ctxtParams := ContextParams{
+		Params: tosca.Parameters{
+			Value:   wantValue,
+			Gas:     wantGas,
+			Context: runCtxt,
+		},
+		Code:         wantCode,
+		Status:       wantStatus,
+		Pc:           wantPc,
+		Refund:       wantRefund,
+		Stack:        wantStack,
+		Memory:       wantMemory,
+		ReturnData:   wantReturnData,
+		WithShaCache: true,
+	}
+
+	ctxt := NewContext(ctxtParams)
+
+	if ctxt.params.Value.Cmp(wantValue) != 0 {
+		t.Errorf("unexpected value: want %v, got %v", wantValue, ctxt.params.Value)
+	}
+	if !ctxt.context.AccountExists(tosca.Address{1}) {
+		t.Errorf("unexpected context: want %v, got %v", runCtxt, ctxt.context)
+	}
+	if !reflect.DeepEqual(ctxt.code, wantCode) {
+		t.Errorf("unexpected code: want %v, got %v", wantCode, ctxt.code)
+	}
+	if ctxt.GetStatus() != wantStatus {
+		t.Errorf("unexpected status: want %v, got %v", wantStatus, ctxt.status)
+	}
+	if ctxt.GetPc() != wantPc {
+		t.Errorf("unexpected pc: want %v, got %v", wantPc, ctxt.pc)
+	}
+	if ctxt.GetGas() != wantGas {
+		t.Errorf("unexpected gas: want %v, got %v", wantGas, ctxt.gas)
+	}
+	if ctxt.GetRefund() != wantRefund {
+		t.Errorf("unexpected refund: want %v, got %v", wantRefund, ctxt.refund)
+	}
+	if !reflect.DeepEqual(ctxt.GetStack(), wantStack) {
+		t.Errorf("unexpected stack: want %v, got %v", wantStack, ctxt.stack)
+	}
+	if !reflect.DeepEqual(ctxt.GetMemory(), wantMemory) {
+		t.Errorf("unexpected memory: want %v, got %v", wantMemory, ctxt.memory)
+	}
+	if !reflect.DeepEqual(ctxt.GetReturnData(), wantReturnData) {
+		t.Errorf("unexpected return data: want %v, got %v", wantReturnData, ctxt.returnData)
+	}
+	if !ctxt.withShaCache {
+		t.Errorf("unexpected WithshaCache value: want true, got %v", ctxt.withShaCache)
+	}
+}
+
 func getFibExample() example {
 	// An implementation of the fib function in EVM byte code.
 	code, err := hex.DecodeString("608060405234801561001057600080fd5b506004361061002b5760003560e01c8063f9b7c7e514610030575b600080fd5b61004a600480360381019061004591906100f6565b610060565b6040516100579190610132565b60405180910390f35b600060018263ffffffff161161007957600190506100b0565b61008e600283610089919061017c565b610060565b6100a360018461009e919061017c565b610060565b6100ad91906101b4565b90505b919050565b600080fd5b600063ffffffff82169050919050565b6100d3816100ba565b81146100de57600080fd5b50565b6000813590506100f0816100ca565b92915050565b60006020828403121561010c5761010b6100b5565b5b600061011a848285016100e1565b91505092915050565b61012c816100ba565b82525050565b60006020820190506101476000830184610123565b92915050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b6000610187826100ba565b9150610192836100ba565b9250828203905063ffffffff8111156101ae576101ad61014d565b5b92915050565b60006101bf826100ba565b91506101ca836100ba565b9250828201905063ffffffff8111156101e6576101e561014d565b5b9291505056fea26469706673582212207fd33e47e97ce5871bb05401e6710238af535ae8aeaab013ca9a9c29152b8a1b64736f6c637827302e382e31372d646576656c6f702e323032322e382e392b636f6d6d69742e62623161386466390058")

--- a/go/interpreter/lfvm/lfvm.go
+++ b/go/interpreter/lfvm/lfvm.go
@@ -79,10 +79,10 @@ func NewVm(config Config) (*VM, error) {
 }
 
 // Defines the newest supported revision for this interpreter implementation
-const newestSupportedRevision = tosca.R13_Cancun
+const NewestSupportedRevision = tosca.R13_Cancun
 
 func (v *VM) Run(params tosca.Parameters) (tosca.Result, error) {
-	if params.Revision > newestSupportedRevision {
+	if params.Revision > NewestSupportedRevision {
 		return tosca.Result{}, &tosca.ErrUnsupportedRevision{Revision: params.Revision}
 	}
 

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -82,7 +82,7 @@ func (m *Memory) EnsureCapacity(offset, size uint64, c *context) error {
 		needed = toValidMemorySize(needed)
 		fee := m.ExpansionCosts(needed)
 		if !c.useGas(fee) {
-			c.status = statusOutOfGas
+			c.status = StatusOutOfGas
 			return errOutOfGas
 		}
 		m.total_memory_cost += fee

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -82,7 +82,7 @@ func (m *Memory) EnsureCapacity(offset, size uint64, c *context) error {
 		needed = toValidMemorySize(needed)
 		fee := m.ExpansionCosts(needed)
 		if !c.useGas(fee) {
-			c.status = StatusOutOfGas
+			c.SignalOutOfGas()
 			return errOutOfGas
 		}
 		m.total_memory_cost += fee

--- a/go/interpreter/lfvm/stack.go
+++ b/go/interpreter/lfvm/stack.go
@@ -20,7 +20,7 @@ import (
 
 var staticStackBoundary = [NUM_OPCODES]InstructionStack{}
 
-const stackLimit = 1024 // Maximum size of VM stack allowed.
+const StackLimit = 1024 // Maximum size of VM stack allowed.
 
 type Stack struct {
 	data      [1024]uint256.Int
@@ -37,12 +37,12 @@ func (s *Stack) Data() []uint256.Int {
 	return s.data[:s.stack_ptr]
 }
 
-func (s *Stack) push(d *uint256.Int) {
+func (s *Stack) Push(d *uint256.Int) {
 	s.data[s.stack_ptr] = *d
 	s.stack_ptr++
 }
 
-func (s *Stack) pushEmpty() *uint256.Int {
+func (s *Stack) PushEmpty() *uint256.Int {
 	s.stack_ptr++
 	return &s.data[s.stack_ptr-1]
 }
@@ -52,12 +52,12 @@ func (s *Stack) pop() *uint256.Int {
 	return &s.data[s.stack_ptr]
 }
 
-func (s *Stack) len() int {
+func (s *Stack) Len() int {
 	return s.stack_ptr
 }
 
 func (s *Stack) swap(n int) {
-	s.data[s.len()-n], s.data[s.len()-1] = s.data[s.len()-1], s.data[s.len()-n]
+	s.data[s.Len()-n], s.data[s.Len()-1] = s.data[s.Len()-1], s.data[s.Len()-n]
 }
 
 func (s *Stack) dup(n int) {
@@ -66,11 +66,11 @@ func (s *Stack) dup(n int) {
 }
 
 func (s *Stack) peek() *uint256.Int {
-	return &s.data[s.len()-1]
+	return &s.data[s.Len()-1]
 }
 
 func (s *Stack) Back(n int) *uint256.Int {
-	return &s.data[s.len()-n-1]
+	return &s.data[s.Len()-n-1]
 }
 
 func ToHex(z *uint256.Int) string {
@@ -88,8 +88,8 @@ func ToHex(z *uint256.Int) string {
 
 func (s *Stack) String() string {
 	var b bytes.Buffer
-	for i := 0; i < s.len(); i++ {
-		b.WriteString(fmt.Sprintf("    [%2d] %v\n", s.len()-i-1, ToHex(s.Back(i))))
+	for i := 0; i < s.Len(); i++ {
+		b.WriteString(fmt.Sprintf("    [%2d] %v\n", s.Len()-i-1, ToHex(s.Back(i))))
 	}
 	return b.String()
 }
@@ -106,9 +106,9 @@ func NewStack() *Stack {
 	return stackPool.Get().(*Stack)
 }
 
-func ReturnStack(s *Stack) {
-	s.stack_ptr = 0
-	stackPool.Put(s)
+func ReturnStack(c *context) {
+	c.stack.stack_ptr = 0
+	stackPool.Put(c.stack)
 }
 
 // ------------------ Stack Boundry ------------------
@@ -117,7 +117,7 @@ func ReturnStack(s *Stack) {
 func newInstructionStack(min, max, _increase int) InstructionStack {
 	return InstructionStack{
 		stackMin: min,
-		stackMax: stackLimit - max,
+		stackMax: StackLimit - max,
 		increase: _increase,
 	}
 }

--- a/go/interpreter/lfvm/super_instructions.go
+++ b/go/interpreter/lfvm/super_instructions.go
@@ -160,7 +160,7 @@ func opPush1_Push1_Push1_Shl_Sub(c *context) {
 	shift := uint8(arg2)
 	value := uint8(arg1 & 0xFF)
 	delta := uint8(arg1 >> 8)
-	trg := c.stack.pushEmpty()
+	trg := c.stack.PushEmpty()
 	trg.SetUint64(uint64(value))
 	trg.Lsh(trg, uint(shift))
 	trg.Sub(trg, uint256.NewInt(uint64(delta)))


### PR DESCRIPTION
CT adapter is not an essential part of the interpreter implementation. Because of this, we move it to its own folder and package.
To enable this separation a few members of `lfvm` had to be made public. The amount of public conversions was kept to a minimum. IF this makes the package looks inconsistent, we can discuss how to best approach it.
Members made public:
- `convertWithObserver` method from `converter.go`
- `newestSupportedRevision` constant
- `status` enum (type and values)

Introduced methods to prevent making public types or members public:
- `NewInstruction`, `IsIndexOp` and `GetArgOf`, to create, consult `index[i] == op` and getter, correspondingly 
- `NewContext`, a series of getters, `IsRunning` and `SignalOutofGas`.

Stack:
- `ReturnStack` is modified to take a `Context` as parameter and return its stack to the pool, this way the context's stack pointer does not need to be exposed.
- `stackLimit` constant is made public 
- `len`, `push` and `pushEmpty` are also made public