### PR TITLE
LFVM: unify error status

### DIFF
--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -88,7 +88,7 @@ func (a *ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 
 	result, err := getOutput(ctxt)
 	if err != nil {
-		ctxt.status = statusOutOfGas
+		ctxt.signalError()
 	}
 
 	// Update the resulting state.
@@ -177,7 +177,7 @@ func convertLfvmStatusToCtStatus(status status) (st.StatusCode, error) {
 		return st.Reverted, nil
 	case statusSelfDestructed:
 		return st.Stopped, nil
-	case statusInvalidInstruction, statusOutOfGas, statusError:
+	case statusError:
 		return st.Failed, nil
 	default:
 		return st.Failed, fmt.Errorf("unable to convert lfvm status %v to ct status", status)

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -303,16 +303,16 @@ func TestLogOpSizeOverflow(t *testing.T) {
 		"log2_zero":        {logn: 2, size: zero, logCalls: 1, want: statusRunning},
 		"log3_zero":        {logn: 3, size: zero, logCalls: 1, want: statusRunning},
 		"log4_zero":        {logn: 4, size: zero, logCalls: 1, want: statusRunning},
-		"log0_max":         {logn: 0, size: maxUint64, logCalls: 0, want: statusOutOfGas},
-		"log1_max":         {logn: 1, size: maxUint64, logCalls: 0, want: statusOutOfGas},
-		"log2_max":         {logn: 2, size: maxUint64, logCalls: 0, want: statusOutOfGas},
-		"log3_max":         {logn: 3, size: maxUint64, logCalls: 0, want: statusOutOfGas},
-		"log4_max":         {logn: 4, size: maxUint64, logCalls: 0, want: statusOutOfGas},
-		"log0_much_larger": {logn: 0, size: originalBugValue, logCalls: 0, want: statusOutOfGas},
-		"log1_much_larger": {logn: 1, size: originalBugValue, logCalls: 0, want: statusOutOfGas},
-		"log2_much_larger": {logn: 2, size: originalBugValue, logCalls: 0, want: statusOutOfGas},
-		"log3_much_larger": {logn: 3, size: originalBugValue, logCalls: 0, want: statusOutOfGas},
-		"log4_much_larger": {logn: 4, size: originalBugValue, logCalls: 0, want: statusOutOfGas},
+		"log0_max":         {logn: 0, size: maxUint64, logCalls: 0, want: statusError},
+		"log1_max":         {logn: 1, size: maxUint64, logCalls: 0, want: statusError},
+		"log2_max":         {logn: 2, size: maxUint64, logCalls: 0, want: statusError},
+		"log3_max":         {logn: 3, size: maxUint64, logCalls: 0, want: statusError},
+		"log4_max":         {logn: 4, size: maxUint64, logCalls: 0, want: statusError},
+		"log0_much_larger": {logn: 0, size: originalBugValue, logCalls: 0, want: statusError},
+		"log1_much_larger": {logn: 1, size: originalBugValue, logCalls: 0, want: statusError},
+		"log2_much_larger": {logn: 2, size: originalBugValue, logCalls: 0, want: statusError},
+		"log3_much_larger": {logn: 3, size: originalBugValue, logCalls: 0, want: statusError},
+		"log4_much_larger": {logn: 4, size: originalBugValue, logCalls: 0, want: statusError},
 	}
 
 	for name, test := range tests {
@@ -371,7 +371,7 @@ func TestBlobHash(t *testing.T) {
 			setup:    func(params *tosca.Parameters, stack *stack) {},
 			gas:      2,
 			revision: tosca.R12_Shanghai,
-			status:   statusInvalidInstruction,
+			status:   statusError,
 			want:     tosca.Hash{},
 		},
 		"no-hashes": {
@@ -446,7 +446,7 @@ func TestBlobBaseFee(t *testing.T) {
 			setup:    func(*tosca.Parameters) {},
 			gas:      2,
 			revision: tosca.R12_Shanghai,
-			status:   statusInvalidInstruction,
+			status:   statusError,
 			want:     tosca.Value{},
 		},
 	}
@@ -515,7 +515,7 @@ func TestMCopy(t *testing.T) {
 		},
 		"old-revision": {
 			revision:       tosca.R12_Shanghai,
-			expectedStatus: statusInvalidInstruction,
+			expectedStatus: statusError,
 		},
 		"copy": {
 			revision:       tosca.R13_Cancun,
@@ -613,7 +613,7 @@ func TestCreateShanghaiInitCodeSize(t *testing.T) {
 		"paris-max-running":       {tosca.R11_Paris, maxInitCodeSize, statusRunning},
 		"paris-max+1-running":     {tosca.R11_Paris, maxInitCodeSize + 1, statusRunning},
 		"paris-100k-running":      {tosca.R11_Paris, 100000, statusRunning},
-		"paris-maxuint64-running": {tosca.R11_Paris, math.MaxUint64, statusOutOfGas},
+		"paris-maxuint64-running": {tosca.R11_Paris, math.MaxUint64, statusError},
 
 		"shanghai-0-running":         {tosca.R12_Shanghai, 0, statusRunning},
 		"shanghai-1-running":         {tosca.R12_Shanghai, 1, statusRunning},
@@ -622,7 +622,7 @@ func TestCreateShanghaiInitCodeSize(t *testing.T) {
 		"shanghai-max-running":       {tosca.R12_Shanghai, maxInitCodeSize, statusRunning},
 		"shanghai-max+1-running":     {tosca.R12_Shanghai, maxInitCodeSize + 1, statusError},
 		"shanghai-100k-running":      {tosca.R12_Shanghai, 100000, statusError},
-		"shanghai-maxuint64-running": {tosca.R12_Shanghai, math.MaxUint64, statusOutOfGas},
+		"shanghai-maxuint64-running": {tosca.R12_Shanghai, math.MaxUint64, statusError},
 	}
 
 	for name, test := range tests {
@@ -755,7 +755,7 @@ func TestTransientStorageOperations(t *testing.T) {
 			setup:    func(runContext *tosca.MockRunContext) {},
 			stackPtr: 1,
 			revision: tosca.R11_Paris,
-			status:   statusInvalidInstruction,
+			status:   statusError,
 		},
 		"tstore-regular": {
 			op: opTstore,
@@ -771,7 +771,7 @@ func TestTransientStorageOperations(t *testing.T) {
 			setup:    func(runContext *tosca.MockRunContext) {},
 			stackPtr: 2,
 			revision: tosca.R11_Paris,
-			status:   statusInvalidInstruction,
+			status:   statusError,
 		},
 	}
 
@@ -874,7 +874,7 @@ func TestExpansionCostOverflow(t *testing.T) {
 
 					test.op(&ctxt)
 
-					if ctxt.status != statusOutOfGas && ctxt.status != statusError {
+					if ctxt.status != statusError {
 						t.Errorf("unexpected status, wanted not running, got %v, and gas of %v", ctxt.status, ctxt.gas)
 					}
 				})

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -740,6 +740,6 @@ func BenchmarkSatisfiesStackRequirements(b *testing.B) {
 
 	opCodes := allOpCodes()
 	for i := 0; i < b.N; i++ {
-		satisfiesStackRequirements(context, opCodes[i%len(opCodes)])
+		satisfiesStackRequirements(context.stack.len(), opCodes[i%len(opCodes)])
 	}
 }

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -62,15 +62,6 @@ func TestContext_useGas_HandlesTerminationIfOutOfGas(t *testing.T) {
 				t.Errorf("expected UseGas to return %v, got %v", want, success)
 			}
 
-			// Check that the status is updated correctly.
-			wantStatus := statusRunning
-			if !success {
-				wantStatus = statusOutOfGas
-			}
-			if ctx.status != wantStatus {
-				t.Errorf("expected status to be %v, got %v", wantStatus, ctx.status)
-			}
-
 			// Check that the remaining gas is correct.
 			wantGas := tosca.Gas(0)
 			if success {
@@ -448,8 +439,6 @@ func TestRunGenerateResult(t *testing.T) {
 		expectedErr    error
 		expectedResult tosca.Result
 	}{
-		"invalid instruction": {func(ctx *context) { ctx.status = statusInvalidInstruction }, nil, tosca.Result{Success: false}},
-		"out of gas":          {func(ctx *context) { ctx.status = statusOutOfGas }, nil, tosca.Result{Success: false}},
 		"max init code": {func(ctx *context) { ctx.status = statusError }, nil,
 			tosca.Result{Success: false}},
 		"error": {func(ctx *context) { ctx.status = statusError }, nil, tosca.Result{Success: false}},
@@ -569,7 +558,7 @@ func TestStepsDetectsNonExecutableCode(t *testing.T) {
 		// Run testing code
 		steps(&ctxt, false)
 
-		if want, got := statusInvalidInstruction, ctxt.status; want != got {
+		if want, got := statusError, ctxt.status; want != got {
 			t.Errorf("unexpected status: want %v, got %v", want, got)
 		}
 	}
@@ -640,8 +629,8 @@ func TestStepsFailsOnTooLittleGas(t *testing.T) {
 	// Run testing code
 	steps(&ctxt, false)
 
-	if ctxt.status != statusOutOfGas {
-		t.Errorf("unexpected status: want OUT_OF_GAS, got %v", ctxt.status)
+	if ctxt.status != statusError {
+		t.Errorf("unexpected status: want statusError, got %v", ctxt.status)
 	}
 }
 

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -71,7 +71,7 @@ func (m *Memory) getExpansionCosts(size uint64) tosca.Gas {
 // expandMemory tries to expand memory to the given size.
 // If the memory is already large enough or size is 0, it does nothing.
 // If there is not enough gas in the context or an overflow occurs when adding offset and
-// size, it returns an error.
+// size, it returns an error. Caller should check the error and handle it.
 func (m *Memory) expandMemory(offset, size uint64, c *context) error {
 	if size == 0 {
 		return nil
@@ -79,13 +79,11 @@ func (m *Memory) expandMemory(offset, size uint64, c *context) error {
 	needed := offset + size
 	// check overflow
 	if needed < offset {
-		c.signalError()
 		return errGasUintOverflow
 	}
 	if m.length() < needed {
 		fee := m.getExpansionCosts(needed)
 		if !c.useGas(fee) {
-			c.status = statusOutOfGas
 			return errOutOfGas
 		}
 		m.expandMemoryWithoutCharging(needed)

--- a/go/interpreter/lfvm/super_instructions.go
+++ b/go/interpreter/lfvm/super_instructions.go
@@ -86,7 +86,7 @@ func opDup2_Mstore(c *context) {
 	var addr = c.stack.peek()
 
 	offset := addr.Uint64()
-	if err := c.memory.SetWord(offset, value, c); err != nil {
+	if c.memory.SetWord(offset, value, c) != nil {
 		c.signalError()
 	}
 }


### PR DESCRIPTION
Different error status were handled similarly but inconsistently. Functions were also inconsistent when propagating or generating errors regarding when they would be responsible for reporting `statusError`, because of this there were also a lot of code smells of the type 
```
if err != nil {
    return
}
```
Hiding error handling which seems very error prone.

This PR:
- unifies the 3 erroneous status (`statusOutOfGas`, `statusInvalidInstruction` and `statusError`) in a single `statusError`
- adds documentation for functions whose errors should be handled by caller
- consistently handles error propagating and handling.

A CT run was made to corroborate that correctness of known cases has not been affected. 