### PR TITLE
Floria: Add access list

### DIFF
--- a/go/integration_test/processor/access_list_test.go
+++ b/go/integration_test/processor/access_list_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package processor
+
+import (
+	"bytes"
+	"slices"
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+	"github.com/Fantom-foundation/Tosca/go/tosca/vm"
+)
+
+func TestProcessor_AccessListIsHandledCorrectly(t *testing.T) {
+	sender := tosca.Address{1}
+	receiver := &tosca.Address{2}
+	checkValue := byte(0x42)
+	gas := tosca.Gas(1000000)
+	accessedKey := tosca.Key{0x55}
+
+	tests := map[string]struct {
+		accessList      []tosca.AccessTuple
+		expectedGasUsed tosca.Gas
+	}{
+		"empty_access_list": {
+			accessList:      []tosca.AccessTuple{},
+			expectedGasUsed: tosca.Gas(140704),
+		},
+		"account_access": {
+			accessList: []tosca.AccessTuple{
+				{
+					Address: *receiver,
+					Keys:    nil,
+				},
+			},
+			expectedGasUsed: tosca.Gas(142864),
+		},
+		"storage_access": {
+			accessList: []tosca.AccessTuple{
+				{
+					Address: *receiver,
+					Keys:    []tosca.Key{accessedKey},
+				},
+			},
+			expectedGasUsed: tosca.Gas(144574),
+		},
+	}
+
+	for processorName, processor := range getProcessors() {
+		for testName, test := range tests {
+			t.Run(processorName+"/"+testName, func(t *testing.T) {
+
+				code := []byte{
+					byte(vm.PUSH1), checkValue,
+					byte(vm.PUSH32),
+				}
+				code = append(code, accessedKey[:]...)
+				code = append(code, []byte{
+					byte(vm.SSTORE),
+					byte(vm.PUSH32),
+				}...)
+				code = append(code, accessedKey[:]...)
+				code = append(code, []byte{
+					byte(vm.SLOAD),
+					byte(vm.PUSH1), checkValue,
+					byte(vm.PUSH1), byte(0),
+					byte(vm.MSTORE),
+					byte(vm.PUSH1), byte(32),
+					byte(vm.PUSH1), byte(0),
+					byte(vm.RETURN),
+				}...)
+
+				blockParams := tosca.BlockParameters{Revision: tosca.R09_Berlin}
+
+				transaction := tosca.Transaction{
+					Sender:     sender,
+					Recipient:  receiver,
+					GasLimit:   gas,
+					Nonce:      0,
+					AccessList: test.accessList,
+				}
+				scenario := getScenarioContext(sender, *receiver, code, gas)
+				transactionContext := newScenarioContext(scenario.Before)
+
+				// Run the processor
+				result, err := processor.Run(blockParams, transaction, transactionContext)
+				if err != nil || !result.Success {
+					t.Errorf("execution failed with error: %v and success %v", err, result.Success)
+				}
+				if result.GasUsed != test.expectedGasUsed {
+					t.Errorf("expected gas used %v, got %v", test.expectedGasUsed, result.GasUsed)
+				}
+				if !slices.Equal(result.Output, append(bytes.Repeat([]byte{0}, 31), checkValue)) {
+					t.Errorf("value was not stored and loaded correctly, got %v", result.Output)
+				}
+			})
+		}
+	}
+}

--- a/go/processor/floria/precompiled.go
+++ b/go/processor/floria/precompiled.go
@@ -36,6 +36,12 @@ func handlePrecompiledContract(revision tosca.Revision, input tosca.Data, addres
 }
 
 func getPrecompiledContract(address tosca.Address, revision tosca.Revision) (geth.PrecompiledContract, bool) {
+	precompiles := getPrecompiledContracts(revision)
+	contract, ok := precompiles[common.Address(address)]
+	return contract, ok
+}
+
+func getPrecompiledContracts(revision tosca.Revision) map[common.Address]geth.PrecompiledContract {
 	var precompiles map[common.Address]geth.PrecompiledContract
 	switch revision {
 	case tosca.R13_Cancun:
@@ -45,6 +51,14 @@ func getPrecompiledContract(address tosca.Address, revision tosca.Revision) (get
 	default: // Istanbul is the oldest supported revision supported by Sonic
 		precompiles = geth.PrecompiledContractsIstanbul
 	}
-	contract, ok := precompiles[common.Address(address)]
-	return contract, ok
+	return precompiles
+}
+
+func getPrecompiledAddresses(revision tosca.Revision) []tosca.Address {
+	precompiles := getPrecompiledContracts(revision)
+	addresses := make([]tosca.Address, 0, len(precompiles))
+	for addr := range precompiles {
+		addresses = append(addresses, tosca.Address(addr))
+	}
+	return addresses
 }

--- a/go/processor/floria/precompiled_test.go
+++ b/go/processor/floria/precompiled_test.go
@@ -43,6 +43,9 @@ func TestPrecompiled_RightNumberOfContractsDependingOnRevision(t *testing.T) {
 		if count != test.numberOfContracts {
 			t.Errorf("unexpected number of precompiled contracts for revision %v, want %v, got %v", test.revision, test.numberOfContracts, count)
 		}
+		if len(getPrecompiledAddresses(test.revision)) != test.numberOfContracts {
+			t.Errorf("unexpected number of precompiled contracts for revision %v, want %v, got %v", test.revision, test.numberOfContracts, count)
+		}
 	}
 }
 

--- a/go/processor/floria/processor_test.go
+++ b/go/processor/floria/processor_test.go
@@ -367,3 +367,27 @@ func TestProcessor_CallParameters(t *testing.T) {
 
 	}
 }
+
+func TestProcessor_SetUpAccessList(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	context := tosca.NewMockTransactionContext(ctrl)
+
+	transaction := tosca.Transaction{
+		Recipient: &tosca.Address{1},
+		AccessList: []tosca.AccessTuple{
+			{
+				Address: tosca.Address{2},
+				Keys:    []tosca.Key{{1}, {2}},
+			},
+		},
+	}
+
+	context.EXPECT().AccessAccount(*transaction.Recipient)
+	for _, contract := range getPrecompiledAddresses(tosca.R09_Berlin) {
+		context.EXPECT().AccessAccount(contract)
+	}
+	context.EXPECT().AccessStorage(tosca.Address{2}, tosca.Key{1})
+	context.EXPECT().AccessStorage(tosca.Address{2}, tosca.Key{2})
+
+	setUpAccessList(transaction, context, tosca.R09_Berlin)
+}


### PR DESCRIPTION
This PR adds the access list introduced in the Berlin revision to Floria.
The integration test scenario had to been changed to also deal with keys. The current implementation requires an iteration through all (worst case) entries which is not performant but should not be a problem for the scenario, which is only used in tests.  
Contributes to #714.