### PR TITLE
Refactor allowed operations in static context check. 

### DIFF
--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -244,6 +244,13 @@ func opMsize(c *context) {
 }
 
 func opSstore(c *context) {
+
+	// SStore is a write instruction, it shall not be executed in static mode.
+	if c.params.Static {
+		c.signalError()
+		return
+	}
+
 	gasfunc := gasSStore
 	if c.isAtLeast(tosca.R09_Berlin) {
 		gasfunc = gasSStoreEIP2929
@@ -287,6 +294,15 @@ func opSload(c *context) {
 }
 
 func opTstore(c *context) {
+
+	// Although not mentioned in the yellow paper, nor in CALL description at
+	// website (https://www.evm.codes/#FA) Geth treats this Op as a write instruction.
+	// therefore it shall not be executed in static mode.
+	if c.params.Static {
+		c.signalError()
+		return
+	}
+
 	if !c.isAtLeast(tosca.R13_Cancun) {
 		c.status = statusInvalidInstruction
 		return
@@ -698,6 +714,13 @@ func opBlobBaseFee(c *context) {
 }
 
 func opSelfdestruct(c *context) {
+
+	// SelfDestruct is a write instruction, it shall not be executed in static mode.
+	if c.params.Static {
+		c.signalError()
+		return
+	}
+
 	gasfunc := gasSelfdestruct
 	if c.isAtLeast(tosca.R09_Berlin) {
 		gasfunc = gasSelfdestructEIP2929
@@ -834,6 +857,13 @@ func checkInitCodeSize(c *context, size *uint256.Int) bool {
 }
 
 func opCreate(c *context) {
+
+	// Create is a write instruction, it shall not be executed in static mode.
+	if c.params.Static {
+		c.signalError()
+		return
+	}
+
 	var (
 		value  = c.stack.pop()
 		offset = c.stack.pop()
@@ -897,6 +927,13 @@ func opCreate(c *context) {
 }
 
 func opCreate2(c *context) {
+
+	// Create2 is a write instruction, it shall not be executed in static mode.
+	if c.params.Static {
+		c.signalError()
+		return
+	}
+
 	var (
 		value  = c.stack.pop()
 		offset = c.stack.pop()
@@ -1258,6 +1295,13 @@ func opReturnDataCopy(c *context) {
 }
 
 func opLog(c *context, size int) {
+
+	// LogN op codes are write instructions, they shall not be executed in static mode.
+	if c.params.Static {
+		c.signalError()
+		return
+	}
+
 	topics := make([]tosca.Hash, size)
 	stack := c.stack
 	mStart, mSize := stack.pop(), stack.pop()

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -243,16 +243,6 @@ func steps(c *context, oneStepOnly bool) {
 
 		op := c.code[c.pc].opcode
 
-		// If the interpreter is operating in readonly mode, make sure no
-		// state-modifying operation is performed. The 3rd stack item
-		// for a call operation is the value. Transferring value from one
-		// account to the others means the state is modified and should also
-		// return with an error.
-		if c.params.Static && (isWriteInstruction(op) || (op == CALL && c.stack.len() > 3 && c.stack.peekN(2).Sign() != 0)) {
-			c.signalError()
-			return
-		}
-
 		// Check stack boundary for every instruction
 		if !satisfiesStackRequirements(c, op) {
 			return
@@ -658,19 +648,4 @@ func _precomputeStackLimits() [256]stackLimits {
 		}
 	}
 	return res
-}
-
-func isWriteInstruction(opCode OpCode) bool {
-	const mask uint32 = 1 | // = 1 << (SSTORE - SSTORE) |
-		1<<(LOG0-SSTORE) |
-		1<<(LOG1-SSTORE) |
-		1<<(LOG2-SSTORE) |
-		1<<(LOG3-SSTORE) |
-		1<<(LOG4-SSTORE) |
-		1<<(CREATE-SSTORE) |
-		1<<(CREATE2-SSTORE) |
-		1<<(SELFDESTRUCT-SSTORE) |
-		1<<(TSTORE-SSTORE)
-
-	return SSTORE <= opCode && mask&(1<<(opCode-SSTORE)) != 0
 }

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -846,14 +846,6 @@ func BenchmarkFib10_SI(b *testing.B) {
 	benchmarkFib(b, 10, true)
 }
 
-var sink bool
-
-func BenchmarkIsWriteInstruction(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		sink = isWriteInstruction(OpCode(i % int(NUM_EXECUTABLE_OPCODES)))
-	}
-}
-
 func toKey(value byte) tosca.Key {
 	res := tosca.Key{}
 	res[len(res)-1] = value


### PR DESCRIPTION
Some Instructions are not allowed in static contexts, such checks can be done per opcode basis instead of in the main dispatching function. 

Checks have been moved into each op execution routine, Call check (regarding zero value) was already in place. 

- [x] CT

![image](https://github.com/user-attachments/assets/235c139c-3e1e-422e-9a85-df6f7216168e)