### PR TITLE
Update go-ethereum-sonic dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,6 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20240821150740-8b61095b9134
+replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20240916105249-e7951db0c00b
 
 replace github.com/ethereum/evmc/v11 => ./third_party/evmc

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20240821150740-8b61095b9134 h1:X79UvuZoRxx7yaMF586c6NrsqYHKxSVH1W0JU/fR8bE=
-github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20240821150740-8b61095b9134/go.mod h1:p4knNH76zBuqbEfc6CbZTOnaQNU0WvhzW5f0qq6aMoU=
+github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20240916105249-e7951db0c00b h1:RkK1XUuFi2z0A2XGMgRsI9Cd1+v70Da8jzEPeqnZ+vI=
+github.com/Fantom-foundation/go-ethereum-sonic v0.0.0-20240916105249-e7951db0c00b/go.mod h1:p4knNH76zBuqbEfc6CbZTOnaQNU0WvhzW5f0qq6aMoU=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -75,17 +75,3 @@ func TestRunContextAdapter_SetBalanceHasCorrectEffect(t *testing.T) {
 		})
 	}
 }
-
-func TestRunContextAdapter_ReferenceGethInterpreterIsNotExported(t *testing.T) {
-	if res, err := tosca.NewInterpreter("geth", nil); res == nil || err != nil {
-		t.Fatal("geth reference interpreter not available in Tosca")
-	}
-	evm := &geth.EVM{}
-	interpreter := geth.NewInterpreter("geth", evm, geth.Config{})
-	if interpreter == nil {
-		t.Fatal("no interpreter registered for 'geth'")
-	}
-	if _, ok := interpreter.(*gethInterpreterAdapter); ok {
-		t.Fatal("geth reference interpreter is exported")
-	}
-}

--- a/go/integration_test/processor/processor_test.go
+++ b/go/integration_test/processor/processor_test.go
@@ -12,6 +12,7 @@ package processor
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/Fantom-foundation/Tosca/go/tosca"
@@ -19,9 +20,13 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	op "github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
+	"golang.org/x/exp/maps"
 
 	_ "github.com/Fantom-foundation/Tosca/go/processor/floria" // < registers floria processor for testing
 	_ "github.com/Fantom-foundation/Tosca/go/processor/opera"  // < registers opera processor for testing
+
+	_ "github.com/Fantom-foundation/Tosca/go/interpreter/evmzero" // < registers evmzero interpreter for testing
+	_ "github.com/Fantom-foundation/Tosca/go/interpreter/lfvm"    // < registers lfvm interpreter for testing
 )
 
 // This file contains a few initial shake-down tests or a Processor implementation.
@@ -207,4 +212,19 @@ func getProcessors() map[string]tosca.Processor {
 		}
 	}
 	return res
+}
+
+func TestGetProcessors_ContainsMainConfigurations(t *testing.T) {
+	// The main task of this job is to make sure that the essential processors
+	// and interpreters are registered and available for testing.
+	all := maps.Keys(getProcessors())
+	wanted := []string{
+		"opera/geth", "opera/lfvm", "opera/evmzero",
+		"floria/geth", "floria/lfvm", "floria/evmzero",
+	}
+	for _, n := range wanted {
+		if !slices.Contains(all, n) {
+			t.Errorf("Configuration %q is not registered, got %v", n, all)
+		}
+	}
 }

--- a/go/processor/opera/processor.go
+++ b/go/processor/opera/processor.go
@@ -22,7 +22,6 @@ import (
 	"math"
 	"math/big"
 	"strings"
-	"sync"
 
 	"github.com/Fantom-foundation/Tosca/go/geth_adapter"
 	geth_interpreter "github.com/Fantom-foundation/Tosca/go/interpreter/geth"
@@ -42,35 +41,11 @@ func init() {
 	tosca.RegisterProcessorFactory("opera", newProcessor)
 }
 
-var interpreterRegistryLock sync.RWMutex
-var interpreterRegistry map[tosca.Interpreter]string
-
 // newProcessor is a factory function for the geth/opera processor implemented in this file.
 // By including this package, it gets registered in the global processor registry.
 func newProcessor(interpreter tosca.Interpreter) tosca.Processor {
-
-	// To be able to access the provided interpreter within geth, it
-	// needs to be wrapped and registered inside geth's interpreter registry.
-	// However, this registry should not be spammed with multiple entries for
-	// the same interpreter. Thus, a small local index is maintained for them.
-	interpreterRegistryLock.Lock()
-	defer interpreterRegistryLock.Unlock()
-
-	if interpreterRegistry == nil {
-		interpreterRegistry = make(map[tosca.Interpreter]string)
-	}
-
-	if name, ok := interpreterRegistry[interpreter]; ok {
-		return &processor{
-			interpreterImplementation: name,
-		}
-	}
-
-	name := fmt.Sprintf("geth-processor-redirect-%d", len(interpreterRegistry))
-	interpreterRegistry[interpreter] = name
-	geth_adapter.RegisterGethInterpreter(name, interpreter)
 	return &processor{
-		interpreterImplementation: name,
+		interpreter: geth_adapter.NewGethInterpreterFactory(interpreter),
 	}
 }
 
@@ -100,7 +75,7 @@ var (
 )
 
 type processor struct {
-	interpreterImplementation string
+	interpreter geth.InterpreterFactory
 }
 
 func (p *processor) Run(
@@ -151,7 +126,7 @@ func (p *processor) Run(
 
 	// Create a configuration for the geth EVM.
 	config := geth.Config{
-		InterpreterImpl: p.interpreterImplementation,
+		Interpreter: p.interpreter,
 		StatePrecompiles: map[common.Address]geth.PrecompiledStateContract{
 			stateContractAddress: preCompiledStateContract{},
 		},


### PR DESCRIPTION
As a preparation for the integration of Tosca into Sonic, the Tosca extensions in the [go-ethereum-sonic](https://github.com/Fantom-foundation/go-ethereum-sonic) repository got [revised](https://github.com/Fantom-foundation/go-ethereum-sonic/pull/4). This PR updates the dependency to to the latest version and applies necessary interface adaptations.

The interpreter registry in `go-ethereum-sonic` was eliminated by [#4](https://github.com/Fantom-foundation/go-ethereum-sonic/pull/4). As a consequence, the geth registry management code can be eliminated from the `geth_adaptor`, as covered by this PR.

This PR also eliminates the dependency between the `geth_adapter` package and specific interpreter implementations. Before this PR, by importing the `geth_adapter` the `lfvm`, `evmzero`, and `evmone` interpreters got implicitly imported. This is not desired and leads to build issues in Sonic due to the C++ dependencies of the latter two implementations. With this update, these dependencies are removed from the `geth_adapter`.

Due to build dependencies, this PR must only be merged once Aida's [#1164](https://github.com/Fantom-foundation/Aida/pull/1164) has reached main.

- [x] [#1164](https://github.com/Fantom-foundation/Aida/pull/1164) is in Aida's main branch

This is part of #766