### PR TITLE
LFVM: memory methods rename part 1

### DIFF
--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -212,6 +212,6 @@ func convertCtMemoryToLfvmMemory(memory *st.Memory) (*Memory, error) {
 
 func convertLfvmMemoryToCtMemory(memory *Memory) *st.Memory {
 	result := st.NewMemory()
-	result.Set(memory.GetSlice(0, memory.Len()))
+	result.Set(memory.GetSlice(0, memory.length()))
 	return result
 }

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -240,7 +240,7 @@ func opMload(c *context) {
 }
 
 func opMsize(c *context) {
-	c.stack.pushUndefined().SetUint64(uint64(c.memory.Len()))
+	c.stack.pushUndefined().SetUint64(uint64(c.memory.length()))
 }
 
 func opSstore(c *context) {
@@ -1118,7 +1118,7 @@ func genericCall(c *context, kind tosca.CallKind) {
 		needed_memory_size = ret_memory_size
 	}
 
-	baseGas := c.memory.ExpansionCosts(needed_memory_size)
+	baseGas := c.memory.getExpansionCosts(needed_memory_size)
 	checkGas := func(cost tosca.Gas) bool {
 		return 0 <= cost && cost <= c.gas
 	}

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -586,8 +586,8 @@ func TestMCopy(t *testing.T) {
 				t.Errorf("expected status %v, got %v", test.expectedStatus, ctxt.status)
 				return
 			}
-			if ctxt.memory.Len() != uint64(len(test.memoryAfter)) {
-				t.Errorf("expected memory size %d, got %d", uint64(len(test.memoryAfter)), ctxt.memory.Len())
+			if ctxt.memory.length() != uint64(len(test.memoryAfter)) {
+				t.Errorf("expected memory size %d, got %d", uint64(len(test.memoryAfter)), ctxt.memory.length())
 			}
 			if !bytes.Equal(ctxt.memory.Data(), test.memoryAfter) {
 				t.Errorf("expected memory %v, got %v", test.memoryAfter, ctxt.memory.Data())

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -589,8 +589,8 @@ func TestMCopy(t *testing.T) {
 			if ctxt.memory.length() != uint64(len(test.memoryAfter)) {
 				t.Errorf("expected memory size %d, got %d", uint64(len(test.memoryAfter)), ctxt.memory.length())
 			}
-			if !bytes.Equal(ctxt.memory.Data(), test.memoryAfter) {
-				t.Errorf("expected memory %v, got %v", test.memoryAfter, ctxt.memory.Data())
+			if data := ctxt.memory.GetSlice(0, ctxt.memory.length()); !bytes.Equal(data, test.memoryAfter) {
+				t.Errorf("expected memory %v, got %v", test.memoryAfter, data)
 			}
 			if ctxt.gas != test.gasAfter {
 				t.Errorf("expected gas %d, got %d", test.gasAfter, ctxt.gas)

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -261,24 +261,3 @@ func (m *Memory) GetSliceWithCapacity(offset, size uint64) []byte {
 	m.EnsureCapacityWithoutGas(size)
 	return m.GetSlice(offset, size)
 }
-
-func (m *Memory) Data() []byte {
-	return m.store
-}
-
-func (m *Memory) Print() {
-	fmt.Printf("### mem %d bytes ###\n", len(m.store))
-	if len(m.store) > 0 {
-		addr := 0
-		for i := 0; i+32 <= len(m.store); i += 32 {
-			fmt.Printf("%03d: % x\n", addr, m.store[i:i+32])
-			addr++
-		}
-		if len(m.store)%32 != 0 {
-			fmt.Printf("%03d: % x\n", addr, m.store[len(m.store)/32*32:])
-		}
-	} else {
-		fmt.Println("-- empty --")
-	}
-	fmt.Println("####################")
-}

--- a/go/interpreter/lfvm/memory_test.go
+++ b/go/interpreter/lfvm/memory_test.go
@@ -41,7 +41,7 @@ func TestExpansionCosts(t *testing.T) {
 	for _, test := range tests {
 
 		m := NewMemory()
-		cost := m.ExpansionCosts(test.size)
+		cost := m.getExpansionCosts(test.size)
 		if cost != test.cost {
 			t.Errorf("ExpansionCosts(%d) = %d, want %d", test.size, cost, test.cost)
 		}


### PR DESCRIPTION
Memory internal functions should not be public.
This PR renames `ExpansionCost` into `getExpansionCost` and `Len` to `length`. 
This PR removes `Data` and `Print` methods, since print is never used and data had a single use that can be replaced by a call to `GetSlice`. 
Follow up PRs will make the other functions in memory private and add tests for them. 