### PR TITLE
Zero-initialize stack values in init code size test

### DIFF
--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -646,8 +646,9 @@ func TestCreateShanghaiInitCodeSize(t *testing.T) {
 			}
 
 			// Prepare stack arguments.
-			ctxt.stack.stackPointer = 3
-			ctxt.stack.data[0].Set(uint256.NewInt(test.init_code_size))
+			ctxt.stack.push(uint256.NewInt(test.init_code_size))
+			ctxt.stack.push(uint256.NewInt(0))
+			ctxt.stack.push(uint256.NewInt(0))
 
 			if test.expected == statusRunning {
 				runContext.EXPECT().Call(tosca.Create, gomock.Any()).Return(tosca.CallResult{}, nil)
@@ -714,8 +715,9 @@ func TestCreateShanghaiDeploymentCost(t *testing.T) {
 		}
 
 		// Prepare stack arguments.
-		ctxt.stack.stackPointer = 3
-		ctxt.stack.data[0].Set(uint256.NewInt(test.initCodeSize))
+		ctxt.stack.push(uint256.NewInt(test.initCodeSize))
+		ctxt.stack.push(uint256.NewInt(0))
+		ctxt.stack.push(uint256.NewInt(0))
 
 		runContext.EXPECT().Call(tosca.Create, gomock.Any()).Return(tosca.CallResult{}, nil)
 


### PR DESCRIPTION
This PR fixes a lack of stack-value initialization in the test `TestCreateShanghaiInitCodeSize`.

The test assumed implicitly that a newly created stack is filled with zeros. However, due to stack-recycling, this is not the case. The content is actually undefined. This lead the given test to be flaky, since one of the stack values assumed to be zero leads the following issue if it is not zero:
```
--- FAIL: TestCreateShanghaiDeploymentCost (0.00s)
    instructions.go:888: Unexpected call to *tosca.MockRunContext.GetBalance([0x0100000000000000000000000000000000000000]) at /home/herbert/coding/fantom/tosca/go/interpreter/lfvm/instructions.go:888 because: there are no expected calls of the method "GetBalance" for that receiver
    controller.go:98: missing call(s) to *tosca.MockRunContext.Call(is equal to create (tosca.CallKind), is anything) /home/herbert/coding/fantom/tosca/go/interpreter/lfvm/instructions_test.go:720
    controller.go:98: aborting test due to missing call(s)
```

The issue could be reproduced using
```
go test --race ./interpreter/lfvm/... -count 100
```
