### PR TITLE
Replace interpreter instances with interpreter factories in registry

### DIFF
--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -44,6 +44,13 @@ func init() {
 		// use its own interpreter when requesting the `geth` interpreter. Instead
 		// Tosca's geth reference wrapped in the adapter would be used -- a combination
 		// that is not well tested.
+
+		// TODO: update geth integration to use factories instead of interpreter
+		// implementations
+		interpreter, err := interpreter(nil)
+		if err != nil {
+			panic(fmt.Sprintf("could not create interpreter: %v", err))
+		}
 		if name == "" || name != "geth" {
 			RegisterGethInterpreter(name, interpreter)
 		}

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -77,7 +77,7 @@ func TestRunContextAdapter_SetBalanceHasCorrectEffect(t *testing.T) {
 }
 
 func TestRunContextAdapter_ReferenceGethInterpreterIsNotExported(t *testing.T) {
-	if res := tosca.GetInterpreter("geth"); res == nil {
+	if res, err := tosca.NewInterpreter("geth", nil); res == nil || err != nil {
 		t.Fatal("geth reference interpreter not available in Tosca")
 	}
 	evm := &geth.EVM{}

--- a/go/integration_test/interpreter/revision_test.go
+++ b/go/integration_test/interpreter/revision_test.go
@@ -36,24 +36,32 @@ func TestUnsupportedRevision_KnownRevisions(t *testing.T) {
 
 	for _, variant := range getAllInterpreterVariantsForTests() {
 		for _, revision := range knownRevisions {
+			interpreter, err := tosca.NewInterpreter(variant)
+			if err != nil {
+				t.Fatalf("failed to load interpreter: %v", err)
+			}
 			evm := TestEVM{
-				interpreter: tosca.GetInterpreter(variant),
+				interpreter: interpreter,
 				revision:    revision,
 				state:       mockStateDB,
 			}
-			_, err := evm.Run(code, []byte{})
+			_, err = evm.Run(code, []byte{})
 			if err != nil {
 				t.Errorf("unexpected error during evm run")
 			}
 		}
 
 		for _, revision := range unknownRevisions {
+			interpreter, err := tosca.NewInterpreter(variant)
+			if err != nil {
+				t.Fatalf("failed to load interpreter: %v", err)
+			}
 			evm := TestEVM{
-				interpreter: tosca.GetInterpreter(variant),
+				interpreter: interpreter,
 				revision:    revision,
 				state:       mockStateDB,
 			}
-			_, err := evm.Run(code, []byte{})
+			_, err = evm.Run(code, []byte{})
 			targetError := &tosca.ErrUnsupportedRevision{}
 			if !errors.As(err, &targetError) {
 				t.Errorf("Running on %s: expected unsupported revision error but got %v", variant, err)

--- a/go/integration_test/interpreter/test_evm.go
+++ b/go/integration_test/interpreter/test_evm.go
@@ -46,8 +46,13 @@ func GetCleanEVM(revision Revision, interpreter string, stateDB StateDB) TestEVM
 		rev = tosca.R10_London
 	}
 
+	instance, err := tosca.NewInterpreter(interpreter)
+	if err != nil {
+		panic(err)
+	}
+
 	return TestEVM{
-		interpreter: tosca.GetInterpreter(interpreter),
+		interpreter: instance,
 		revision:    rev,
 		state:       stateDB,
 	}

--- a/go/integration_test/interpreter/vm_test.go
+++ b/go/integration_test/interpreter/vm_test.go
@@ -41,7 +41,10 @@ var (
 func TestExamples_ComputesCorrectResult(t *testing.T) {
 	for _, example := range testExamples {
 		for _, variant := range getAllInterpreterVariantsForTests() {
-			vm := tosca.GetInterpreter(variant)
+			vm, err := tosca.NewInterpreter(variant)
+			if err != nil {
+				t.Fatalf("failed to load %s interpreter: %v", variant, err)
+			}
 			for i := 0; i < 10; i++ {
 				t.Run(fmt.Sprintf("%s-%s-%d", example.Name, variant, i), func(t *testing.T) {
 					want := example.RunReference(i)
@@ -61,9 +64,15 @@ func TestExamples_ComputesCorrectResult(t *testing.T) {
 func TestExamples_ComputesCorrectGasPrice(t *testing.T) {
 	for _, example := range testExamples {
 		for _, revision := range revisions {
-			reference := tosca.GetInterpreter("geth")
+			reference, err := tosca.NewInterpreter("geth")
+			if err != nil {
+				t.Fatalf("failed to load geth interpreter: %v", err)
+			}
 			for _, variant := range getAllInterpreterVariantsForTests() {
-				vm := tosca.GetInterpreter(variant)
+				vm, err := tosca.NewInterpreter(variant)
+				if err != nil {
+					t.Fatalf("failed to load %s interpreter: %v", variant, err)
+				}
 				for i := 0; i < 10; i++ {
 					t.Run(fmt.Sprintf("%s-%s-%s-%d", example.Name, revision, variant, i), func(t *testing.T) {
 						want, err := example.RunOn(reference, i)
@@ -93,7 +102,10 @@ func BenchmarkEmpty(b *testing.B) {
 		Context: runContext,
 	}
 	for _, variant := range getAllInterpreterVariantsForTests() {
-		interpreter := tosca.GetInterpreter(variant)
+		interpreter, err := tosca.NewInterpreter(variant)
+		if err != nil {
+			b.Fatalf("failed to load %s interpreter: %v", variant, err)
+		}
 		b.Run(variant, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, err := interpreter.Run(emptyRunParameters)
@@ -169,7 +181,10 @@ func benchmark(b *testing.B, example examples.Example, arg int) {
 	wanted := example.RunReference(arg)
 
 	for _, variant := range getAllInterpreterVariantsForTests() {
-		evm := tosca.GetInterpreter(variant)
+		evm, err := tosca.NewInterpreter(variant)
+		if err != nil {
+			b.Fatalf("failed to load %s interpreter: %v", variant, err)
+		}
 		if pvm, ok := evm.(tosca.ProfilingInterpreter); ok {
 			pvm.ResetProfile()
 		}

--- a/go/integration_test/processor/processor_test.go
+++ b/go/integration_test/processor/processor_test.go
@@ -197,7 +197,11 @@ func getProcessors() map[string]tosca.Processor {
 
 	res := map[string]tosca.Processor{}
 	for processorName, factory := range factories {
-		for interpreterName, interpreter := range interpreter {
+		for interpreterName, interpreterFactory := range interpreter {
+			interpreter, err := interpreterFactory(nil)
+			if err != nil {
+				panic(fmt.Sprintf("failed to load interpreter %s: %v", interpreterName, err))
+			}
 			processor := factory(interpreter)
 			res[fmt.Sprintf("%s/%s", processorName, interpreterName)] = processor
 		}

--- a/go/interpreter/evmone/evmone.go
+++ b/go/interpreter/evmone/evmone.go
@@ -33,8 +33,12 @@ func init() {
 	}
 	// This instance remains in its basic configuration and is registered
 	// as the default "evmone" VM and as the "evmone-basic" tosca.
-	tosca.RegisterInterpreter("evmone", &evmoneInstance{evmone})
-	tosca.RegisterInterpreter("evmone-basic", &evmoneInstance{evmone})
+	tosca.RegisterInterpreterFactory("evmone", func(any) (tosca.Interpreter, error) {
+		return &evmoneInstance{evmone}, nil
+	})
+	tosca.RegisterInterpreterFactory("evmone-basic", func(any) (tosca.Interpreter, error) {
+		return &evmoneInstance{evmone}, nil
+	})
 
 	// A second instance is configured to use the advanced execution mode.
 	evmone, err = evmc.LoadEvmcInterpreter("libevmone.so")
@@ -44,7 +48,9 @@ func init() {
 	if err := evmone.SetOption("advanced", "on"); err != nil {
 		panic(fmt.Errorf("failed to configure evmone advanced mode: %v", err))
 	}
-	tosca.RegisterInterpreter("evmone-advanced", &evmoneInstance{evmone})
+	tosca.RegisterInterpreterFactory("evmone-advanced", func(any) (tosca.Interpreter, error) {
+		return &evmoneInstance{evmone}, nil
+	})
 }
 
 type evmoneInstance struct {

--- a/go/interpreter/evmone/evmone_test.go
+++ b/go/interpreter/evmone/evmone_test.go
@@ -33,7 +33,10 @@ func TestFib10(t *testing.T) {
 
 	for _, variant := range variants {
 		t.Run(variant, func(t *testing.T) {
-			interpreter := tosca.GetInterpreter(variant)
+			interpreter, err := tosca.NewInterpreter(variant)
+			if err != nil {
+				t.Fatalf("failed to load evmone interpreter: %v", err)
+			}
 			got, err := example.RunOn(interpreter, arg)
 			if err != nil {
 				t.Fatalf("running the fib example failed: %v", err)
@@ -58,7 +61,10 @@ func benchmarkFib(b *testing.B, arg int) {
 
 	for _, variant := range variants {
 		b.Run(variant, func(b *testing.B) {
-			interpreter := tosca.GetInterpreter(variant)
+			interpreter, err := tosca.NewInterpreter(variant)
+			if err != nil {
+				b.Fatalf("failed to load evmone interpreter: %v", err)
+			}
 			for i := 0; i < b.N; i++ {
 				got, err := example.RunOn(interpreter, arg)
 				if err != nil {

--- a/go/interpreter/evmzero/evmzero.go
+++ b/go/interpreter/evmzero/evmzero.go
@@ -36,7 +36,9 @@ func init() {
 			panic(fmt.Errorf("failed to load evmzero library: %s", err))
 		}
 		// This instance remains in its basic configuration.
-		tosca.RegisterInterpreter("evmzero", &evmzeroInstance{evm})
+		tosca.RegisterInterpreterFactory("evmzero", func(any) (tosca.Interpreter, error) {
+			return &evmzeroInstance{evm}, nil
+		})
 	}
 
 	// We create a second instance in which we enable logging.
@@ -48,7 +50,9 @@ func init() {
 		if err = evm.SetOption("logging", "true"); err != nil {
 			panic(fmt.Errorf("failed to configure EVM instance: %s", err))
 		}
-		tosca.RegisterInterpreter("evmzero-logging", &evmzeroInstance{evm})
+		tosca.RegisterInterpreterFactory("evmzero-logging", func(any) (tosca.Interpreter, error) {
+			return &evmzeroInstance{evm}, nil
+		})
 	}
 
 	// A third instance without analysis cache.
@@ -60,7 +64,9 @@ func init() {
 		if err = evm.SetOption("analysis_cache", "false"); err != nil {
 			panic(fmt.Errorf("failed to configure EVM instance: %s", err))
 		}
-		tosca.RegisterInterpreter("evmzero-no-analysis-cache", &evmzeroInstance{evm})
+		tosca.RegisterInterpreterFactory("evmzero-no-analysis-cache", func(any) (tosca.Interpreter, error) {
+			return &evmzeroInstance{evm}, nil
+		})
 	}
 
 	// Another instance without SHA3 cache.
@@ -72,7 +78,9 @@ func init() {
 		if err = evm.SetOption("sha3_cache", "false"); err != nil {
 			panic(fmt.Errorf("failed to configure EVM instance: %s", err))
 		}
-		tosca.RegisterInterpreter("evmzero-no-sha3-cache", &evmzeroInstance{evm})
+		tosca.RegisterInterpreterFactory("evmzero-no-sha3-cache", func(any) (tosca.Interpreter, error) {
+			return &evmzeroInstance{evm}, nil
+		})
 	}
 
 	// Another instance in which we enable profiling.
@@ -84,7 +92,9 @@ func init() {
 		if err = evm.SetOption("profiling", "true"); err != nil {
 			panic(fmt.Errorf("failed to configure EVM instance: %s", err))
 		}
-		tosca.RegisterInterpreter("evmzero-profiling", &evmzeroInstanceWithProfiler{&evmzeroInstance{evm}})
+		tosca.RegisterInterpreterFactory("evmzero-profiling", func(any) (tosca.Interpreter, error) {
+			return &evmzeroInstanceWithProfiler{&evmzeroInstance{evm}}, nil
+		})
 	}
 
 	// Another instance in which we enable profiling external.
@@ -96,7 +106,9 @@ func init() {
 		if err = evm.SetOption("profiling_external", "true"); err != nil {
 			panic(fmt.Errorf("failed to configure EVM instance: %s", err))
 		}
-		tosca.RegisterInterpreter("evmzero-profiling-external", &evmzeroInstanceWithProfiler{&evmzeroInstance{evm}})
+		tosca.RegisterInterpreterFactory("evmzero-profiling-external", func(any) (tosca.Interpreter, error) {
+			return &evmzeroInstanceWithProfiler{&evmzeroInstance{evm}}, nil
+		})
 	}
 }
 

--- a/go/interpreter/evmzero/evmzero_test.go
+++ b/go/interpreter/evmzero/evmzero_test.go
@@ -28,7 +28,10 @@ func TestFib10(t *testing.T) {
 	// compute expected value
 	wanted := example.RunReference(arg)
 
-	interpreter := tosca.GetInterpreter("evmzero")
+	interpreter, err := tosca.NewInterpreter("evmzero")
+	if err != nil {
+		t.Fatalf("failed to load evmzero interpreter: %v", err)
+	}
 	got, err := example.RunOn(interpreter, arg)
 	if err != nil {
 		t.Fatalf("running the fib example failed: %v", err)
@@ -41,8 +44,12 @@ func TestFib10(t *testing.T) {
 
 func TestEvmzero_DumpProfile(t *testing.T) {
 	example := examples.GetFibExample()
-	interpreter, ok := tosca.GetInterpreter("evmzero-profiling").(tosca.ProfilingInterpreter)
-	if !ok || interpreter == nil {
+	instance, err := tosca.NewInterpreter("evmzero-profiling")
+	if err != nil {
+		t.Fatalf("failed to load evmzero interpreter: %v", err)
+	}
+	interpreter, ok := instance.(tosca.ProfilingInterpreter)
+	if !ok {
 		t.Fatalf("profiling evmzero configuration does not support profiling")
 	}
 	for i := 0; i < 10; i++ {
@@ -60,7 +67,7 @@ func TestEvmzero_DumpProfile(t *testing.T) {
 func BenchmarkNewEvmcInterpreter(b *testing.B) {
 	b.Run("evmzero", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			tosca.GetInterpreter("evmzero")
+			tosca.NewInterpreter("evmzero")
 		}
 	})
 }
@@ -76,7 +83,10 @@ func benchmarkFib(b *testing.B, arg int) {
 	wanted := example.RunReference(arg)
 
 	b.Run("evmzero", func(b *testing.B) {
-		interpreter := tosca.GetInterpreter("evmzero")
+		interpreter, err := tosca.NewInterpreter("evmzero")
+		if err != nil {
+			b.Fatalf("failed to load evmzero interpreter: %v", err)
+		}
 		for i := 0; i < b.N; i++ {
 			got, err := example.RunOn(interpreter, arg)
 			if err != nil {
@@ -114,9 +124,9 @@ func TestEvmcInterpreter_BlobHashCanBeRead(t *testing.T) {
 		Code: code,
 	}
 
-	evm := tosca.GetInterpreter("evmzero")
-	if evm == nil {
-		t.Fatalf("failed to locate evmzero")
+	evm, err := tosca.NewInterpreter("evmzero")
+	if err != nil {
+		t.Fatalf("failed to load evmzero interpreter: %v", err)
 	}
 
 	result, err := evm.Run(params)

--- a/go/interpreter/geth/geth.go
+++ b/go/interpreter/geth/geth.go
@@ -29,7 +29,9 @@ import (
 )
 
 func init() {
-	tosca.RegisterInterpreter("geth", &gethVm{})
+	tosca.RegisterInterpreterFactory("geth", func(any) (tosca.Interpreter, error) {
+		return &gethVm{}, nil
+	})
 }
 
 type gethVm struct{}

--- a/go/interpreter/lfvm/lfvm.go
+++ b/go/interpreter/lfvm/lfvm.go
@@ -47,11 +47,11 @@ func init() {
 	}
 
 	for name, config := range configs {
-		vm, err := NewVm(config)
-		if err != nil {
-			panic(fmt.Sprintf("failed to create %s: %v", name, err))
-		}
-		tosca.RegisterInterpreter(name, vm)
+		config := config
+		tosca.RegisterInterpreterFactory(name, func(any) (tosca.Interpreter, error) {
+			// TODO: support configuration of cache sizes
+			return NewVm(config)
+		})
 	}
 }
 
@@ -79,27 +79,28 @@ func RegisterExperimentalInterpreterConfigurations() {
 					config.runner = loggingRunner{}
 				}
 
-				vm, err := NewVm(config)
 				name := "lfvm" + si + shaCache + mode
-				if err != nil {
-					panic(fmt.Sprintf("failed to create %s: %v", name, err))
-				}
-
 				if name != "lfvm" && name != "lfvm-si" {
-					tosca.RegisterInterpreter(name, vm)
+					tosca.RegisterInterpreterFactory(
+						name,
+						func(any) (tosca.Interpreter, error) {
+							return NewVm(config)
+						},
+					)
 				}
 			}
 		}
 	}
-	vm, err := NewVm(Config{
-		ConversionConfig: ConversionConfig{
-			CacheSize: -1,
+	tosca.RegisterInterpreterFactory(
+		"lfvm-no-code-cache",
+		func(any) (tosca.Interpreter, error) {
+			return NewVm(Config{
+				ConversionConfig: ConversionConfig{
+					CacheSize: -1,
+				},
+			})
 		},
-	})
-	if err != nil {
-		panic(fmt.Sprintf("failed to create no-code-cache instance: %v", err))
-	}
-	tosca.RegisterInterpreter("lfvm-no-code-cache", vm)
+	)
 }
 
 type Config struct {

--- a/go/interpreter/lfvm/lfvm_test.go
+++ b/go/interpreter/lfvm/lfvm_test.go
@@ -17,9 +17,9 @@ import (
 )
 
 func TestLfvm_OfficialConfigurationHasSanctionedProperties(t *testing.T) {
-	vm := tosca.GetInterpreter("lfvm")
-	if vm == nil {
-		t.Fatal("lfvm is not registered")
+	vm, err := tosca.NewInterpreter("lfvm")
+	if err != nil {
+		t.Fatalf("lfvm is not registered: %v", err)
 	}
 	lfvm, ok := vm.(*lfvm)
 	if !ok {

--- a/go/tosca/interpreter_registry.go
+++ b/go/tosca/interpreter_registry.go
@@ -30,14 +30,47 @@ import (
 // GetInterpreter performs a lookup for the given name (case-insensitive) in
 // the registry. The result is nil if no interpreter was registered under the
 // given name.
+//
+// Deprecated: Use NewInterpreter instead.
 func GetInterpreter(name string) Interpreter {
+	res, err := NewInterpreter(name, nil)
+	if err != nil {
+		return nil
+	}
+	return res
+}
+
+// NewInterpreter performs a lookup for the given name (case-insensitive) in
+// the registry and creates a new Interpreter using the given optional
+// configuration. If no configuration is provided, the implementation uses
+// its default configuration. An error is returned if no factory was
+// registered under the given name.
+func NewInterpreter(name string, config ...any) (Interpreter, error) {
+	if len(config) > 1 {
+		return nil, fmt.Errorf("invalid configuration: too many arguments")
+	}
+	factory := GetInterpreterFactory(name)
+	if factory == nil {
+		return nil, fmt.Errorf("interpreter not found: %s", name)
+	}
+	c := any(nil)
+	if len(config) > 0 {
+		c = config[0]
+	}
+	return factory(c)
+}
+
+// GetInterpreterFactory performs a lookup for the given name (case-insensitive)
+// in the registry. The result is nil if no factory was registered under the
+// given name.
+func GetInterpreterFactory(name string) InterpreterFactory {
 	interpreterRegistryLock.Lock()
 	defer interpreterRegistryLock.Unlock()
 	return interpreterRegistry[strings.ToLower(name)]
 }
 
 // GetAllRegisteredInterpreters obtains all registered implementations.
-func GetAllRegisteredInterpreters() map[string]Interpreter {
+func GetAllRegisteredInterpreters() map[string]InterpreterFactory {
 	interpreterRegistryLock.Lock()
 	defer interpreterRegistryLock.Unlock()
 	return maps.Clone(interpreterRegistry)
@@ -48,22 +81,43 @@ func GetAllRegisteredInterpreters() map[string]Interpreter {
 // and a panic is triggered if an implementation was bound to the same name
 // before, or the implementation is nil. This function is mainly intended to be
 // used by package initialization code.
+//
+// Deprecated: Use RegisterInterpreterFactory instead.
 func RegisterInterpreter(name string, impl Interpreter) {
+	err := RegisterInterpreterFactory(name, func(any) (Interpreter, error) {
+		return impl, nil
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+
+// RegisterInterpreterFactory registers a new Interpreter implementation
+// to be exported for general use in the binary. The name is not case-sensitive,
+// and a panic is triggered if a factory was bound to the same name before, or
+// the factory is nil. This function is mainly intended to be used by package
+// initialization code.
+func RegisterInterpreterFactory(name string, factory InterpreterFactory) error {
 	key := strings.ToLower(name)
-	if impl == nil {
-		panic(fmt.Sprintf("invalid initialization: cannot register nil-interpreter using `%s`", key))
+	if factory == nil {
+		return fmt.Errorf("invalid initialization: cannot register nil-factory using `%s`", key)
 	}
 	interpreterRegistryLock.Lock()
 	defer interpreterRegistryLock.Unlock()
 	if _, found := interpreterRegistry[key]; found {
-		panic(fmt.Sprintf("invalid initialization: multiple Interpreters registered for `%s`", key))
+		return fmt.Errorf("invalid initialization: multiple factories registered for `%s`", key)
 	}
-	interpreterRegistry[key] = impl
+	interpreterRegistry[key] = factory
+	return nil
 }
 
-// interpreterRegistry is a global registry for Interpreter instances of
+// InterpreterFactory is the type of a function that creates a new Interpreter
+// using a interpreter specific configuration.
+type InterpreterFactory func(config any) (Interpreter, error)
+
+// interpreterRegistry is a global registry for Interpreter factories of
 // different implementations and configurations.
-var interpreterRegistry = map[string]Interpreter{}
+var interpreterRegistry = map[string]InterpreterFactory{}
 
 // interpreterRegistryLock to protect access to the registry.
 var interpreterRegistryLock sync.Mutex

--- a/go/tosca/interpreter_registry_test.go
+++ b/go/tosca/interpreter_registry_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package tosca
+
+import "testing"
+
+func TestInterpreterRegistry_NameCollisionsAreDetected(t *testing.T) {
+	const name = "something-just-for-this-test"
+	factory := func(any) (Interpreter, error) {
+		return nil, nil
+	}
+	if err := RegisterInterpreterFactory(name, factory); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := RegisterInterpreterFactory(name, factory); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestInterpreterRegistry_NilFactoriesAreRejected(t *testing.T) {
+	const name = "something"
+	if err := RegisterInterpreterFactory(name, nil); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}


### PR DESCRIPTION
This PR updates the interpreter registry to contain factories instead of instantiated interpreters. This provides the following benefits:
- EVM configurations do not consume resources if they are not used
- when creating an EVM, client-code defined properties (e.g. cache sizes) can be passed the construction process of the interpreter instances (prepared but not implemented by this PR)

**Note to reviewers:** start with the changes in the Tosca package, which is the main part of this PR. All the rest is just API adaptations.

TODO:
- [x] check backward compatibility in Aida
- [x] check backward compatibility in Sonic

