### PR TITLE
Cleanup of the LFVM hash cache

### DIFF
--- a/go/interpreter/lfvm/hash_cache.go
+++ b/go/interpreter/lfvm/hash_cache.go
@@ -16,26 +16,6 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 )
 
-// hashCacheEntry32 is an entry of a cache for hashes of 32-byte long inputs.
-type hashCacheEntry32 struct {
-	// key is the input value cache entries are indexed by.
-	key [32]byte
-	// hash is the cached (Sha3) hash of the key.
-	hash tosca.Hash
-	// pred/succ pointers are used for a double linked list for the LRU order.
-	pred, succ *hashCacheEntry32
-}
-
-// hashCacheEntry64 is an entry of a cache for hashes of 64-byte long inputs.
-type hashCacheEntry64 struct {
-	// key is the input value cache entries are indexed by.
-	key [64]byte
-	// hash is the cached (Sha3) hash of the key.
-	hash tosca.Hash
-	// pred/succ pointers are used for a double linked list for the LRU order.
-	pred, succ *hashCacheEntry64
-}
-
 // HashCache is an LRU governed fixed-capacity cache for SHA3 hashes.
 // The cache maintains hashes for hashed input data of size 32 and 64,
 // which are the vast majority of values hashed when running EVM
@@ -223,4 +203,24 @@ func (h *HashCache) getFree64() *hashCacheEntry64 {
 	h.tail64.succ = nil
 	delete(h.index64, res.key)
 	return res
+}
+
+// hashCacheEntry32 is an entry of a cache for hashes of 32-byte long inputs.
+type hashCacheEntry32 struct {
+	// key is the input value cache entries are indexed by.
+	key [32]byte
+	// hash is the cached (Sha3) hash of the key.
+	hash tosca.Hash
+	// pred/succ pointers are used for a double linked list for the LRU order.
+	pred, succ *hashCacheEntry32
+}
+
+// hashCacheEntry64 is an entry of a cache for hashes of 64-byte long inputs.
+type hashCacheEntry64 struct {
+	// key is the input value cache entries are indexed by.
+	key [64]byte
+	// hash is the cached (Sha3) hash of the key.
+	hash tosca.Hash
+	// pred/succ pointers are used for a double linked list for the LRU order.
+	pred, succ *hashCacheEntry64
 }

--- a/go/interpreter/lfvm/hash_cache.go
+++ b/go/interpreter/lfvm/hash_cache.go
@@ -16,18 +16,18 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 )
 
-// Sha3HashCache is an LRU governed fixed-capacity cache for SHA3 hashes.
+// sha3HashCache is an LRU governed fixed-capacity cache for SHA3 hashes.
 // The cache maintains hashes for hashed input data of size 32 and 64,
 // which are the vast majority of values hashed when running EVM
 // instructions. Inputs of other sizes are hashed on demand without caching.
-type Sha3HashCache struct {
+type sha3HashCache struct {
 	cache32 *hashCache[[32]byte]
 	cache64 *hashCache[[64]byte]
 }
 
 // newSha3HashCache creates a Sha3HashCache with the given capacity of entries.
-func newSha3HashCache(capacity32 int, capacity64 int) *Sha3HashCache {
-	return &Sha3HashCache{
+func newSha3HashCache(capacity32 int, capacity64 int) *sha3HashCache {
+	return &sha3HashCache{
 		cache32: newHashCache(capacity32, func(key [32]byte) tosca.Hash {
 			return Keccak256For32byte(key)
 		}),
@@ -38,7 +38,7 @@ func newSha3HashCache(capacity32 int, capacity64 int) *Sha3HashCache {
 }
 
 // hash fetches a cached hash or computes the hash for the provided data.
-func (h *Sha3HashCache) hash(data []byte) tosca.Hash {
+func (h *sha3HashCache) hash(data []byte) tosca.Hash {
 	if len(data) == 32 {
 		var key [32]byte
 		copy(key[:], data)

--- a/go/interpreter/lfvm/hash_cache_test.go
+++ b/go/interpreter/lfvm/hash_cache_test.go
@@ -13,8 +13,12 @@ package lfvm
 import (
 	"fmt"
 	"math/rand"
+	"slices"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/Fantom-foundation/Tosca/go/tosca"
 )
 
 func TestSha3HashCache_hash_ProducesCorrectHashesForInputs(t *testing.T) {
@@ -42,6 +46,260 @@ func TestSha3HashCache_hash_ProducesCorrectHashesForInputs(t *testing.T) {
 			t.Errorf("expected hash to be %x, but got %x", want, got)
 		}
 	}
+}
+
+func TestHashCache_UsesProvidedHashingFunction(t *testing.T) {
+	hash := func(i int) tosca.Hash {
+		return tosca.Hash{byte(i)}
+	}
+
+	cache := newHashCache(10, hash)
+	for i := 0; i < 100; i++ {
+		want := hash(i)
+		got := cache.getHash(i)
+		if want != got {
+			t.Errorf("expected hash to be %x, but got %x", want, got)
+		}
+	}
+}
+
+func TestHashCache_HashesAreCached(t *testing.T) {
+	// To test whether results are cached, we use a hash function that
+	// returns different results at each call.
+	counter := 0
+	hash := func(int) tosca.Hash {
+		counter++
+		return tosca.Hash{byte(counter)}
+	}
+
+	cache := newHashCache(10, hash)
+
+	hash1 := cache.getHash(1)
+	hash2 := cache.getHash(2)
+
+	if want, got := hash1, cache.getHash(1); want != got {
+		t.Errorf("expected hash to be %v, but got %v", want, got)
+	}
+	if want, got := hash2, cache.getHash(2); want != got {
+		t.Errorf("expected hash to be %v, but got %v", want, got)
+	}
+}
+
+func TestHashCache_CapacityIsIncreasedToAtLeast2(t *testing.T) {
+	capacity := []int{-1000, -1, 0, 1, 2, 3, 1000}
+	for _, c := range capacity {
+		cache := newHashCache(c, func(int) tosca.Hash {
+			return tosca.Hash{}
+		})
+		want := c
+		if want < 2 {
+			want = 2
+		}
+		if got := len(cache.entries); got != want {
+			t.Errorf("expected cache to have %d entries, but got %d", want, got)
+		}
+	}
+}
+
+func TestHashCache_RespectsCapacity(t *testing.T) {
+	hash := func(int) tosca.Hash {
+		return tosca.Hash{}
+	}
+	for _, capacity := range []int{2, 10, 42, 123} {
+		t.Run(fmt.Sprintf("capacity=%d", capacity), func(t *testing.T) {
+			cache := newHashCache(capacity, hash)
+			for i := 0; i < 2*capacity; i++ {
+				cache.getHash(i)
+
+				if got := len(cache.entries); got != capacity {
+					t.Errorf("expected cache to have %d entries, but got %d", capacity, got)
+				}
+
+				want := i + 1
+				if want > capacity {
+					want = capacity
+				}
+				if got := len(cache.index); got != want {
+					t.Errorf("expected cache to have %d entries in the index, but got %d", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestHashCache_UsesLruReplacementOrder(t *testing.T) {
+	sequence := []struct {
+		touchedKey int
+		lruOrder   []int
+	}{
+		{0, []int{0}}, // < not really needed, just here for clarity
+		// New keys are added to the front, and the last key is removed when the
+		// capacity is reached.
+		{1, []int{1, 0}},
+		{2, []int{2, 1, 0}},
+		{3, []int{3, 2, 1}},
+		{4, []int{4, 3, 2}},
+		// Accessing an existing key moves it to the front.
+		{2, []int{2, 4, 3}}, // < moves last element to the front
+		{4, []int{4, 2, 3}}, // < moves an element in the middle to the front
+		{4, []int{4, 2, 3}}, // < touches the front element
+	}
+
+	cache := newHashCache(3, func(int) tosca.Hash {
+		return tosca.Hash{}
+	})
+
+	// The cache is initiated with the zero value.
+	got := checkIndexAndGetLruOrder(t, cache)
+	if want := []int{0}; !slices.Equal(want, got) {
+		t.Errorf("expected initial order to be %v, but got %v", want, got)
+	}
+
+	for i, step := range sequence {
+		cache.getHash(step.touchedKey)
+		got := checkIndexAndGetLruOrder(t, cache)
+		if want := step.lruOrder; !slices.Equal(want, got) {
+			t.Errorf(
+				"after step %d expected order to be %v, but got %v",
+				i, want, got,
+			)
+		}
+	}
+}
+
+func TestHashCache_ReusingKeysBeforeReachingTheCapacityLimitDoesNotLeadToDuplicates(t *testing.T) {
+	sequence := []struct {
+		touchedKey int
+		lruOrder   []int
+	}{
+		{1, []int{1, 0}},
+		{0, []int{0, 1}},
+		{1, []int{1, 0}},
+		{0, []int{0, 1}},
+		{1, []int{1, 0}},
+	}
+
+	cache := newHashCache(3, func(int) tosca.Hash {
+		return tosca.Hash{}
+	})
+
+	for i, step := range sequence {
+		cache.getHash(step.touchedKey)
+		got := checkIndexAndGetLruOrder(t, cache)
+		if want := step.lruOrder; !slices.Equal(want, got) {
+			t.Errorf(
+				"after step %d expected order to be %v, but got %v",
+				i, want, got,
+			)
+		}
+	}
+}
+
+func checkIndexAndGetLruOrder(t *testing.T, h *hashCache[int]) []int {
+	t.Helper()
+
+	getForwardOrder := func(h *hashCache[int]) []int {
+		var res []int
+		for e := h.head; e != nil; e = e.succ {
+			res = append(res, e.key)
+		}
+		return res
+	}
+
+	getBackwardOrder := func(h *hashCache[int]) []int {
+		var res []int
+		for e := h.tail; e != nil; e = e.pred {
+			res = append(res, e.key)
+		}
+		slices.Reverse(res)
+		return res
+	}
+
+	forward := getForwardOrder(h)
+	backward := getBackwardOrder(h)
+
+	// Check that the double-linked list is consistent.
+	if !slices.Equal(forward, backward) {
+		t.Errorf("expected forward and backward order to be identical but got %v and %v", forward, backward)
+	}
+
+	// Check that there are no duplicates in the keys.
+	seen := make(map[int]struct{})
+	for _, k := range forward {
+		if _, found := seen[k]; found {
+			t.Errorf("expected key %d to be unique, but it is duplicated", k)
+		}
+		seen[k] = struct{}{}
+	}
+
+	// Check that the index has the same size as the keys.
+	if want, got := len(forward), len(h.index); want != got {
+		t.Errorf("expected index to have %d entries, but got %d", want, got)
+	}
+
+	// Check that the keys are in the index.
+	for _, k := range forward {
+		if _, found := h.index[k]; !found {
+			t.Errorf("expected key %d to be in the index, but it is not", k)
+		}
+	}
+	return forward
+}
+
+func TestHashCache_AccessesAreThreadSafe(t *testing.T) {
+	// This test is designed to detect race conditions in cases in combination
+	// with Go's data race detection. It should be run with the -race flag.
+	cache := newHashCache(10, func(int) tosca.Hash {
+		return tosca.Hash{}
+	})
+
+	const (
+		threads  = 10
+		accesses = 1000
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(threads)
+	for i := 0; i < threads; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < accesses; j++ {
+				cache.getHash(j % 10)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Check that the cache is consistent.
+	checkIndexAndGetLruOrder(t, cache)
+}
+
+func TestHashCache_ConcurrentThreadsCanNotIntroduceDuplicates(t *testing.T) {
+	const key = 12
+	var barrier sync.WaitGroup
+	barrier.Add(2)
+	cache := newHashCache(10, func(i int) tosca.Hash {
+		if i != key {
+			return tosca.Hash{}
+		}
+		// Wait for two go-routines to compute the hash at the same time.
+		barrier.Done()
+		barrier.Wait()
+		return tosca.Hash{}
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			cache.getHash(key)
+		}()
+	}
+	wg.Wait()
+
+	// Check that the cache is consistent.
+	checkIndexAndGetLruOrder(t, cache)
 }
 
 func benchmarkSha3HashCache(b *testing.B, inputSize int, mutateInput bool) {

--- a/go/interpreter/lfvm/hash_cache_test.go
+++ b/go/interpreter/lfvm/hash_cache_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package lfvm
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestHashCache_hash_ProducesCorrectHashesForInputs(t *testing.T) {
+	inputs := [][]byte{
+		{},
+		{0},
+		{1, 2, 3, 4, 5},
+		make([]byte, 32),
+		make([]byte, 64),
+		make([]byte, 123),
+	}
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 100; i++ {
+		input := make([]byte, r.Intn(150))
+		r.Read(input)
+		inputs = append(inputs, input)
+	}
+
+	cache := newHashCache(10, 10)
+	for _, input := range inputs {
+		want := Keccak256(input)
+		got := cache.hash(input)
+		if want != got {
+			t.Errorf("expected hash to be %x, but got %x", want, got)
+		}
+	}
+}
+
+func benchmarkHashCache(b *testing.B, inputSize int, mutateInput bool) {
+	input := make([]byte, inputSize)
+	cache := newHashCache(128, 128)
+	for i := 0; i < b.N; i++ {
+		if mutateInput {
+			input[0] = byte(i)
+		}
+		cache.hash(input)
+	}
+}
+
+func BenchmarkHashCache_Hits(b *testing.B) {
+	for _, size := range []int{16, 32, 64, 128} {
+		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+			benchmarkHashCache(b, size, false)
+		})
+	}
+}
+
+func BenchmarkHashCache_Miss(b *testing.B) {
+	for _, size := range []int{16, 32, 64, 128} {
+		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+			benchmarkHashCache(b, size, true)
+		})
+	}
+}

--- a/go/interpreter/lfvm/hash_cache_test.go
+++ b/go/interpreter/lfvm/hash_cache_test.go
@@ -17,7 +17,7 @@ import (
 	"time"
 )
 
-func TestHashCache_hash_ProducesCorrectHashesForInputs(t *testing.T) {
+func TestSha3HashCache_hash_ProducesCorrectHashesForInputs(t *testing.T) {
 	inputs := [][]byte{
 		{},
 		{0},
@@ -34,7 +34,7 @@ func TestHashCache_hash_ProducesCorrectHashesForInputs(t *testing.T) {
 		inputs = append(inputs, input)
 	}
 
-	cache := newHashCache(10, 10)
+	cache := newSha3HashCache(10, 10)
 	for _, input := range inputs {
 		want := Keccak256(input)
 		got := cache.hash(input)
@@ -44,9 +44,9 @@ func TestHashCache_hash_ProducesCorrectHashesForInputs(t *testing.T) {
 	}
 }
 
-func benchmarkHashCache(b *testing.B, inputSize int, mutateInput bool) {
+func benchmarkSha3HashCache(b *testing.B, inputSize int, mutateInput bool) {
 	input := make([]byte, inputSize)
-	cache := newHashCache(128, 128)
+	cache := newSha3HashCache(128, 128)
 	for i := 0; i < b.N; i++ {
 		if mutateInput {
 			input[0] = byte(i)
@@ -58,7 +58,7 @@ func benchmarkHashCache(b *testing.B, inputSize int, mutateInput bool) {
 func BenchmarkHashCache_Hits(b *testing.B) {
 	for _, size := range []int{16, 32, 64, 128} {
 		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
-			benchmarkHashCache(b, size, false)
+			benchmarkSha3HashCache(b, size, false)
 		})
 	}
 }
@@ -66,7 +66,7 @@ func BenchmarkHashCache_Hits(b *testing.B) {
 func BenchmarkHashCache_Miss(b *testing.B) {
 	for _, size := range []int{16, 32, 64, 128} {
 		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
-			benchmarkHashCache(b, size, true)
+			benchmarkSha3HashCache(b, size, true)
 		})
 	}
 }

--- a/go/interpreter/lfvm/hash_cache_test.go
+++ b/go/interpreter/lfvm/hash_cache_test.go
@@ -77,6 +77,10 @@ func TestHashCache_HashesAreCached(t *testing.T) {
 	hash1 := cache.getHash(1)
 	hash2 := cache.getHash(2)
 
+	if hash1 == hash2 {
+		t.Fatalf("expected different hashes for different inputs")
+	}
+
 	if want, got := hash1, cache.getHash(1); want != got {
 		t.Errorf("expected hash to be %v, but got %v", want, got)
 	}
@@ -313,7 +317,7 @@ func benchmarkSha3HashCache(b *testing.B, inputSize int, mutateInput bool) {
 	}
 }
 
-func BenchmarkHashCache_Hits(b *testing.B) {
+func BenchmarkSha3HashCache_Hits(b *testing.B) {
 	for _, size := range []int{16, 32, 64, 128} {
 		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
 			benchmarkSha3HashCache(b, size, false)
@@ -321,7 +325,7 @@ func BenchmarkHashCache_Hits(b *testing.B) {
 	}
 }
 
-func BenchmarkHashCache_Miss(b *testing.B) {
+func BenchmarkSha3HashCache_Miss(b *testing.B) {
 	for _, size := range []int{16, 32, 64, 128} {
 		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
 			benchmarkSha3HashCache(b, size, true)

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -579,7 +579,7 @@ func opExp(c *context) {
 }
 
 // Evaluations show a 96% hit rate of this configuration.
-var hashCache = newHashCache(1<<16, 1<<18)
+var sha3Cache = newSha3HashCache(1<<16, 1<<18)
 
 func opSha3(c *context) {
 	offset, size := c.stack.pop(), c.stack.peek()
@@ -603,7 +603,7 @@ func opSha3(c *context) {
 	var hash tosca.Hash
 	if c.withShaCache {
 		// Cache hashes since identical values are frequently re-hashed.
-		hash = hashCache.hash(data)
+		hash = sha3Cache.hash(data)
 	} else {
 		hash = Keccak256(data)
 	}


### PR DESCRIPTION
This PR applies various cleanup steps of the LFVM hash cache implementation. In particular:
- refactoring the hash cache structure to use generic types to eliminate code duplication
- added documentation
- added unit tests for hashing, LRU caching order, and capacity constraints
- added micro-benchmarks to assess impact of code generalization


Benchmarks have been implemented and evaluated to assess the impact of those refactoring steps. The results are as follows:
```
pkg: github.com/Fantom-foundation/Tosca/go/interpreter/lfvm
cpu: Intel(R) Core(TM) i7-6600U CPU @ 2.60GHz
                          │   base.txt   │              mod.txt               │
                          │    sec/op    │   sec/op     vs base               │
HashCache_Hits/size=16-4    517.1n ± 11%   482.8n ± 3%  -6.63% (p=0.001 n=10)
HashCache_Hits/size=32-4    36.73n ±  3%   34.62n ± 1%  -5.76% (p=0.000 n=10)
HashCache_Hits/size=64-4    41.19n ±  2%   39.35n ± 3%  -4.48% (p=0.000 n=10)
HashCache_Hits/size=128-4   527.9n ±  3%   491.1n ± 4%  -6.97% (p=0.000 n=10)
HashCache_Miss/size=16-4    521.5n ±  1%   483.6n ± 1%  -7.27% (p=0.000 n=10)
HashCache_Miss/size=32-4    686.2n ±  2%   644.5n ± 3%  -6.08% (p=0.000 n=10)
HashCache_Miss/size=64-4    740.5n ±  2%   742.3n ± 3%       ~ (p=0.353 n=10)
HashCache_Miss/size=128-4   530.2n ±  1%   497.2n ± 2%  -6.22% (p=0.000 n=10)
geomean                     295.4n         279.4n       -5.42%
```
```
pkg: github.com/Fantom-foundation/Tosca/go/interpreter/lfvm
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
                           │  base.txt   │               mod.txt               │
                           │   sec/op    │   sec/op     vs base                │
HashCache_Hits/size=16-16    386.2n ± 0%   387.7n ± 2%        ~ (p=0.109 n=10)
HashCache_Hits/size=32-16    25.42n ± 0%   24.22n ± 0%   -4.72% (p=0.000 n=10)
HashCache_Hits/size=64-16    27.74n ± 0%   26.31n ± 6%   -5.16% (p=0.012 n=10)
HashCache_Hits/size=128-16   391.5n ± 0%   395.2n ± 1%   +0.92% (p=0.000 n=10)
HashCache_Miss/size=16-16    386.6n ± 0%   387.4n ± 1%        ~ (p=0.170 n=10)
HashCache_Miss/size=32-16    509.5n ± 1%   523.4n ± 0%   +2.74% (p=0.000 n=10)
HashCache_Miss/size=64-16    549.1n ± 1%   605.6n ± 1%  +10.28% (p=0.000 n=10)
HashCache_Miss/size=128-16   392.7n ± 0%   393.5n ± 0%   +0.22% (p=0.030 n=10)
geomean                      214.8n        215.9n        +0.51%
```