### PR TITLE
tosca: constErr 

### DIFF
--- a/go/interpreter/lfvm/errors.go
+++ b/go/interpreter/lfvm/errors.go
@@ -10,21 +10,15 @@
 
 package lfvm
 
+import "github.com/Fantom-foundation/Tosca/go/tosca"
+
 const (
-	errGasUintOverflow       = ConstError("gas uint64 overflow")
-	errInvalidCode           = ConstError("invalid code")
-	errInvalidJump           = ConstError("invalid jump destination")
-	errOutOfGas              = ConstError("out of gas")
-	errReturnDataOutOfBounds = ConstError("return data out of bounds")
-	errStackOverflow         = ConstError("stack overflow")
-	errStackUnderflow        = ConstError("stack underflow")
-	errWriteProtection       = ConstError("write protection")
+	errGasUintOverflow       = tosca.ConstError("gas uint64 overflow")
+	errInvalidCode           = tosca.ConstError("invalid code")
+	errInvalidJump           = tosca.ConstError("invalid jump destination")
+	errOutOfGas              = tosca.ConstError("out of gas")
+	errReturnDataOutOfBounds = tosca.ConstError("return data out of bounds")
+	errStackOverflow         = tosca.ConstError("stack overflow")
+	errStackUnderflow        = tosca.ConstError("stack underflow")
+	errWriteProtection       = tosca.ConstError("write protection")
 )
-
-// ConstError is an error type that can be used to define immutable
-// error constants.
-type ConstError string
-
-func (e ConstError) Error() string {
-	return string(e)
-}

--- a/go/interpreter/lfvm/gas.go
+++ b/go/interpreter/lfvm/gas.go
@@ -52,8 +52,8 @@ const (
 
 // Gas errors definitions
 const (
-	errNotEnoughGasReentrancy  = ConstError("not enough gas for reentrancy sentry")
-	errAddressNotFoundInSstore = ConstError("address was not present in access list during sstore op")
+	errNotEnoughGasReentrancy  = tosca.ConstError("not enough gas for reentrancy sentry")
+	errAddressNotFoundInSstore = tosca.ConstError("address was not present in access list during sstore op")
 )
 
 var static_gas_prices = [NUM_OPCODES]tosca.Gas{}

--- a/go/tosca/errors.go
+++ b/go/tosca/errors.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package tosca
+
+// ConstError is an error type that can be used to define immutable
+// error constants.
+type ConstError string
+
+func (e ConstError) Error() string {
+	return string(e)
+}

--- a/go/tosca/errors_test.go
+++ b/go/tosca/errors_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package tosca
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestConstError_Error(t *testing.T) {
+	// Define a constant error
+	const myError = ConstError("this is a constant error")
+
+	// Test the Error() method
+	if myError.Error() != "this is a constant error" {
+		t.Errorf("expected 'this is a constant error', got '%s'", myError.Error())
+	}
+
+	// tests error.Is
+	if !errors.Is(myError, ConstError("this is a constant error")) {
+		t.Errorf("expected true, got false")
+	}
+}
+
+func TestConstError_Empty(t *testing.T) {
+	// Define an empty constant error
+	const emptyError ConstError = ""
+
+	// Test the Error() method
+	if emptyError.Error() != "" {
+		t.Errorf("expected empty string, got '%s'", emptyError.Error())
+	}
+}


### PR DESCRIPTION
This PR moves `constErr` to `tosca`, so that it can be used in other projects as well, such as `floria` or `ct`.
Follow up PRs should take care of implementing the usage of this type and facilitating the comparison with `errors.Is`.

side note:
a similar approach can be taken for groups of errors that have a variable value, but for this a type needs to be made for each group of errors. We should be on the look to use this pattern since it simplifies error comparing 