### PR TITLE
Provide public LFVM interpreter creator function

### DIFF
--- a/go/interpreter/lfvm/instruction_statistcs_test.go
+++ b/go/interpreter/lfvm/instruction_statistcs_test.go
@@ -84,7 +84,7 @@ func TestStatisticsRunner_DumpProfilePrintsExpectedOutput(t *testing.T) {
 				stats: newStatistics(),
 			}
 
-			instance, err := NewVm(Config{
+			instance, err := newVm(config{
 				runner: statsRunner,
 			})
 			if err != nil {

--- a/go/interpreter/lfvm/lfvm_test.go
+++ b/go/interpreter/lfvm/lfvm_test.go
@@ -16,6 +16,19 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 )
 
+func TestNewInterpreter_ProducesInstanceWithSanctionedProperties(t *testing.T) {
+	lfvm, err := NewInterpreter(Config{})
+	if err != nil {
+		t.Fatalf("failed to create LFVM instance: %v", err)
+	}
+	if lfvm.config.WithShaCache != true {
+		t.Fatalf("LFVM is not configured with sha cache")
+	}
+	if lfvm.config.ConversionConfig.WithSuperInstructions != false {
+		t.Fatalf("LFVM is configured with super instructions")
+	}
+}
+
 func TestLfvm_OfficialConfigurationHasSanctionedProperties(t *testing.T) {
 	vm, err := tosca.NewInterpreter("lfvm")
 	if err != nil {


### PR DESCRIPTION
This PR performs a clean-up of the LFVM instantiation code. It does so by
- providing a new `NewInterpreter(Config)` function where `Config` is supposed to be extended in the future with LFVM specific properties (e.g. cache sizes); the implementation of these properties is beyond the scope of this PR, but since this interface will be accessed by down-stream components (e.g. the Sonic client), adding the `Config` only once needed will be a breaking change;
- the package internal pre-existing `Config` was made private
- the old factory function `NewVm` was made private

This is part of #676, #687, #774, and #766