### PR TITLE
LFVM: move `addressInAccessList` to `getAccessCost`

### DIFF
--- a/go/interpreter/lfvm/gas.go
+++ b/go/interpreter/lfvm/gas.go
@@ -67,13 +67,13 @@ func getBerlinGasPriceInternal(op OpCode) tosca.Gas {
 	case BALANCE:
 		gp = 100
 	case CALL:
-		gp = 100
+		gp = 0
 	case CALLCODE:
-		gp = 100
+		gp = 0
 	case STATICCALL:
-		gp = 100
+		gp = 0
 	case DELEGATECALL:
-		gp = 100
+		gp = 0
 	case SELFDESTRUCT:
 		gp = 5000
 	}

--- a/go/interpreter/lfvm/gas.go
+++ b/go/interpreter/lfvm/gas.go
@@ -223,11 +223,11 @@ func getStaticGasPriceInternal(op OpCode) tosca.Gas {
 	case CREATE2:
 		return 32000
 	case CALL:
-		return 700 // Should be 100 according to evm.code
+		return 700
 	case CALLCODE:
 		return 700
 	case STATICCALL:
-		return 700 // Should be 100 according to evm.code
+		return 700
 	case RETURN:
 		return 0
 	case STOP:
@@ -237,7 +237,7 @@ func getStaticGasPriceInternal(op OpCode) tosca.Gas {
 	case INVALID:
 		return 0
 	case DELEGATECALL:
-		return 700 // Should be 100 according to evm.code
+		return 700
 	case SELFDESTRUCT:
 		return 0 // should be 5000 according to evm.code
 	}

--- a/go/interpreter/lfvm/gas.go
+++ b/go/interpreter/lfvm/gas.go
@@ -343,19 +343,6 @@ func gasEip2929AccountCheck(c *context, address tosca.Address) error {
 	return nil
 }
 
-func calculateAccessCost(address tosca.Address, revision tosca.Revision, runContext tosca.RunContext) (isWarm bool, accessCost tosca.Gas) {
-	isWarm = true
-	if revision >= tosca.R09_Berlin {
-		// Check slot presence in the access list
-		//lint:ignore SA1019 deprecated functions to be migrated in #616
-		isWarm = runContext.IsAddressInAccessList(address)
-		// The WarmStorageReadCostEIP2929 (100) is already deducted in the form of a constant cost, so
-		// the cost to charge for cold access, if any, is Cold - Warm
-		accessCost = ColdAccountAccessCostEIP2929 - WarmStorageReadCostEIP2929
-	}
-	return isWarm, accessCost
-}
-
 func gasSelfdestruct(c *context) tosca.Gas {
 	gas := SelfdestructGasEIP150
 	var address = tosca.Address(c.stack.peekN(0).Bytes20())

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -1087,9 +1087,9 @@ func getAccessCost(accessStatus tosca.AccessStatus) tosca.Gas {
 	// however, the warm access cost is charged as part of the base gas cost.
 	// (https://eips.ethereum.org/EIPS/eip-2929)
 	if accessStatus == tosca.ColdAccess {
-		return tosca.Gas(2500)
+		return tosca.Gas(2600)
 	}
-	return tosca.Gas(0)
+	return tosca.Gas(100)
 }
 
 func genericCall(c *context, kind tosca.CallKind) {

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -1084,7 +1084,6 @@ func neededMemorySize(c *context, offset, size *uint256.Int) (uint64, error) {
 
 func getAccessCost(accessStatus tosca.AccessStatus) tosca.Gas {
 	// EIP-2929 says that cold access cost is 2600 and warm is 100.
-	// however, the warm access cost is charged as part of the base gas cost.
 	// (https://eips.ethereum.org/EIPS/eip-2929)
 	if accessStatus == tosca.ColdAccess {
 		return tosca.Gas(2600)

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -883,31 +883,12 @@ func TestExpansionCostOverflow(t *testing.T) {
 	}
 }
 
-func TestCallChargesAppropriatelyForColdWarmAccess(t *testing.T) {
-
-	tests := map[string]struct {
-		accessStatus tosca.AccessStatus
-		cost         tosca.Gas
-	}{
-		"warm": {
-			accessStatus: tosca.WarmAccess,
-		},
-		"cold": {
-			accessStatus: tosca.ColdAccess,
-			cost:         2500,
-		},
+func TestGetAccessCost_RespondsWithProperGasPrice(t *testing.T) {
+	if want, got := tosca.Gas(100), getAccessCost(tosca.WarmAccess); want != got {
+		t.Errorf("unexpected gas cost, wanted %d, got %d", want, got)
 	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-
-			cost := getAccessCost(test.accessStatus)
-
-			if cost != test.cost {
-				t.Errorf("unexpected gas cost, wanted %v, got %v", test.cost, cost)
-			}
-
-		})
+	if want, got := tosca.Gas(2600), getAccessCost(tosca.ColdAccess); want != got {
+		t.Errorf("unexpected gas cost, wanted %d, got %d", want, got)
 	}
 }
 


### PR DESCRIPTION
This PR removes the function `addressInAccessList` and reworks its functionality into `getAccessCost`. It also adds comprehensive documentation for the values used, and a test for the different cases.

Note: static call prices after berlin should be 0, and warm cost should be applied in dynamic cost calcualtion (https://eips.ethereum.org/EIPS/eip-2929). This changes are also applied in this PR.