### PR TITLE
Floria: Reject code longer than max code size

### DIFF
--- a/go/processor/floria/processor.go
+++ b/go/processor/floria/processor.go
@@ -24,6 +24,8 @@ const (
 	TxAccessListAddressGas    = 2400
 	TxAccessListStorageKeyGas = 1900
 
+	maxCodeSize = 24576
+
 	MaxRecursiveDepth = 1024 // Maximum depth of call/create stack.
 )
 

--- a/go/processor/floria/run_context.go
+++ b/go/processor/floria/run_context.go
@@ -119,7 +119,11 @@ func (r runContext) Call(kind tosca.CallKind, parameters tosca.CallParameters) (
 	if err != nil || !result.Success {
 		r.RestoreSnapshot(snapshot)
 	} else if kind == tosca.Create || kind == tosca.Create2 {
-		if r.blockParameters.Revision >= tosca.R10_London && result.Output[0] == 0xEF {
+		code := result.Output
+		if len(code) > maxCodeSize {
+			return tosca.CallResult{}, nil
+		}
+		if r.blockParameters.Revision >= tosca.R10_London && len(code) > 0 && code[0] == 0xEF {
 			return tosca.CallResult{}, nil
 		}
 		r.SetCode(createdAddress, tosca.Code(result.Output))


### PR DESCRIPTION
The Spurious Dragon revision introduced an upper bound for the resulting code size of a create instruction. This  check is added to the runContext of Floria and checked against geth using an integration test.
Contributes to #714.