### PR TITLE
LFVM: `set` and `setByte` test

### DIFF
--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -211,11 +211,8 @@ func convertCtMemoryToLfvmMemory(memory *st.Memory) (*Memory, error) {
 
 	result := NewMemory()
 	size := uint64(len(data))
-	err := result.expandMemoryWithoutCharging(size)
-	if err != nil {
-		return nil, err
-	}
-	err = result.Set(0, size, data)
+	result.expandMemoryWithoutCharging(size)
+	err := result.set(0, size, data)
 	return result, err
 }
 

--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -208,7 +208,7 @@ func convertCtMemoryToLfvmMemory(memory *st.Memory) *Memory {
 
 	result := NewMemory()
 	size := uint64(len(data))
-	result.expandMemoryWithoutCharging(size)
+	_ = result.expandMemoryWithoutCharging(size)
 	copy(result.store, data)
 	return result
 }

--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -88,6 +88,7 @@ func (a *ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 	}
 
 	// Update the resulting state.
+	var err error
 	state.Status, err = convertLfvmStatusToCtStatus(status)
 	if err != nil {
 		return nil, err

--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -212,7 +212,7 @@ func convertCtMemoryToLfvmMemory(memory *st.Memory) (*Memory, error) {
 	result := NewMemory()
 	size := uint64(len(data))
 	result.expandMemoryWithoutCharging(size)
-	err := result.set(0, size, data)
+	err := result.trySet(0, size, data)
 	return result, err
 }
 

--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -58,10 +58,7 @@ func (a *ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 
 	pcMap := a.getPcMap(state.Code)
 
-	memory, err := convertCtMemoryToLfvmMemory(state.Memory)
-	if err != nil {
-		return nil, err
-	}
+	memory := convertCtMemoryToLfvmMemory(state.Memory)
 
 	// Set up execution context.
 	var ctxt = &context{
@@ -206,14 +203,14 @@ func convertLfvmStackToCtStack(stack *stack, result *st.Stack) *st.Stack {
 	return result
 }
 
-func convertCtMemoryToLfvmMemory(memory *st.Memory) (*Memory, error) {
+func convertCtMemoryToLfvmMemory(memory *st.Memory) *Memory {
 	data := memory.Read(0, uint64(memory.Size()))
 
 	result := NewMemory()
 	size := uint64(len(data))
 	result.expandMemoryWithoutCharging(size)
-	err := result.trySet(0, size, data)
-	return result, err
+	copy(result.store, data)
+	return result
 }
 
 func convertLfvmMemoryToCtMemory(memory *Memory) *st.Memory {

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -210,7 +210,7 @@ func opMcopy(c *context) error {
 	if err != nil {
 		return err
 	}
-	if err := c.memory.setWithCapacityAndGasCheck(destOffset, size, data, c); err != nil {
+	if err := c.memory.set(destOffset, size, data, c); err != nil {
 		return err
 	}
 	return nil
@@ -384,7 +384,7 @@ func opCallDataCopy(c *context) error {
 		return err
 	}
 
-	return c.memory.set(memOffset64, length64, getData(c.params.Input, dataOffset64, length64))
+	return c.memory.set(memOffset64, length64, getData(c.params.Input, dataOffset64, length64), c)
 }
 
 func opAnd(c *context) {
@@ -814,7 +814,7 @@ func opCodeCopy(c *context) error {
 		return err
 	}
 	codeCopy := getData(c.params.Code, uint64CodeOffset, length.Uint64())
-	return c.memory.set(memOffset.Uint64(), length.Uint64(), codeCopy)
+	return c.memory.set(memOffset.Uint64(), length.Uint64(), codeCopy, c)
 }
 
 func opExtcodesize(c *context) error {
@@ -1009,7 +1009,7 @@ func opExtCodeCopy(c *context) error {
 		return err
 	}
 	codeCopy := getData(c.context.GetCode(address), uint64CodeOffset, length.Uint64())
-	return c.memory.set(memOffset.Uint64(), length.Uint64(), codeCopy)
+	return c.memory.set(memOffset.Uint64(), length.Uint64(), codeCopy, c)
 }
 
 func checkSizeOffsetUint64Overflow(offset, size *uint256.Int) error {
@@ -1224,7 +1224,7 @@ func opReturnDataCopy(c *context) error {
 		return errOutOfGas
 	}
 
-	return c.memory.setWithCapacityAndGasCheck(memOffset.Uint64(), length.Uint64(), c.returnData[offset64:end64], c)
+	return c.memory.set(memOffset.Uint64(), length.Uint64(), c.returnData[offset64:end64], c)
 }
 
 func opLog(c *context, size int) error {

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -380,11 +380,13 @@ func opCallDataCopy(c *context) error {
 		return err
 	}
 
-	if err := c.memory.expandMemory(memOffset64, length64, c); err != nil {
+	data, err := c.memory.getSlice(memOffset64, length64, c)
+	if err != nil {
 		return err
 	}
-
-	return c.memory.set(memOffset64, length64, getData(c.params.Input, dataOffset64, length64), c)
+	codeCopy := getData(c.params.Input, dataOffset64, length64)
+	copy(data, codeCopy)
+	return nil
 }
 
 func opAnd(c *context) {
@@ -810,11 +812,13 @@ func opCodeCopy(c *context) error {
 		return err
 	}
 
-	if err := c.memory.expandMemory(memOffset.Uint64(), length.Uint64(), c); err != nil {
+	data, err := c.memory.getSlice(memOffset.Uint64(), length.Uint64(), c)
+	if err != nil {
 		return err
 	}
 	codeCopy := getData(c.params.Code, uint64CodeOffset, length.Uint64())
-	return c.memory.set(memOffset.Uint64(), length.Uint64(), codeCopy, c)
+	copy(data, codeCopy)
+	return nil
 }
 
 func opExtcodesize(c *context) error {
@@ -1005,11 +1009,13 @@ func opExtCodeCopy(c *context) error {
 		uint64CodeOffset = math.MaxUint64
 	}
 
-	if err := c.memory.expandMemory(memOffset.Uint64(), length.Uint64(), c); err != nil {
+	data, err := c.memory.getSlice(memOffset.Uint64(), length.Uint64(), c)
+	if err != nil {
 		return err
 	}
 	codeCopy := getData(c.context.GetCode(address), uint64CodeOffset, length.Uint64())
-	return c.memory.set(memOffset.Uint64(), length.Uint64(), codeCopy, c)
+	copy(data, codeCopy)
+	return nil
 }
 
 func checkSizeOffsetUint64Overflow(offset, size *uint256.Int) error {

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -176,7 +176,7 @@ func opMstore8(c *context) error {
 	if overflow {
 		return errOverflow
 	}
-	return c.memory.SetByte(offset, byte(value.Uint64()), c)
+	return c.memory.setByte(offset, byte(value.Uint64()), c)
 }
 
 func opMcopy(c *context) error {
@@ -210,7 +210,7 @@ func opMcopy(c *context) error {
 	if err != nil {
 		return err
 	}
-	if err := c.memory.SetWithCapacityAndGasCheck(destOffset, size, data, c); err != nil {
+	if err := c.memory.setWithCapacityAndGasCheck(destOffset, size, data, c); err != nil {
 		return err
 	}
 	return nil
@@ -1224,7 +1224,7 @@ func opReturnDataCopy(c *context) error {
 		return errOutOfGas
 	}
 
-	return c.memory.SetWithCapacityAndGasCheck(memOffset.Uint64(), length.Uint64(), c.returnData[offset64:end64], c)
+	return c.memory.setWithCapacityAndGasCheck(memOffset.Uint64(), length.Uint64(), c.returnData[offset64:end64], c)
 }
 
 func opLog(c *context, size int) error {

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -384,7 +384,7 @@ func opCallDataCopy(c *context) error {
 		return err
 	}
 
-	return c.memory.Set(memOffset64, length64, getData(c.params.Input, dataOffset64, length64))
+	return c.memory.set(memOffset64, length64, getData(c.params.Input, dataOffset64, length64))
 }
 
 func opAnd(c *context) {
@@ -814,7 +814,7 @@ func opCodeCopy(c *context) error {
 		return err
 	}
 	codeCopy := getData(c.params.Code, uint64CodeOffset, length.Uint64())
-	return c.memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
+	return c.memory.set(memOffset.Uint64(), length.Uint64(), codeCopy)
 }
 
 func opExtcodesize(c *context) error {
@@ -1009,7 +1009,7 @@ func opExtCodeCopy(c *context) error {
 		return err
 	}
 	codeCopy := getData(c.context.GetCode(address), uint64CodeOffset, length.Uint64())
-	return c.memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
+	return c.memory.set(memOffset.Uint64(), length.Uint64(), codeCopy)
 }
 
 func checkSizeOffsetUint64Overflow(offset, size *uint256.Int) error {

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -165,7 +165,8 @@ func opMstore(c *context) error {
 	if overflow {
 		return errOverflow
 	}
-	return c.memory.setWord(offset, value, c)
+	data := value.Bytes32()
+	return c.memory.set(offset, data[:], c)
 }
 
 func opMstore8(c *context) error {
@@ -176,7 +177,7 @@ func opMstore8(c *context) error {
 	if overflow {
 		return errOverflow
 	}
-	return c.memory.setByte(offset, byte(value.Uint64()), c)
+	return c.memory.set(offset, []byte{byte(value.Uint64())}, c)
 }
 
 func opMcopy(c *context) error {
@@ -210,7 +211,7 @@ func opMcopy(c *context) error {
 	if err != nil {
 		return err
 	}
-	if err := c.memory.set(destOffset, size, data, c); err != nil {
+	if err := c.memory.set(destOffset, data, c); err != nil {
 		return err
 	}
 	return nil
@@ -1230,7 +1231,7 @@ func opReturnDataCopy(c *context) error {
 		return errOutOfGas
 	}
 
-	return c.memory.set(memOffset.Uint64(), length.Uint64(), c.returnData[offset64:end64], c)
+	return c.memory.set(memOffset.Uint64(), c.returnData[offset64:end64], c)
 }
 
 func opLog(c *context, size int) error {

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -165,7 +165,7 @@ func opMstore(c *context) error {
 	if overflow {
 		return errOverflow
 	}
-	return c.memory.SetWord(offset, value, c)
+	return c.memory.setWord(offset, value, c)
 }
 
 func opMstore8(c *context) error {

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -149,7 +149,8 @@ func (m *Memory) readWord(offset uint64, target *uint256.Int, c *context) error 
 	return nil
 }
 
-// set sets the given value at the given offset, expands memory as needed and charges for it.
+// set copies the given value into memory at the given offset.
+// Expands memory as needed and charges for it.
 // Returns error if insufficient gas or offset+size overflows.
 func (m *Memory) set(offset, size uint64, value []byte, c *context) error {
 	data, err := m.getSlice(offset, size, c)
@@ -160,13 +161,16 @@ func (m *Memory) set(offset, size uint64, value []byte, c *context) error {
 	return nil
 }
 
-// setByte sets a byte at the given offset, expanding memory as needed and charging for it.
+// setByte copies the given byte at the given offset in memory.
+// Expanding memory as needed and charging for it.
 // Returns error if insufficient gas or offset+1 overflows.
 func (m *Memory) setByte(offset uint64, value byte, c *context) error {
 	return m.set(offset, 1, []byte{value}, c)
 }
 
-// setWord sets a 32-byte word at the given offset, expanding memory as needed and charging for it.
+// setWord copies the given 32-byte word at the given offset.
+// Expanding memory as needed and charging for it.
+// Returns error if insufficient gas or offset+32 overflows.
 func (m *Memory) setWord(offset uint64, value *uint256.Int, c *context) error {
 	data := value.Bytes32()
 	return m.set(offset, 32, data[:], c)

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -185,15 +185,11 @@ func (m *Memory) trySet(offset, size uint64, value []byte) error {
 			return errOverflow
 		}
 		if offset+size > m.length() {
-			return makeInsufficientMemoryError(m.length(), size, offset)
+			return fmt.Errorf("memory too small, size %d, attempted to write %d bytes at %d", m.length(), size, offset)
 		}
 		copy(m.store[offset:offset+size], value)
 	}
 	return nil
-}
-
-func makeInsufficientMemoryError(memSize, size, offset uint64) error {
-	return tosca.ConstError(fmt.Sprintf("memory too small, size %d, attempted to write %d bytes at %d", memSize, size, offset))
 }
 
 // set sets the given value at the given offset, expands memory as needed and charges for it.

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -11,8 +11,6 @@
 package lfvm
 
 import (
-	"fmt"
-
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 	"github.com/holiman/uint256"
 )
@@ -121,87 +119,6 @@ func (m *Memory) length() uint64 {
 	return uint64(len(m.store))
 }
 
-// setByte sets a byte at the given offset, expanding memory as needed and charging for it.
-// Returns error if insufficient gas or offset+1 overflows.
-func (m *Memory) setByte(offset uint64, value byte, c *context) error {
-	return m.set(offset, 1, []byte{value}, c)
-}
-
-func (m *Memory) SetWord(offset uint64, value *uint256.Int, c *context) error {
-	err := m.expandMemory(offset, 32, c)
-	if err != nil {
-		return err
-	}
-
-	if m.length() < offset+32 {
-		return fmt.Errorf("memory too small, size %d, attempted to write 32 byte at position %d", m.length(), offset)
-	}
-
-	// Inlining and unrolling value.WriteToSlice(..) lead to a 7x speedup
-	dest := m.store[offset : offset+32]
-	dest[31] = byte(value[0])
-	dest[30] = byte(value[0] >> 8)
-	dest[29] = byte(value[0] >> 16)
-	dest[28] = byte(value[0] >> 24)
-	dest[27] = byte(value[0] >> 32)
-	dest[26] = byte(value[0] >> 40)
-	dest[25] = byte(value[0] >> 48)
-	dest[24] = byte(value[0] >> 56)
-
-	dest[23] = byte(value[1])
-	dest[22] = byte(value[1] >> 8)
-	dest[21] = byte(value[1] >> 16)
-	dest[20] = byte(value[1] >> 24)
-	dest[19] = byte(value[1] >> 32)
-	dest[18] = byte(value[1] >> 40)
-	dest[17] = byte(value[1] >> 48)
-	dest[16] = byte(value[1] >> 56)
-
-	dest[15] = byte(value[2])
-	dest[14] = byte(value[2] >> 8)
-	dest[13] = byte(value[2] >> 16)
-	dest[12] = byte(value[2] >> 24)
-	dest[11] = byte(value[2] >> 32)
-	dest[10] = byte(value[2] >> 40)
-	dest[9] = byte(value[2] >> 48)
-	dest[8] = byte(value[2] >> 56)
-
-	dest[7] = byte(value[3])
-	dest[6] = byte(value[3] >> 8)
-	dest[5] = byte(value[3] >> 16)
-	dest[4] = byte(value[3] >> 24)
-	dest[3] = byte(value[3] >> 32)
-	dest[2] = byte(value[3] >> 40)
-	dest[1] = byte(value[3] >> 48)
-	dest[0] = byte(value[3] >> 56)
-	return nil
-}
-
-// set sets the given value at the given offset, expands memory as needed and charges for it.
-// Returns error if insufficient gas or offset+size overflows.
-func (m *Memory) trySet(offset, size uint64, value []byte) error {
-	if size > 0 {
-		if offset+size < offset {
-			return errOverflow
-		}
-		if offset+size > m.length() {
-			return fmt.Errorf("memory too small, size %d, attempted to write %d bytes at %d", m.length(), size, offset)
-		}
-		copy(m.store[offset:offset+size], value)
-	}
-	return nil
-}
-
-// set sets the given value at the given offset, expands memory as needed and charges for it.
-// Returns error if insufficient gas or offset+size overflows.
-func (m *Memory) set(offset, size uint64, value []byte, c *context) error {
-	err := m.expandMemory(offset, size, c)
-	if err != nil {
-		return err
-	}
-	return m.trySet(offset, size, value)
-}
-
 // getSlice obtains a slice of size bytes from the memory at the given offset.
 // The returned slice is backed by the memory's internal data. Updates to the
 // slice will thus effect the memory states. This connection is invalidated by any
@@ -230,4 +147,27 @@ func (m *Memory) readWord(offset uint64, target *uint256.Int, c *context) error 
 	}
 	target.SetBytes32(data)
 	return nil
+}
+
+// set sets the given value at the given offset, expands memory as needed and charges for it.
+// Returns error if insufficient gas or offset+size overflows.
+func (m *Memory) set(offset, size uint64, value []byte, c *context) error {
+	data, err := m.getSlice(offset, size, c)
+	if err != nil {
+		return err
+	}
+	copy(data, value)
+	return nil
+}
+
+// setByte sets a byte at the given offset, expanding memory as needed and charging for it.
+// Returns error if insufficient gas or offset+1 overflows.
+func (m *Memory) setByte(offset uint64, value byte, c *context) error {
+	return m.set(offset, 1, []byte{value}, c)
+}
+
+// setWord sets a 32-byte word at the given offset, expanding memory as needed and charging for it.
+func (m *Memory) SetWord(offset uint64, value *uint256.Int, c *context) error {
+	data := value.Bytes32()
+	return m.set(offset, 32, data[:], c)
 }

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -167,7 +167,7 @@ func (m *Memory) setByte(offset uint64, value byte, c *context) error {
 }
 
 // setWord sets a 32-byte word at the given offset, expanding memory as needed and charging for it.
-func (m *Memory) SetWord(offset uint64, value *uint256.Int, c *context) error {
+func (m *Memory) setWord(offset uint64, value *uint256.Int, c *context) error {
 	data := value.Bytes32()
 	return m.set(offset, 32, data[:], c)
 }

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -150,28 +150,13 @@ func (m *Memory) readWord(offset uint64, target *uint256.Int, c *context) error 
 }
 
 // set copies the given value into memory at the given offset.
-// Expands memory as needed and charges for it.
-// Returns error if insufficient gas or offset+size overflows.
-func (m *Memory) set(offset, size uint64, value []byte, c *context) error {
-	data, err := m.getSlice(offset, size, c)
+// Expands the memory size as needed and charges for it.
+// Returns an error if there is not enough gas or offset+len(value) overflows.
+func (m *Memory) set(offset uint64, value []byte, c *context) error {
+	data, err := m.getSlice(offset, uint64(len(value)), c)
 	if err != nil {
 		return err
 	}
 	copy(data, value)
 	return nil
-}
-
-// setByte copies the given byte at the given offset in memory.
-// Expanding memory as needed and charging for it.
-// Returns error if insufficient gas or offset+1 overflows.
-func (m *Memory) setByte(offset uint64, value byte, c *context) error {
-	return m.set(offset, 1, []byte{value}, c)
-}
-
-// setWord copies the given 32-byte word at the given offset.
-// Expanding memory as needed and charging for it.
-// Returns error if insufficient gas or offset+32 overflows.
-func (m *Memory) setWord(offset uint64, value *uint256.Int, c *context) error {
-	data := value.Bytes32()
-	return m.set(offset, 32, data[:], c)
 }

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -122,7 +122,7 @@ func (m *Memory) length() uint64 {
 }
 
 // setByte sets a byte at the given offset, expanding memory as needed and charging for it.
-// If any error occurs during EnsureCapacity, this is reflected in context status.
+// Returns error if insufficient gas or offset+1 overflows.
 func (m *Memory) setByte(offset uint64, value byte, c *context) error {
 	return m.setWithCapacityAndGasCheck(offset, 1, []byte{value}, c)
 }
@@ -177,29 +177,33 @@ func (m *Memory) SetWord(offset uint64, value *uint256.Int, c *context) error {
 	return nil
 }
 
-func (m *Memory) Set(offset, size uint64, value []byte) error {
+// set sets the given value at the given offset.
+// Returns error if insufficient memory or offset+size overflows.
+func (m *Memory) set(offset, size uint64, value []byte) error {
 	if size > 0 {
 		if offset+size < offset {
 			return errOverflow
 		}
 		if offset+size > m.length() {
-			return fmt.Errorf("memory too small, size %d, attempted to write %d bytes at %d", m.length(), size, offset)
+			return makeInsufficientMemoryError(m.length(), size, offset)
 		}
 		copy(m.store[offset:offset+size], value)
 	}
 	return nil
 }
 
+func makeInsufficientMemoryError(memSize, size, offset uint64) error {
+	return tosca.ConstError(fmt.Sprintf("memory too small, size %d, attempted to write %d bytes at %d", memSize, size, offset))
+}
+
+// setWithCapacityAndGasCheck sets the given value at the given offset, expands memory as needed and charges for it.
+// Returns error if insufficient gas or offset+size overflows.
 func (m *Memory) setWithCapacityAndGasCheck(offset, size uint64, value []byte, c *context) error {
 	err := m.expandMemory(offset, size, c)
 	if err != nil {
 		return err
 	}
-	err = m.Set(offset, size, value)
-	if err != nil {
-		return err
-	}
-	return nil
+	return m.set(offset, size, value)
 }
 
 // getSlice obtains a slice of size bytes from the memory at the given offset.

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -124,7 +124,7 @@ func (m *Memory) length() uint64 {
 // setByte sets a byte at the given offset, expanding memory as needed and charging for it.
 // Returns error if insufficient gas or offset+1 overflows.
 func (m *Memory) setByte(offset uint64, value byte, c *context) error {
-	return m.setWithCapacityAndGasCheck(offset, 1, []byte{value}, c)
+	return m.set(offset, 1, []byte{value}, c)
 }
 
 func (m *Memory) SetWord(offset uint64, value *uint256.Int, c *context) error {
@@ -177,9 +177,9 @@ func (m *Memory) SetWord(offset uint64, value *uint256.Int, c *context) error {
 	return nil
 }
 
-// set sets the given value at the given offset.
+// trySet sets the given value at the given offset.
 // Returns error if insufficient memory or offset+size overflows.
-func (m *Memory) set(offset, size uint64, value []byte) error {
+func (m *Memory) trySet(offset, size uint64, value []byte) error {
 	if size > 0 {
 		if offset+size < offset {
 			return errOverflow
@@ -196,14 +196,14 @@ func makeInsufficientMemoryError(memSize, size, offset uint64) error {
 	return tosca.ConstError(fmt.Sprintf("memory too small, size %d, attempted to write %d bytes at %d", memSize, size, offset))
 }
 
-// setWithCapacityAndGasCheck sets the given value at the given offset, expands memory as needed and charges for it.
+// set sets the given value at the given offset, expands memory as needed and charges for it.
 // Returns error if insufficient gas or offset+size overflows.
-func (m *Memory) setWithCapacityAndGasCheck(offset, size uint64, value []byte, c *context) error {
+func (m *Memory) set(offset, size uint64, value []byte, c *context) error {
 	err := m.expandMemory(offset, size, c)
 	if err != nil {
 		return err
 	}
-	return m.set(offset, size, value)
+	return m.trySet(offset, size, value)
 }
 
 // getSlice obtains a slice of size bytes from the memory at the given offset.

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -177,8 +177,8 @@ func (m *Memory) SetWord(offset uint64, value *uint256.Int, c *context) error {
 	return nil
 }
 
-// trySet sets the given value at the given offset.
-// Returns error if insufficient memory or offset+size overflows.
+// set sets the given value at the given offset, expands memory as needed and charges for it.
+// Returns error if insufficient gas or offset+size overflows.
 func (m *Memory) trySet(offset, size uint64, value []byte) error {
 	if size > 0 {
 		if offset+size < offset {

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -121,17 +121,10 @@ func (m *Memory) length() uint64 {
 	return uint64(len(m.store))
 }
 
-func (m *Memory) SetByte(offset uint64, value byte, c *context) error {
-	err := m.expandMemory(offset, 1, c)
-	if err != nil {
-		return err
-	}
-
-	if m.length() < offset+1 {
-		return fmt.Errorf("memory too small, size %d, attempted to write at position %d", m.length(), offset)
-	}
-	m.store[offset] = value
-	return nil
+// setByte sets a byte at the given offset, expanding memory as needed and charging for it.
+// If any error occurs during EnsureCapacity, this is reflected in context status.
+func (m *Memory) setByte(offset uint64, value byte, c *context) error {
+	return m.setWithCapacityAndGasCheck(offset, 1, []byte{value}, c)
 }
 
 func (m *Memory) SetWord(offset uint64, value *uint256.Int, c *context) error {
@@ -197,7 +190,7 @@ func (m *Memory) Set(offset, size uint64, value []byte) error {
 	return nil
 }
 
-func (m *Memory) SetWithCapacityAndGasCheck(offset, size uint64, value []byte, c *context) error {
+func (m *Memory) setWithCapacityAndGasCheck(offset, size uint64, value []byte, c *context) error {
 	err := m.expandMemory(offset, size, c)
 	if err != nil {
 		return err

--- a/go/interpreter/lfvm/memory_test.go
+++ b/go/interpreter/lfvm/memory_test.go
@@ -143,9 +143,8 @@ func TestMemory_expandMemory_ErrorCases(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctxt := getEmptyContext()
+			ctxt := context{gas: test.gas}
 			m := NewMemory()
-			ctxt.gas = test.gas
 
 			err := m.expandMemory(test.offset, test.size, &ctxt)
 			if !errors.Is(err, test.expected) {
@@ -187,10 +186,9 @@ func TestMemory_expandMemory_expandsMemoryOnlyWhenNeeded(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctxt := getEmptyContext()
+			ctxt := context{gas: 3}
 			m := NewMemory()
 			m.store = make([]byte, test.initialMemorySize)
-			ctxt.gas = 3
 
 			err := m.expandMemory(test.offset, test.size, &ctxt)
 			if err != nil {
@@ -367,7 +365,7 @@ func TestMemory_Set_SuccessfulCases(t *testing.T) {
 	}
 	size := uint64(len(data))
 
-	c := getEmptyContext()
+	c := context{gas: 3}
 	m := NewMemory()
 	m.store = make([]byte, memoryOriginalSize)
 
@@ -411,8 +409,7 @@ func TestToValidateMemorySize_ReturnsOverflowError(t *testing.T) {
 }
 
 func TestMemory_Set_ErrorCases(t *testing.T) {
-	c := getEmptyContext()
-	c.gas = 0
+	c := context{gas: 0}
 	m := NewMemory()
 
 	err := m.set(0, 1, []byte{}, &c)
@@ -434,10 +431,9 @@ func TestMemory_SetByte_SuccessfulCases(t *testing.T) {
 	memory := []byte{0x12, 0x34, 0x56, 0x78}
 	offset := uint64(8)
 
-	ctxt := getEmptyContext()
+	ctxt := context{gas: 3}
 	m := NewMemory()
 	m.store = bytes.Clone(memory)
-	ctxt.gas = tosca.Gas(3)
 	value := byte(0xff)
 
 	err := m.setByte(offset, value, &ctxt)
@@ -464,9 +460,8 @@ func TestMemory_SetByte_SuccessfulCases(t *testing.T) {
 }
 
 func TestMemory_SetByte_ErrorCases(t *testing.T) {
-	ctxt := getEmptyContext()
+	ctxt := context{gas: 0}
 	m := NewMemory()
-	ctxt.gas = 0
 	err := m.setByte(math.MaxUint64, 0x12, &ctxt)
 	if !errors.Is(err, errOverflow) {
 		t.Errorf("unexpected error, want: %v, got: %v", errOverflow, err)
@@ -478,8 +473,7 @@ func TestMemory_SetByte_ErrorCases(t *testing.T) {
 }
 
 func TestMemory_setWord_successfulCase(t *testing.T) {
-	c := getEmptyContext()
-	c.gas = 7
+	c := context{gas: 6 + 1}
 	m := NewMemory()
 	offset := uint64(1)
 	value := new(uint256.Int).SetBytes([]byte{0xff, 0xee})
@@ -500,10 +494,9 @@ func TestMemory_setWord_successfulCase(t *testing.T) {
 }
 
 func TestMemory_SetWord_ErrorCases(t *testing.T) {
-	ctxt := getEmptyContext()
+	ctxt := context{gas: 0}
 	// SetWord (and EnsureCapacity) check for offset overflow before checking gas
 	// hence it is fine to check both cases with gas = 0
-	ctxt.gas = 0
 	m := NewMemory()
 	if err := m.setWord(math.MaxUint64-31, new(uint256.Int), &ctxt); !errors.Is(err, errOverflow) {
 		t.Fatalf("expected error, wanted overflow error but got %v", err)

--- a/go/interpreter/lfvm/memory_test.go
+++ b/go/interpreter/lfvm/memory_test.go
@@ -386,9 +386,9 @@ func TestMemory_SetByte_SuccessfulCases(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctxt := getEmptyContext()
 			m := NewMemory()
-			m.store = test.memory
+			m.store = bytes.Clone(test.memory)
 			ctxt.gas = tosca.Gas(3)
-			value := byte(0x12)
+			value := byte(0xff)
 
 			err := m.setByte(test.offset, value, &ctxt)
 			if err != nil {
@@ -399,8 +399,23 @@ func TestMemory_SetByte_SuccessfulCases(t *testing.T) {
 			if m.length() <= test.offset {
 				t.Errorf("unexpected memory size, want: %d, got: %d", test.offset, m.length())
 			}
-			if m.store[test.offset] != value {
-				t.Errorf("unexpected value, want: %v, got: %v", value, m.store[test.offset])
+			if test.memory != nil {
+				for i, b := range test.memory {
+					if i == int(test.offset) {
+						if m.store[i] != value {
+							t.Errorf("unexpected value, want: %v, got: %v", value, m.store[i])
+						}
+					} else {
+						if m.store[i] != b {
+							t.Errorf("unexpected value at position %v, want: %v, got: %v", i, b, m.store[i])
+						}
+					}
+				}
+			} else {
+				// for empty memories expansion we only want to check the offset byte.
+				if m.store[test.offset] != value {
+					t.Errorf("unexpected value, want: %v, got: %v", value, m.store[test.offset])
+				}
 			}
 		})
 	}
@@ -421,7 +436,7 @@ func TestMemory_SetByte_ErrorCases(t *testing.T) {
 
 }
 
-func TestMemory_Set_SuccessfulCases(t *testing.T) {
+func TestMemory_TrySet_SuccessfulCases(t *testing.T) {
 
 	memoryOriginalSize := uint64(8)
 	offset := uint64(1)
@@ -436,7 +451,7 @@ func TestMemory_Set_SuccessfulCases(t *testing.T) {
 	m := NewMemory()
 	m.store = make([]byte, memoryOriginalSize)
 
-	err := m.set(offset, size, data)
+	err := m.trySet(offset, size, data)
 	if err != nil {
 		t.Fatalf("unexpected error, want: %v, got: %v", nil, err)
 	}
@@ -450,24 +465,25 @@ func TestMemory_Set_SuccessfulCases(t *testing.T) {
 
 }
 
-func TestMemory_Set_ErrorCases(t *testing.T) {
+func TestMemory_TrySet_ErrorCases(t *testing.T) {
+	c := context{gas: 0}
 	m := NewMemory()
 	m.store = make([]byte, 8)
 	// since we are only testing for failed cases, data is not relevant because
 	// the internal checks are done with offset and size parameters.
 
 	// size overflow
-	err := m.set(1, math.MaxUint64, []byte{})
+	err := m.set(1, math.MaxUint64, []byte{}, &c)
 	if !errors.Is(err, errOverflow) {
 		t.Errorf("unexpected error, want: %v, got: %v", errOverflow, err)
 	}
 	// offset overflow
-	err = m.set(math.MaxUint64, 1, []byte{})
+	err = m.set(math.MaxUint64, 1, []byte{}, &c)
 	if !errors.Is(err, errOverflow) {
 		t.Errorf("unexpected error, want: %v, got: %v", errOverflow, err)
 	}
 	// not enough memory
-	err = m.set(32, 32, []byte{})
+	err = m.trySet(32, 32, []byte{})
 	if !errors.Is(err, makeInsufficientMemoryError(8, 32, 32)) {
 		t.Errorf("unexpected error, want: %v, got: %v", makeInsufficientMemoryError(8, 32, 32), err)
 	}

--- a/go/interpreter/lfvm/memory_test.go
+++ b/go/interpreter/lfvm/memory_test.go
@@ -12,6 +12,7 @@ package lfvm
 
 import (
 	"bytes"
+	"crypto/rand"
 	"errors"
 	"math"
 	"testing"
@@ -379,148 +380,85 @@ func TestToValidateMemorySize_ReturnsOverflowError(t *testing.T) {
 	}
 }
 
-func TestMemory_set_SuccessfulCase(t *testing.T) {
-	const (
-		writeSize   = uint64(8)
-		offset      = uint64(1)
-		paddingSize = 32 - (writeSize + offset)
-	)
-	data := make([]byte, writeSize)
-	for i := range data {
-		// add non zero values.
-		data[i] = byte(i + 1)
-	}
-	c := context{gas: 3}
-	m := NewMemory()
-	m.store = []byte{0xff}
-
-	err := m.set(offset, writeSize, data, &c)
-	if err != nil {
-		t.Fatalf("unexpected error, want: %v, got: %v", nil, err)
-	}
-	got, err := toValidMemorySize(writeSize)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if m.length() != got {
-		t.Errorf("set should have expanded the memory to %d, but instead got: %d", got, m.length())
-	}
-	want := append([]byte{0xff}, data...)
-	want = append(want, []byte{paddingSize - 1: 0x0}...)
-	if !bytes.Equal(m.store, want) {
-		t.Errorf("unexpected memory value, want: %x, got: %x", want, m.store)
-	}
-}
-
-func TestMemory_set_ErrorCases(t *testing.T) {
-	c := context{gas: 0}
-	m := NewMemory()
-
-	err := m.set(0, 1, []byte{}, &c)
-	if !errors.Is(err, errOutOfGas) {
-		t.Errorf("unexpected error, want: %v, got: %v", errOutOfGas, err)
-	}
-	err = m.set(math.MaxUint64, 1, []byte{}, &c)
-	if !errors.Is(err, errOverflow) {
-		t.Errorf("unexpected error, want: %v, got: %v", errOverflow, err)
-	}
-	err = m.set(1, math.MaxUint64, []byte{}, &c)
-	if !errors.Is(err, errOverflow) {
-		t.Errorf("unexpected error, want: %v, got: %v", errOverflow, err)
-	}
-}
-
-func TestMemory_set_sizeZeroDoesNotProduceExpansion(t *testing.T) {
+func TestMemory_set_UpdatesDataInMemoryAtGivenOffset(t *testing.T) {
+	before := generateRandomBytes(128)
 	for offset := uint64(0); offset < 128; offset++ {
-		c := context{gas: 0}
-		m := NewMemory()
-		m.store = []byte{0x1}
-		err := m.set(offset, 0, []byte{}, &c)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if m.length() != 1 {
-			t.Errorf("memory should not have been expanded, instead is: %d", m.length())
+		for size := 0; size < int(128-offset); size++ {
+			data := generateRandomBytes(size)
+
+			// test the memory update
+			m := &Memory{store: bytes.Clone(before)}
+			if err := m.set(offset, data, nil); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			// check if only the data at the given offset has changed
+			want := bytes.Clone(before)
+			copy(want[offset:], data)
+			if !bytes.Equal(m.store, want) {
+				t.Errorf("unexpected memory value after set, want: %x, got: %x", want, m.store)
+			}
 		}
 	}
 }
 
-func TestMemory_setByte_SuccessfulCase(t *testing.T) {
-	memory := []byte{0x12, 0x34, 0x56, 0x78}
-	offset := uint64(8)
-	ctxt := context{gas: 3}
-	m := NewMemory()
-	m.store = bytes.Clone(memory)
-	value := byte(0xff)
-
-	err := m.setByte(offset, value, &ctxt)
-	if err != nil {
-		t.Errorf("unexpected error, want: %v, got: %v", nil, err)
-	}
-	got, err := toValidMemorySize(offset + 1)
-	if err != nil {
+func TestMemory_set_PreservesMemoryWhenGrowingAndPadsWithZeros(t *testing.T) {
+	before := generateRandomBytes(32)
+	m := &Memory{store: bytes.Clone(before)}
+	if err := m.set(64, []byte{0x1, 0x2}, &context{gas: 100}); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if m.length() != got {
-		t.Errorf("unexpected memory size, want: %d, got: %d", got, m.length())
+
+	want := bytes.Clone(before)              // < preserved data
+	want = append(want, make([]byte, 32)...) // < zero-padding before the new data
+	want = append(want, []byte{0x1, 0x2}...) // < the new data
+	want = append(want, make([]byte, 30)...) // < zero-padding after the new data
+
+	if !bytes.Equal(m.store, want) {
+		t.Errorf("unexpected memory value after set, want: %x, got: %x", want, m.store)
 	}
-	for i, b := range m.store {
-		if i == int(offset) {
-			if m.store[i] != value {
-				t.Errorf("unexpected value, want: %v, got: %v", value, m.store[i])
+}
+
+func TestMemory_set_IgnoresEmptyData(t *testing.T) {
+	before := generateRandomBytes(32)
+	for _, offset := range []uint64{0, 32, 64} {
+		for _, data := range [][]byte{nil, {}} {
+			m := &Memory{store: bytes.Clone(before)}
+			if err := m.set(offset, data, nil); err != nil {
+				t.Errorf("unexpected error: %v", err)
 			}
-		} else {
-			if m.store[i] != b {
-				t.Errorf("unexpected value at position %v, want: %v, got: %v", i, b, m.store[i])
+			if !bytes.Equal(m.store, before) {
+				t.Errorf("unexpected no change in data, want: %x, got: %x", before, m.store)
 			}
 		}
 	}
-
 }
 
-func TestMemory_SetByte_ErrorCases(t *testing.T) {
-	ctxt := context{gas: 0}
-	m := NewMemory()
-	err := m.setByte(math.MaxUint64, 0x12, &ctxt)
-	if !errors.Is(err, errOverflow) {
-		t.Errorf("unexpected error, want: %v, got: %v", errOverflow, err)
+func TestMemory_set_FailsIfThereIsNotEnoughGasToGrow(t *testing.T) {
+	c := &context{gas: 2}
+	m := &Memory{store: make([]byte, 32)}
+	if err := m.set(64, []byte{0x1}, c); !errors.Is(err, errOutOfGas) {
+		t.Errorf("unexpected error %v, got %v", errOutOfGas, err)
 	}
-	err = m.setByte(0, 0x12, &ctxt)
-	if !errors.Is(err, errOutOfGas) {
-		t.Errorf("unexpected error, want: %v, got: %v", errOutOfGas, err)
+	if len(m.store) != 32 {
+		t.Errorf("memory should not have been expanded, instead is: %d", len(m.store))
 	}
 }
 
-func TestMemory_setWord_successfulCase(t *testing.T) {
-	c := context{gas: 6 + 1}
-	m := NewMemory()
-	offset := uint64(1)
-	value := new(uint256.Int).SetBytes([]byte{0xff, 0xee})
-	err := m.setWord(offset, value, &c)
-	if err != nil {
-		t.Fatalf("unexpected error, want: %v, got: %v", nil, err)
+func TestMemory_set_FailsIfOffsetLeadsToOverflow(t *testing.T) {
+	m := &Memory{store: make([]byte, 32)}
+	data := []byte{0x1, 0x2, 0x3}
+	offset := math.MaxUint64 - uint64(len(data)) + 1
+	if err := m.set(offset, data, nil); !errors.Is(err, errOverflow) {
+		t.Errorf("unexpected error %v, got %v", errOutOfGas, err)
 	}
-	if m.length() != 64 {
-		t.Errorf("memory size should be 64 bytes instead got: %d", m.length())
-	}
-	val32 := value.Bytes32()
-	if !bytes.Equal(m.store[offset:offset+32], val32[:]) {
-		t.Errorf("unexpected memory value, want: %x, got: %x", value.Bytes32(), m.store[offset:offset+32])
-	}
-	if c.gas != 1 {
-		t.Errorf("unexpected gas value, want: %d, got: %d", 1, c.gas)
+	if len(m.store) != 32 {
+		t.Errorf("memory should not have been expanded, instead is: %d", len(m.store))
 	}
 }
 
-func TestMemory_SetWord_ErrorCases(t *testing.T) {
-	ctxt := context{gas: 0}
-	// SetWord (and EnsureCapacity) check for offset overflow before checking gas
-	// hence it is fine to check both cases with gas = 0
-	m := NewMemory()
-	if err := m.setWord(math.MaxUint64-31, new(uint256.Int), &ctxt); !errors.Is(err, errOverflow) {
-		t.Fatalf("expected error, wanted overflow error but got %v", err)
-	}
-	if err := m.setWord(0, new(uint256.Int), &ctxt); !errors.Is(err, errOutOfGas) {
-		t.Fatalf("expected error, wanted out of gas error but got %v", err)
-	}
+func generateRandomBytes(size int) []byte {
+	data := make([]byte, size)
+	_, _ = rand.Read(data)
+	return data
 }

--- a/go/interpreter/lfvm/memory_test.go
+++ b/go/interpreter/lfvm/memory_test.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"errors"
 	"math"
-	"strings"
 	"testing"
 
 	"github.com/Fantom-foundation/Tosca/go/tosca"
@@ -505,30 +504,6 @@ func TestMemory_Set_SuccessfulCases(t *testing.T) {
 		t.Errorf("unexpected memory value, want: %x, got: %x", want, m.store)
 	}
 
-}
-
-func TestMemory_TrySet_ErrorCases(t *testing.T) {
-	c := context{gas: 0}
-	m := NewMemory()
-	m.store = make([]byte, 8)
-	// since we are only testing for failed cases, data is not relevant because
-	// the internal checks are done with offset and size parameters.
-
-	// size overflow
-	err := m.set(1, math.MaxUint64, []byte{}, &c)
-	if !errors.Is(err, errOverflow) {
-		t.Errorf("unexpected error, want: %v, got: %v", errOverflow, err)
-	}
-	// offset overflow
-	err = m.set(math.MaxUint64, 1, []byte{}, &c)
-	if !errors.Is(err, errOverflow) {
-		t.Errorf("unexpected error, want: %v, got: %v", errOverflow, err)
-	}
-	// not enough memory
-	err = m.trySet(32, 32, []byte{})
-	if !strings.Contains(err.Error(), "memory too small") {
-		t.Errorf("unexpected error, want: memory too small, got: %v", err)
-	}
 }
 
 func TestToValidMemorySize_RoundsUpToNextMultipleOf32(t *testing.T) {

--- a/go/interpreter/lfvm/memory_test.go
+++ b/go/interpreter/lfvm/memory_test.go
@@ -448,7 +448,7 @@ func TestMemory_Set_Successful(t *testing.T) {
 		t.Fatalf("unexpected error, want: %v, got: %v", nil, err)
 	}
 	if m.length() != 32 {
-		t.Errorf("set should not change memory size, want: %d, got: %d", 32, m.length())
+		t.Errorf("memory size should be 32 bytes instead got: %d", m.length())
 	}
 	if !bytes.Equal(m.store[offset:offset+size], value) {
 		t.Errorf("unexpected memory value, want: %x, got: %x", value, m.store[offset:offset+size])

--- a/go/interpreter/lfvm/memory_test.go
+++ b/go/interpreter/lfvm/memory_test.go
@@ -468,12 +468,12 @@ func TestMemory_Set_ErrorCases(t *testing.T) {
 		t.Errorf("unexpected error, want: %v, got: %v", errOutOfGas, err)
 	}
 	err = m.set(math.MaxUint64, 1, []byte{}, &c)
-	if !errors.Is(err, errGasUintOverflow) {
-		t.Errorf("unexpected error, want: %v, got: %v", errGasUintOverflow, err)
+	if !errors.Is(err, errOverflow) {
+		t.Errorf("unexpected error, want: %v, got: %v", errOverflow, err)
 	}
 	err = m.set(1, math.MaxUint64, []byte{}, &c)
-	if !errors.Is(err, errGasUintOverflow) {
-		t.Errorf("unexpected error, want: %v, got: %v", errGasUintOverflow, err)
+	if !errors.Is(err, errOverflow) {
+		t.Errorf("unexpected error, want: %v, got: %v", errOverflow, err)
 	}
 }
 

--- a/go/interpreter/lfvm/memory_test.go
+++ b/go/interpreter/lfvm/memory_test.go
@@ -477,7 +477,7 @@ func TestMemory_Set_ErrorCases(t *testing.T) {
 	}
 }
 
-func TestMemory_TrySet_SuccessfulCases(t *testing.T) {
+func TestMemory_Set_SuccessfulCases(t *testing.T) {
 
 	memoryOriginalSize := uint64(8)
 	offset := uint64(1)
@@ -489,10 +489,11 @@ func TestMemory_TrySet_SuccessfulCases(t *testing.T) {
 	}
 	size := uint64(len(data))
 
+	c := getEmptyContext()
 	m := NewMemory()
 	m.store = make([]byte, memoryOriginalSize)
 
-	err := m.trySet(offset, size, data)
+	err := m.set(offset, size, data, &c)
 	if err != nil {
 		t.Fatalf("unexpected error, want: %v, got: %v", nil, err)
 	}

--- a/go/interpreter/lfvm/memory_test.go
+++ b/go/interpreter/lfvm/memory_test.go
@@ -356,6 +356,68 @@ func TestMemory_readWord_ErrorCases(t *testing.T) {
 	}
 }
 
+func TestMemory_SetByte_SuccessfulCases(t *testing.T) {
+
+	baseData := []byte{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef}
+
+	tests := map[string]struct {
+		memory []byte
+		offset uint64
+	}{
+		"write to empty memory": {},
+		"write to first element of memory": {
+			memory: baseData,
+			offset: 0,
+		},
+		"write with offset within memory": {
+			memory: baseData,
+			offset: 4,
+		},
+		"offset trigger expansion of empty memory": {
+			offset: 2,
+		},
+		"offset trigger memory expansion": {
+			memory: baseData[:4],
+			offset: 8,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctxt := getEmptyContext()
+			m := NewMemory()
+			m.store = test.memory
+			ctxt.gas = tosca.Gas(3)
+			value := byte(0x12)
+
+			err := m.setByte(test.offset, value, &ctxt)
+			if err != nil {
+				t.Errorf("unexpected error, want: %v, got: %v", nil, err)
+			}
+			if m.length() < test.offset {
+				t.Errorf("unexpected memory size, want: %d, got: %d", test.offset, m.length())
+			}
+			if m.store[test.offset] != value {
+				t.Errorf("unexpected value, want: %v, got: %v", value, m.store[test.offset])
+			}
+		})
+	}
+}
+
+func TestMemory_SetByte_ErrorCases(t *testing.T) {
+	ctxt := getEmptyContext()
+	m := NewMemory()
+	ctxt.gas = 0
+	err := m.setByte(math.MaxUint64, 0x12, &ctxt)
+	if !errors.Is(err, errOverflow) {
+		t.Errorf("unexpected error, want: %v, got: %v", errOverflow, err)
+	}
+	err = m.setByte(0, 0x12, &ctxt)
+	if !errors.Is(err, errOutOfGas) {
+		t.Errorf("unexpected error, want: %v, got: %v", errOverflow, err)
+	}
+}
+
 func TestToValidMemorySize_RoundsUpToNextMultipleOf32(t *testing.T) {
 	for i := uint64(0); i < 128; i++ {
 		got, err := toValidMemorySize(i)

--- a/go/interpreter/lfvm/super_instructions.go
+++ b/go/interpreter/lfvm/super_instructions.go
@@ -87,7 +87,8 @@ func opDup2_Mstore(c *context) error {
 	var addr = c.stack.peek()
 
 	offset := addr.Uint64()
-	return c.memory.setWord(offset, value, c)
+	data := value.Bytes32()
+	return c.memory.set(offset, data[:], c)
 }
 
 func opDup2_Lt(c *context) {

--- a/go/interpreter/lfvm/super_instructions.go
+++ b/go/interpreter/lfvm/super_instructions.go
@@ -87,7 +87,7 @@ func opDup2_Mstore(c *context) error {
 	var addr = c.stack.peek()
 
 	offset := addr.Uint64()
-	return c.memory.SetWord(offset, value, c)
+	return c.memory.setWord(offset, value, c)
 }
 
 func opDup2_Lt(c *context) {


### PR DESCRIPTION
This PR is part of a series of PRs that aim to make private and improve the memory methods. 
In this PR:
- `SetByte` and `SetWord` are now private functions.
- `Set` functions is removed since we are moving towards enforcing that memory can not attempt to read/write without expanding first.
- `SetWithCapacityAndGasCheck` is renamed to `set`, simplified to simply call `getSlice` from #761 and then copy from input value to the slice.
- `setByte` and `setWord` is implemented as a specialization of `setWithCapacityAndGasCheck`.
- tests are added for `set`, `setByte` and `setWord`.

This is part of #682
This PR will rework set to be a specialization+copy of `getSlice` from #761 