### PR TITLE
Floria: Invalid code starting with 0xEF is rejected

### DIFF
--- a/go/processor/floria/run_context.go
+++ b/go/processor/floria/run_context.go
@@ -119,6 +119,9 @@ func (r runContext) Call(kind tosca.CallKind, parameters tosca.CallParameters) (
 	if err != nil || !result.Success {
 		r.RestoreSnapshot(snapshot)
 	} else if kind == tosca.Create || kind == tosca.Create2 {
+		if r.blockParameters.Revision >= tosca.R10_London && result.Output[0] == 0xEF {
+			return tosca.CallResult{}, nil
+		}
 		r.SetCode(createdAddress, tosca.Code(result.Output))
 	}
 


### PR DESCRIPTION
Starting with the London revision, it is no longer possible to create accounts with a code starting with 0xEF. 
This simple check is added to Floria and checked with an integration test.