### PR TITLE
Switch to 9bit opcodes

### DIFF
--- a/go/interpreter/lfvm/gas.go
+++ b/go/interpreter/lfvm/gas.go
@@ -11,8 +11,6 @@
 package lfvm
 
 import (
-	"fmt"
-
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 	"github.com/holiman/uint256"
 )
@@ -50,38 +48,19 @@ const (
 	UNKNOWN_GAS_PRICE = 999999
 )
 
-var static_gas_prices = [512]tosca.Gas{}
-var static_gas_prices_berlin = [512]tosca.Gas{}
+var static_gas_prices = [numOpCodes]tosca.Gas{}
+var static_gas_prices_berlin = [numOpCodes]tosca.Gas{}
 
 func init() {
 
 	var gp tosca.Gas
 	for i := range static_gas_prices {
 		op := OpCode(i)
-		if !op.isExecutable() {
-			static_gas_prices[i] = UNKNOWN_GAS_PRICE
-			static_gas_prices_berlin[i] = UNKNOWN_GAS_PRICE
-			continue
-		}
-
 		gp = getStaticGasPriceInternal(op)
 		static_gas_prices[i] = gp
 		static_gas_prices_berlin[i] = gp
 	}
-	initBerlinGasPrice()
 
-	for i := range static_gas_prices {
-		op := OpCode(i)
-		if static_gas_prices[i] == UNKNOWN_GAS_PRICE && op.isExecutable() {
-			panic(fmt.Sprintf("Gas price for %v is unknown", op))
-		}
-		if static_gas_prices_berlin[i] == UNKNOWN_GAS_PRICE && op.isExecutable() {
-			panic(fmt.Sprintf("Berlin gas price for %v is unknown", op))
-		}
-	}
-}
-
-func initBerlinGasPrice() {
 	// Changed static gas prices with EIP2929
 	static_gas_prices_berlin[SLOAD] = 0
 	static_gas_prices_berlin[EXTCODECOPY] = 100
@@ -95,15 +74,14 @@ func initBerlinGasPrice() {
 	static_gas_prices_berlin[SELFDESTRUCT] = 5000
 }
 
-func getStaticGasPrices(revision tosca.Revision) []tosca.Gas {
+func getStaticGasPrices(revision tosca.Revision) *[numOpCodes]tosca.Gas {
 	if revision >= tosca.R09_Berlin {
-		return static_gas_prices_berlin[:]
+		return &static_gas_prices_berlin
 	}
-	return static_gas_prices[:]
+	return &static_gas_prices
 }
 
 func getStaticGasPriceInternal(op OpCode) tosca.Gas {
-	price := getStaticGasPriceInternal
 	if PUSH1 <= op && op <= PUSH32 {
 		return 3
 	}
@@ -256,48 +234,14 @@ func getStaticGasPriceInternal(op OpCode) tosca.Gas {
 		return 700 // Should be 100 according to evm.code
 	case SELFDESTRUCT:
 		return 0 // should be 5000 according to evm.code
+	}
 
-		// --- Super instructions ---
-	case PUSH1_ADD:
-		return price(PUSH1) + price(ADD)
-	case PUSH1_SHL:
-		return price(PUSH1) + price(SHL)
-	case PUSH1_DUP1:
-		return price(PUSH1) + price(DUP1)
-	case PUSH2_JUMP:
-		return price(PUSH2) + price(JUMP)
-	case PUSH2_JUMPI:
-		return price(PUSH2) + price(JUMPI)
-	case SWAP1_POP:
-		return price(SWAP1) + price(POP)
-	case SWAP2_POP:
-		return price(SWAP2) + price(POP)
-	case DUP2_MSTORE:
-		return price(DUP2) + price(MSTORE)
-	case DUP2_LT:
-		return price(DUP2) + price(LT)
-	case POP_JUMP:
-		return price(POP) + price(JUMP)
-	case POP_POP:
-		return price(POP) + price(POP)
-	case SWAP2_SWAP1:
-		return price(SWAP2) + price(SWAP1)
-	case PUSH1_PUSH1:
-		return price(PUSH1) + price(PUSH1)
-	case ISZERO_PUSH2_JUMPI:
-		return price(ISZERO) + price(PUSH2) + price(JUMPI)
-	case PUSH1_PUSH4_DUP3:
-		return price(PUSH1) + price(PUSH4) + price(DUP3)
-	case SWAP2_SWAP1_POP_JUMP:
-		return price(SWAP2) + price(SWAP1) + price(POP) + price(JUMP)
-	case SWAP1_POP_SWAP2_SWAP1:
-		return price(SWAP1) + price(POP) + price(SWAP2) + price(SWAP1)
-	case POP_SWAP2_SWAP1_POP:
-		return price(POP) + price(SWAP2) + price(SWAP1) + price(POP)
-	case AND_SWAP1_POP_SWAP2_SWAP1:
-		return price(AND) + price(SWAP1) + price(POP) + price(SWAP2) + price(SWAP1)
-	case PUSH1_PUSH1_PUSH1_SHL_SUB:
-		return 3*price(PUSH1) + price(SHL) + price(SUB)
+	if op.isSuperInstruction() {
+		var sum tosca.Gas
+		for _, subOp := range op.decompose() {
+			sum += getStaticGasPriceInternal(subOp)
+		}
+		return sum
 	}
 
 	return UNKNOWN_GAS_PRICE

--- a/go/interpreter/lfvm/instruction_statistics.go
+++ b/go/interpreter/lfvm/instruction_statistics.go
@@ -157,18 +157,6 @@ type statsCollector struct {
 }
 
 func (s *statsCollector) nextOp(op OpCode) {
-	// Stats for extended opcodes are collected for each decomposed OpCode.
-	// Extended opcodes which are not super-instructions yield no stats.
-	if op >= FIRST_LFVM_EXTENDED_OPCODE {
-		for _, component := range op.decompose() {
-			s.accumulateStats(component)
-		}
-		return
-	}
-	s.accumulateStats(op)
-}
-
-func (s *statsCollector) accumulateStats(op OpCode) {
 	cur := uint64(op)
 	s.stats.count++
 	s.stats.singleCount[cur]++

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -170,13 +170,10 @@ type OpcodeTest struct {
 func TestInterpreter_step_DetectsLowerStackLimitViolation(t *testing.T) {
 	// Add tests for execution
 
-	for _, op := range allExecutableOpCodes() {
+	for _, op := range allOpCodes() {
 
 		// Ignore operations that do not need any data on the stack.
-		usage, err := computeStackUsage(op)
-		if err != nil {
-			t.Fatalf("failed to obtain stack limit: %v", err)
-		}
+		usage := computeStackUsage(op)
 		if usage.from >= 0 {
 			continue
 		}
@@ -197,12 +194,9 @@ func TestInterpreter_step_DetectsLowerStackLimitViolation(t *testing.T) {
 
 func TestInterpreter_step_DetectsUpperStackLimitViolation(t *testing.T) {
 	// Add tests for execution
-	for _, op := range allExecutableOpCodes() {
+	for _, op := range allOpCodes() {
 		// Ignore operations that do not need any data on the stack.
-		usage, err := computeStackUsage(op)
-		if err != nil {
-			t.Fatalf("failed to obtain stack limit: %v", err)
-		}
+		usage := computeStackUsage(op)
 		if usage.to <= 0 {
 			continue
 		}
@@ -555,10 +549,10 @@ func TestStepsProperlyHandlesJUMP_TO(t *testing.T) {
 func TestStepsDetectsNonExecutableCode(t *testing.T) {
 	// Create execution context.
 	opCodes := []OpCode{
-		INVALID, // defined invalid
-		NOOP,    // extended set of instructions
-		DATA,    // extended set of instructions
-		0x0c,    //< some code that is not an opcode but within the range
+		INVALID,
+		NOOP,
+		DATA,
+		0x1234,
 	}
 
 	for _, opCode := range opCodes {
@@ -755,7 +749,7 @@ func BenchmarkSatisfiesStackRequirements(b *testing.B) {
 		stack: NewStack(),
 	}
 
-	opCodes := allExecutableOpCodes()
+	opCodes := allOpCodes()
 	for i := 0; i < b.N; i++ {
 		satisfiesStackRequirements(context, opCodes[i%len(opCodes)])
 	}

--- a/go/interpreter/lfvm/stack_usage.go
+++ b/go/interpreter/lfvm/stack_usage.go
@@ -10,8 +10,6 @@
 
 package lfvm
 
-import "fmt"
-
 // stackUsage defines the combined effect of an instruction on the stack. Each
 // instruction is accessing a range of elements on the stack relative to the
 // stack pointer. The range is given by the interval [from, to) where from is
@@ -23,9 +21,8 @@ type stackUsage struct {
 
 // computeStackUsage computes the stack usage of the given opcode. The result
 // is a stackUsage struct that defines the combined effect of the instruction
-// on the stack. If the opcode is not executable (i.e NOOP, INVALID), an error
-// is returned.
-func computeStackUsage(op OpCode) (stackUsage, error) {
+// on the stack. If the opcode is not known, zero stack usage is reported.
+func computeStackUsage(op OpCode) stackUsage {
 
 	// For single instructions it is easiest to define the stack usage based on
 	// the opcode's pops and pushes.
@@ -39,49 +36,49 @@ func computeStackUsage(op OpCode) (stackUsage, error) {
 	}
 
 	if PUSH1 <= op && op <= PUSH32 {
-		return makeUsage(0, 1), nil
+		return makeUsage(0, 1)
 	}
 	if DUP1 <= op && op <= DUP16 {
-		return makeUsage(int(op-DUP1+1), int(op-DUP1+2)), nil
+		return makeUsage(int(op-DUP1+1), int(op-DUP1+2))
 	}
 	if SWAP1 <= op && op <= SWAP16 {
-		return makeUsage(int(op-SWAP1+2), int(op-SWAP1+2)), nil
+		return makeUsage(int(op-SWAP1+2), int(op-SWAP1+2))
 	}
 	if LOG0 <= op && op <= LOG4 {
-		return makeUsage(int(op-LOG0+2), 0), nil
+		return makeUsage(int(op-LOG0+2), 0)
 	}
 
 	switch op {
 	case JUMPDEST, JUMP_TO, STOP:
-		return makeUsage(0, 0), nil
+		return makeUsage(0, 0)
 	case PUSH0, MSIZE, ADDRESS, ORIGIN, CALLER, CALLVALUE, CALLDATASIZE,
 		CODESIZE, GASPRICE, COINBASE, TIMESTAMP, NUMBER,
 		PREVRANDAO, GASLIMIT, PC, GAS, RETURNDATASIZE,
 		SELFBALANCE, CHAINID, BASEFEE, BLOBBASEFEE:
-		return makeUsage(0, 1), nil
+		return makeUsage(0, 1)
 	case POP, JUMP, SELFDESTRUCT:
-		return makeUsage(1, 0), nil
+		return makeUsage(1, 0)
 	case ISZERO, NOT, BALANCE, CALLDATALOAD, EXTCODESIZE,
 		BLOCKHASH, MLOAD, SLOAD, TLOAD, EXTCODEHASH, BLOBHASH:
-		return makeUsage(1, 1), nil
+		return makeUsage(1, 1)
 	case MSTORE, MSTORE8, SSTORE, TSTORE, JUMPI, RETURN, REVERT:
-		return makeUsage(2, 0), nil
+		return makeUsage(2, 0)
 	case ADD, SUB, MUL, DIV, SDIV, MOD, SMOD, EXP, SIGNEXTEND,
 		SHA3, LT, GT, SLT, SGT, EQ, AND, XOR, OR, BYTE,
 		SHL, SHR, SAR:
-		return makeUsage(2, 1), nil
+		return makeUsage(2, 1)
 	case CALLDATACOPY, CODECOPY, RETURNDATACOPY, MCOPY:
-		return makeUsage(3, 0), nil
+		return makeUsage(3, 0)
 	case ADDMOD, MULMOD, CREATE:
-		return makeUsage(3, 1), nil
+		return makeUsage(3, 1)
 	case EXTCODECOPY:
-		return makeUsage(4, 0), nil
+		return makeUsage(4, 0)
 	case CREATE2:
-		return makeUsage(4, 1), nil
+		return makeUsage(4, 1)
 	case STATICCALL, DELEGATECALL:
-		return makeUsage(6, 1), nil
+		return makeUsage(6, 1)
 	case CALL, CALLCODE:
-		return makeUsage(7, 1), nil
+		return makeUsage(7, 1)
 	}
 
 	// For super-instructions, we need to decompose the instruction into its
@@ -89,16 +86,12 @@ func computeStackUsage(op OpCode) (stackUsage, error) {
 	if op.isSuperInstruction() {
 		usages := []stackUsage{}
 		for _, subOp := range op.decompose() {
-			usage, err := computeStackUsage(subOp)
-			if err != nil {
-				return stackUsage{}, err
-			}
-			usages = append(usages, usage)
+			usages = append(usages, computeStackUsage(subOp))
 		}
-		return combineStackUsage(usages...), nil
+		return combineStackUsage(usages...)
 	}
 
-	return stackUsage{}, fmt.Errorf("unsupported opcode: %v", op)
+	return stackUsage{}
 }
 
 // combineStackUsage combines the given stack usages into a single stack usage.

--- a/go/interpreter/lfvm/stack_usage_test.go
+++ b/go/interpreter/lfvm/stack_usage_test.go
@@ -33,31 +33,11 @@ func TestComputeStackUsage_ProducesValidResultsForSingleOps(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.op.String(), func(t *testing.T) {
-			usage, err := computeStackUsage(test.op)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			usage := computeStackUsage(test.op)
 			if got, want := usage, test.usage; got != want {
 				t.Errorf("unexpected result: want %v, got %v", want, got)
 			}
 		})
-	}
-}
-
-func TestComputeStackUsage_ReportsAnErrorForInvalidOperations(t *testing.T) {
-	ops := []OpCode{
-		INVALID, // defined invalid
-		NOOP,    // extended set of instructions
-		DATA,    // extended set of instructions
-		0xffff,  // out of range
-		0x0c,    //< some code that is not an opcode but within the range
-	}
-
-	for _, op := range ops {
-		_, err := computeStackUsage(op)
-		if err == nil {
-			t.Errorf("expected error for opcode %v", op)
-		}
 	}
 }
 
@@ -116,11 +96,7 @@ func TestCombineStackUsage(t *testing.T) {
 		t.Run(fmt.Sprintf("%v", test.ops), func(t *testing.T) {
 			usages := []stackUsage{}
 			for _, op := range test.ops {
-				usage, err := computeStackUsage(op)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				usages = append(usages, usage)
+				usages = append(usages, computeStackUsage(op))
 			}
 
 			res := combineStackUsage(usages...)


### PR DESCRIPTION
This proof-of-concept show-cases how re-defining op-codes as 9-bit values can help reduce complexity.

Advantages:
- simplifies code by not having to distinguish between no-valid, valid and executable OpCodes
- gets rid of code that was handling errors that can no longer be triggered
- eliminates implementation constants in the OpCode enum that signify certain boundaries in the OpCode number range