### PR TITLE
Move C++ coverage utility from ct/common to lib/cpp

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,7 @@ pipeline {
         stage('Test C++ coverage support') {
             steps {
                 sh 'make tosca-cpp-coverage'
-                sh 'go test -v  -run ^TestDumpCppCoverageData$ ./go/ct/common/ --expect-coverage'
+                sh 'go test -v  -run ^TestDumpCppCoverageData$ ./go/lib/cpp/ --expect-coverage'
             }
         }
     }

--- a/go/ct/driver/run.go
+++ b/go/ct/driver/run.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/Fantom-foundation/Tosca/go/ct"
-	"github.com/Fantom-foundation/Tosca/go/ct/common"
 	cliUtils "github.com/Fantom-foundation/Tosca/go/ct/driver/cli"
 	"github.com/Fantom-foundation/Tosca/go/ct/rlz"
 	"github.com/Fantom-foundation/Tosca/go/ct/spc"
@@ -27,6 +26,7 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/interpreter/evmzero"
 	"github.com/Fantom-foundation/Tosca/go/interpreter/geth"
 	"github.com/Fantom-foundation/Tosca/go/interpreter/lfvm"
+	"github.com/Fantom-foundation/Tosca/go/lib/cpp"
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 	"github.com/dsnet/golib/unitconv"
 	"github.com/urfave/cli/v2"
@@ -58,7 +58,7 @@ var evms = map[string]ct.Evm{
 }
 
 func doRun(context *cli.Context) error {
-	defer common.DumpCppCoverageData()
+	defer cpp.DumpCppCoverageData()
 
 	jobCount := cliUtils.JobsFlag.Fetch(context)
 	seed := cliUtils.SeedFlag.Fetch(context)

--- a/go/lib/cpp/coverage.go
+++ b/go/lib/cpp/coverage.go
@@ -8,7 +8,7 @@
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
 
-package common
+package cpp
 
 /*
 #cgo LDFLAGS: -L${SRCDIR}/../../../cpp/build/common/coverage -ltosca_collect_coverage

--- a/go/lib/cpp/coverage_test.go
+++ b/go/lib/cpp/coverage_test.go
@@ -8,7 +8,7 @@
 // On the date above, in accordance with the Business Source License, use of
 // this software will be governed by the GNU Lesser General Public License v3.
 
-package common
+package cpp
 
 import (
 	"flag"


### PR DESCRIPTION
Right now, the LFVM implementation has dependencies to various CT packages. Among those, the `ct/common` package, which, before this PR, has a dependency to C++ code.

In order to build the LFVM interpreter as part of the Go sonic client without the need of an extra C++ compilation step, this dependency needs to be resolved. 

In the long run, all CT dependencies should be eliminated from the LFVM. However, this requires more work. To unblock the build development process in the meanwhile, the C++ coverage utility is factored out into its own `cpp` package, where it also conceptionally fits better. 