### PR TITLE
Cleanup of LFVM interpreter loop

### DIFF
--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -243,30 +243,12 @@ func steps(c *context, oneStepOnly bool) {
 
 		op := c.code[c.pc].opcode
 
-		// JUMP_TO is an LFVM specific operation that has no gas costs nor stack usage.
-		if c.code[c.pc].opcode == JUMP_TO {
-			c.pc = int32(c.code[c.pc].arg)
-			op = c.code[c.pc].opcode
-		}
-
-		// Catch invalid op-codes here, to avoid the need to check them at other places multiple times.
-		if op >= NUM_EXECUTABLE_OPCODES {
-			c.signalError()
-			return
-		}
-
-		// Need to check Call stack boundary before using static gas
-		// TODO: check whether this can be removed
-		if op == CALL && !satisfiesStackRequirements(c, op) {
-			return
-		}
-
 		// If the interpreter is operating in readonly mode, make sure no
 		// state-modifying operation is performed. The 3rd stack item
 		// for a call operation is the value. Transferring value from one
 		// account to the others means the state is modified and should also
 		// return with an error.
-		if c.params.Static && (isWriteInstruction(op) || (op == CALL && c.stack.peekN(2).Sign() != 0)) {
+		if c.params.Static && (isWriteInstruction(op) || (op == CALL && c.stack.len() > 3 && c.stack.peekN(2).Sign() != 0)) {
 			c.signalError()
 			return
 		}

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -652,16 +652,12 @@ func TestStepsProperlyHandlesJUMP_TO(t *testing.T) {
 
 func TestStepsDetectsNonExecutableCode(t *testing.T) {
 	// Create execution context.
-	instructions := []struct {
-		instruction []Instruction
-		status      status
-	}{
-		{[]Instruction{{NUM_EXECUTABLE_OPCODES - 1, 0x0101}, {DATA, 0x0001}, {STOP, 0}}, statusStopped},
-		{[]Instruction{{NUM_EXECUTABLE_OPCODES, 0}}, statusError},
-		{[]Instruction{{NUM_EXECUTABLE_OPCODES + 1, 0}}, statusError},
+	opCodes := []OpCode{
+		NUM_EXECUTABLE_OPCODES,
+		NUM_EXECUTABLE_OPCODES + 1,
 	}
 
-	for _, test := range instructions {
+	for _, opCode := range opCodes {
 		ctxt := getEmptyContext()
 		// Get tosca.Parameters
 		ctxt.params = tosca.Parameters{
@@ -670,13 +666,13 @@ func TestStepsDetectsNonExecutableCode(t *testing.T) {
 			Gas:    10,
 			Code:   []byte{0x0},
 		}
-		ctxt.code = test.instruction
+		ctxt.code = []Instruction{{opCode, 0}}
 
 		// Run testing code
 		steps(&ctxt, false)
 
-		if ctxt.status != test.status {
-			t.Errorf("unexpected status: want STOPPED, got %v", ctxt.status)
+		if want, got := statusInvalidInstruction, ctxt.status; want != got {
+			t.Errorf("unexpected status: want %v, got %v", want, got)
 		}
 	}
 }


### PR DESCRIPTION
This PR eliminates redundant code from the LFVM interpreter loop. This cuts 4-11% of the execution time for dispatcher-intensive benchmarks like Fib.

```
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Tosca/go/integration_test/interpreter
cpu: Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
                  │ baseline.txt │             modified.txt             │
                  │    sec/op    │    sec/op     vs base                │
Fib/10/lfvm-12       179.4µ ± 5%   160.7µ ±  5%  -10.45% (p=0.002 n=10)
Fib/10/lfvm-si-12    127.5µ ± 7%   116.0µ ± 10%   -9.04% (p=0.004 n=10)
geomean              151.3µ        136.5µ         -9.75%
```

```
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Tosca/go/integration_test/interpreter
cpu: Intel(R) Xeon(R) CPU @ 2.80GHz
                  │ baseline.txt │            modified.txt             │
                  │    sec/op    │   sec/op     vs base                │
Fib/10/lfvm-16       118.8µ ± 0%   114.0µ ± 2%   -4.08% (p=0.000 n=10)
Fib/10/lfvm-si-16    92.74µ ± 1%   81.93µ ± 0%  -11.66% (p=0.000 n=10)
geomean              105.0µ        96.63µ        -7.94%
```

Pending:
- [x] run CT check