### PR TITLE
Split official LFVM configuration and experimental configurations

### DIFF
--- a/go/integration_test/interpreter/integration_test.go
+++ b/go/integration_test/interpreter/integration_test.go
@@ -34,7 +34,7 @@ const HUGE_GAS_SENT_WITH_CALL int64 = 1000000000000
 
 func TestMaxCallDepth(t *testing.T) {
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		for _, revision := range revisions {
 			t.Run(fmt.Sprintf("%s/%s", variant, revision), func(t *testing.T) {
 				ctrl := gomock.NewController(t)
@@ -92,7 +92,7 @@ func TestMaxCallDepth(t *testing.T) {
 func TestInvalidJumpOverflow(t *testing.T) {
 
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 
 		for _, revision := range revisions {
 
@@ -181,7 +181,7 @@ func TestCodeCopy(t *testing.T) {
 	}
 
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		for _, revision := range revisions {
 			for name, test := range tests {
 				t.Run(fmt.Sprintf("%s/%s/%s", variant, revision, name), func(t *testing.T) {
@@ -268,7 +268,7 @@ func TestReturnDataCopy(t *testing.T) {
 		{name: "offset overflow", dataSize: 0, dataOffset: overflowValue, returnDataSize: 0, expectFailure: true},
 	}
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 
 		for _, revision := range revisions {
 
@@ -345,7 +345,7 @@ func TestReadOnlyStaticCall(t *testing.T) {
 	}
 
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 
 		for _, revision := range revisions {
 
@@ -454,7 +454,7 @@ func TestInstructionDataInitialization(t *testing.T) {
 	}
 
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		for _, revision := range revisions {
 			for _, test := range tests {
 				t.Run(fmt.Sprintf("%s/%s/%s/%s", variant, revision, test.instruction, test.name), func(t *testing.T) {
@@ -517,7 +517,7 @@ func TestCreateDataInitialization(t *testing.T) {
 	}
 
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 
 		for _, revision := range revisions {
 
@@ -586,7 +586,7 @@ func TestMemoryNotWrittenWithZeroReturnData(t *testing.T) {
 	}
 
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 
 		for _, revision := range revisions {
 
@@ -682,7 +682,7 @@ func TestNoReturnDataForCreate(t *testing.T) {
 	}
 
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 
 		if skipTestForVariant(t.Name(), variant) {
 			continue
@@ -770,7 +770,7 @@ func TestExtCodeHashOnEmptyAccount(t *testing.T) {
 	}
 
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 
 		if skipTestForVariant(t.Name(), variant) {
 			continue
@@ -916,7 +916,7 @@ type overflowTestCase struct {
 
 func runOverflowTests(t *testing.T, instruction vm.OpCode, tests []overflowTestCase) {
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 
 		for _, revision := range revisions {
 
@@ -1111,7 +1111,7 @@ func newMockStateDBForIntegrationTests(ctrl *gomock.Controller) *MockStateDB {
 }
 
 func TestEVM_CanSuccessfullyProcessPcBiggerThanCodeLength(t *testing.T) {
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		revision := Istanbul
 		t.Run(variant, func(t *testing.T) {
 			// all implementations should be able to handle PC that goes beyond the code length.

--- a/go/integration_test/interpreter/invalid_code_test.go
+++ b/go/integration_test/interpreter/invalid_code_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestEmptyCodeShouldBeIgnored(t *testing.T) {
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		evm := GetCleanEVM(Istanbul, variant, nil)
 		t.Run(variant, func(t *testing.T) {
 			code := []byte{}
@@ -31,7 +31,7 @@ func TestEmptyCodeShouldBeIgnored(t *testing.T) {
 }
 
 func TestPushWithMissingDataIsIgnored(t *testing.T) {
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		evm := GetCleanEVM(Istanbul, variant, nil)
 		for i := 1; i <= 32; i++ {
 			op := vm.OpCode(int(vm.PUSH1) - 1 + i)
@@ -50,7 +50,7 @@ func TestPushWithMissingDataIsIgnored(t *testing.T) {
 }
 
 func TestDetectsJumpOutOfCode(t *testing.T) {
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		evm := GetCleanEVM(Istanbul, variant, nil)
 		t.Run(variant, func(t *testing.T) {
 			code := []byte{
@@ -71,7 +71,7 @@ func TestDetectsJumpOutOfCode(t *testing.T) {
 }
 
 func TestDetectsJumpToNonJumpDestTarget(t *testing.T) {
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		evm := GetCleanEVM(Istanbul, variant, nil)
 		t.Run(variant, func(t *testing.T) {
 			code := []byte{

--- a/go/integration_test/interpreter/invalid_instructions_test.go
+++ b/go/integration_test/interpreter/invalid_instructions_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestInterpreterDetectsInvalidInstruction(t *testing.T) {
 	for _, rev := range revisions {
-		for _, variant := range Variants {
+		for _, variant := range getAllInterpreterVariantsForTests() {
 			evm := GetCleanEVM(rev, variant, nil)
 			// LFVM currently does not support detection of invalid codes!
 			// TODO: fix this

--- a/go/integration_test/interpreter/revision_test.go
+++ b/go/integration_test/interpreter/revision_test.go
@@ -34,7 +34,7 @@ func TestUnsupportedRevision_KnownRevisions(t *testing.T) {
 
 	code := []byte{byte(vm.PUSH2), byte(5), byte(2), byte(vm.SUB)}
 
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		for _, revision := range knownRevisions {
 			evm := TestEVM{
 				interpreter: tosca.GetInterpreter(variant),

--- a/go/integration_test/interpreter/stack_boundary_test.go
+++ b/go/integration_test/interpreter/stack_boundary_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestStackMaxBoundary(t *testing.T) {
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		for _, revision := range revisions {
 			for op, info := range getInstructions(revision) {
 				if info.stack.popped >= info.stack.pushed {
@@ -56,7 +56,7 @@ func TestStackMaxBoundary(t *testing.T) {
 
 func TestStackMinBoundary(t *testing.T) {
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		for _, revision := range revisions {
 			for op, info := range getInstructions(revision) {
 				if info.stack.popped <= 0 {

--- a/go/integration_test/interpreter/test_config.go
+++ b/go/integration_test/interpreter/test_config.go
@@ -38,17 +38,13 @@ func getAllInterpreterVariantsForTests() []string {
 	)
 }
 
-// skipTestForVariant returns true, if test should be skipped for variant
+// skipTestForVariant returns true, if the given test should be skipped for
+// the given variant.
 func skipTestForVariant(testName string, variant string) bool {
-	disabledTest := map[string]map[string]bool{
+	disabledTest := map[string][]string{
 		"TestNoReturnDataForCreate": {
-			"evmone":          true,
-			"evmone-basic":    true,
-			"evmone-advanced": true,
+			"evmone", "evmone-basic", "evmone-advanced",
 		},
 	}
-	if disabled, found := disabledTest[testName][variant]; found && disabled {
-		return true
-	}
-	return false
+	return slices.Contains(disabledTest[testName], variant)
 }

--- a/go/integration_test/interpreter/test_config_test.go
+++ b/go/integration_test/interpreter/test_config_test.go
@@ -1,3 +1,13 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
 package interpreter_test
 
 import (

--- a/go/integration_test/interpreter/test_config_test.go
+++ b/go/integration_test/interpreter/test_config_test.go
@@ -1,0 +1,18 @@
+package interpreter_test
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestCoveredVariants_ContainsMainConfigurations(t *testing.T) {
+	all := getAllInterpreterVariantsForTests()
+	wanted := []string{
+		"geth", "lfvm", "lfvm-si", "evmzero", "evmone",
+	}
+	for _, n := range wanted {
+		if !slices.Contains(all, n) {
+			t.Errorf("Variant %q is not registered, got %v", n, all)
+		}
+	}
+}

--- a/go/integration_test/interpreter/verify_gas_test.go
+++ b/go/integration_test/interpreter/verify_gas_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestStaticGas(t *testing.T) {
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		for _, revision := range revisions {
 			// Get static gas for frequently used instructions
 			pushGas := getInstructions(revision)[vm.PUSH1].gas.static
@@ -88,7 +88,7 @@ func TestDynamicGas(t *testing.T) {
 	accountBalance := tosca.Value{100}
 
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		for _, revision := range revisions {
 			// Get static gas for frequently used instructions
 			pushGas := getInstructions(revision)[vm.PUSH1].gas.static
@@ -172,7 +172,7 @@ func TestDynamicGas(t *testing.T) {
 
 func TestOutOfDynamicGas(t *testing.T) {
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		for _, revision := range revisions {
 			// Get static gas for frequently used instructions
 			pushGas := getInstructions(revision)[vm.PUSH1].gas.static
@@ -218,7 +218,7 @@ func TestOutOfDynamicGas(t *testing.T) {
 
 func TestOutOfStaticGasOnly(t *testing.T) {
 	// For every variant of interpreter
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		for _, revision := range revisions {
 			// Get static gas for frequently used instructions
 			pushGas := getInstructions(revision)[vm.PUSH1].gas.static
@@ -327,7 +327,7 @@ func getCallInstructionGas(t *testing.T, revision Revision, callCode []byte) tos
 	// Minimum stack values to execute CALL instruction
 	stackValues := []*big.Int{zeroVal, zeroVal, zeroVal, zeroVal, zeroVal, addressToBigInt(account), gasSentWithCall}
 
-	evm := GetCleanEVM(revision, Variants[0], mockStateDB)
+	evm := GetCleanEVM(revision, "geth", mockStateDB)
 
 	for i := 0; i < len(stackValues); i++ {
 		valueBytes := stackValues[i].Bytes()

--- a/go/integration_test/interpreter/vm_test.go
+++ b/go/integration_test/interpreter/vm_test.go
@@ -40,7 +40,7 @@ var (
 
 func TestExamples_ComputesCorrectResult(t *testing.T) {
 	for _, example := range testExamples {
-		for _, variant := range Variants {
+		for _, variant := range getAllInterpreterVariantsForTests() {
 			vm := tosca.GetInterpreter(variant)
 			for i := 0; i < 10; i++ {
 				t.Run(fmt.Sprintf("%s-%s-%d", example.Name, variant, i), func(t *testing.T) {
@@ -62,7 +62,7 @@ func TestExamples_ComputesCorrectGasPrice(t *testing.T) {
 	for _, example := range testExamples {
 		for _, revision := range revisions {
 			reference := tosca.GetInterpreter("geth")
-			for _, variant := range Variants {
+			for _, variant := range getAllInterpreterVariantsForTests() {
 				vm := tosca.GetInterpreter(variant)
 				for i := 0; i < 10; i++ {
 					t.Run(fmt.Sprintf("%s-%s-%s-%d", example.Name, revision, variant, i), func(t *testing.T) {
@@ -92,7 +92,7 @@ func BenchmarkEmpty(b *testing.B) {
 	emptyRunParameters := tosca.Parameters{
 		Context: runContext,
 	}
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		interpreter := tosca.GetInterpreter(variant)
 		b.Run(variant, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
@@ -168,7 +168,7 @@ func benchmark(b *testing.B, example examples.Example, arg int) {
 	// compute expected value
 	wanted := example.RunReference(arg)
 
-	for _, variant := range Variants {
+	for _, variant := range getAllInterpreterVariantsForTests() {
 		evm := tosca.GetInterpreter(variant)
 		if pvm, ok := evm.(tosca.ProfilingInterpreter); ok {
 			pvm.ResetProfile()

--- a/go/interpreter/lfvm/lfvm_test.go
+++ b/go/interpreter/lfvm/lfvm_test.go
@@ -1,0 +1,24 @@
+package lfvm
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+)
+
+func TestLfvm_OfficialConfigurationHasSanctionedProperties(t *testing.T) {
+	vm := tosca.GetInterpreter("lfvm")
+	if vm == nil {
+		t.Fatal("lfvm is not registered")
+	}
+	lfvm, ok := vm.(*lfvm)
+	if !ok {
+		t.Fatalf("unexpected interpreter implementation, got %T", vm)
+	}
+	if lfvm.config.WithShaCache != true {
+		t.Fatalf("lfvm is not configured with sha cache")
+	}
+	if lfvm.config.ConversionConfig.WithSuperInstructions != false {
+		t.Fatalf("lfvm is configured with super instructions")
+	}
+}

--- a/go/interpreter/lfvm/lfvm_test.go
+++ b/go/interpreter/lfvm/lfvm_test.go
@@ -1,3 +1,13 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
 package lfvm
 
 import (


### PR DESCRIPTION
This PR restricts the default registration of LFVM interpreter configurations to the `lfvm` and `lfvm-si` configurations. These are the only configurations currently accessed outside Tosca. In a follow-up step, this set is to be further restricted to the `lfvm` option only (once down-stream projects have been updated).

Some changes contributed by this PR:
- split of the officially supported configurations and experimental configurations
- renamed the LFVM `VM` type to `lfvm` to make the implementation package private
- updated integration tests to automatically cover all registered interpreter implementations with the exception of logging configurations to ease the diagnosis of failing unit tests (eliminate command line pollution)