### PR TITLE
Floria: Implement account exists check

### DIFF
--- a/go/integration_test/processor/calls_test.go
+++ b/go/integration_test/processor/calls_test.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"math/big"
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/Fantom-foundation/Tosca/go/tosca"
@@ -420,10 +419,6 @@ func TestProcessor_CallingNonExistentAccountIsHandledCorrectly(t *testing.T) {
 		},
 	}
 	for processorName, processor := range getProcessors() {
-		// TODO: implement in Floria
-		if strings.Contains(processorName, "floria") {
-			continue
-		}
 		for testName, test := range tests {
 			t.Run(processorName+"/"+testName, func(t *testing.T) {
 				sender := tosca.Address{1}

--- a/go/integration_test/processor/create_test.go
+++ b/go/integration_test/processor/create_test.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"math/big"
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/Fantom-foundation/Tosca/go/tosca"
@@ -487,10 +486,6 @@ func TestProcessor_CreateExistingAccountFails(t *testing.T) {
 	}
 
 	for processorName, processor := range getProcessors() {
-		// TODO: implement in Floria
-		if strings.Contains(processorName, "floria") {
-			continue
-		}
 		for testName, test := range tests {
 			t.Run(processorName+"/"+testName, func(t *testing.T) {
 				checkValue := byte(42)

--- a/go/processor/floria/run_context_test.go
+++ b/go/processor/floria/run_context_test.go
@@ -73,6 +73,7 @@ func TestCalls_InterpreterResultIsHandledCorrectly(t *testing.T) {
 			context.EXPECT().GetCodeHash(params.Recipient).Return(tosca.Hash{})
 			context.EXPECT().GetCode(params.Recipient).Return([]byte{})
 			context.EXPECT().CreateSnapshot()
+			context.EXPECT().AccountExists(params.Recipient).Return(true)
 			context.EXPECT().RestoreSnapshot(gomock.Any()).AnyTimes()
 
 			test.setup(interpreter)
@@ -114,6 +115,7 @@ func TestCall_TransferValueInCall(t *testing.T) {
 
 	context.EXPECT().GetCodeHash(params.Recipient).Return(tosca.Hash{})
 	context.EXPECT().GetCode(params.Recipient).Return([]byte{})
+	context.EXPECT().AccountExists(params.Recipient).Return(true)
 	context.EXPECT().CreateSnapshot()
 
 	context.EXPECT().GetBalance(params.Sender).Return(tosca.NewValue(100))


### PR DESCRIPTION
This PR adds the checks whether an account exists or not to Floria.
By adding these checks in between precompiled contract handling and the interpreter call, several checks can be removed compared to the reference implementation.
Fixes #713. 