### PR TITLE
LFVM: change return type of useGas to error

### DIFF
--- a/go/interpreter/lfvm/errors.go
+++ b/go/interpreter/lfvm/errors.go
@@ -21,4 +21,5 @@ const (
 	errStackOverflow         = tosca.ConstError("stack overflow")
 	errStackUnderflow        = tosca.ConstError("stack underflow")
 	errWriteProtection       = tosca.ConstError("write protection")
+	errInitCodeTooLarge      = tosca.ConstError("init code larger than allowed")
 )

--- a/go/interpreter/lfvm/gas.go
+++ b/go/interpreter/lfvm/gas.go
@@ -315,12 +315,8 @@ func getRefundForSstore(
 func gasEip2929AccountCheck(c *context, address tosca.Address) error {
 	if c.isAtLeast(tosca.R09_Berlin) {
 		// Charge extra for cold locations.
-		//lint:ignore SA1019 deprecated functions to be migrated in #616
-		if !c.context.IsAddressInAccessList(address) {
-			if !c.useGas(ColdAccountAccessCostEIP2929 - WarmStorageReadCostEIP2929) {
-				return errOutOfGas
-			}
-			c.context.AccessAccount(address)
+		if c.context.AccessAccount(address) == tosca.ColdAccess {
+			return c.useGas(ColdAccountAccessCostEIP2929 - WarmStorageReadCostEIP2929)
 		}
 	}
 	return nil

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -889,7 +889,7 @@ func checkInitCodeSize(c *context, size *uint256.Int) error {
 	if !size.IsUint64() || size.Uint64() > MaxInitCodeSize {
 		c.useGas(c.gas)
 		c.signalError()
-		return errOutOfGas
+		return errInitCodeTooLarge
 	}
 	return c.useGas(tosca.Gas(InitCodeWordGas * tosca.SizeInWords(size.Uint64())))
 }

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -211,7 +211,7 @@ func opMcopy(c *context) {
 
 	size := sizeU256.Uint64()
 	price := tosca.Gas(3 * tosca.SizeInWords(size))
-	if !c.useGas(price) {
+	if err := c.useGas(price); err != nil {
 		c.signalError()
 		return
 	}
@@ -271,7 +271,7 @@ func opSstore(c *context) {
 	storageStatus := c.context.SetStorage(c.params.Recipient, key, value)
 
 	cost += getDynamicCostsForSstore(c.params.Revision, storageStatus)
-	if !c.useGas(cost) {
+	if err := c.useGas(cost); err != nil {
 		c.signalError()
 		return
 	}
@@ -290,7 +290,7 @@ func opSload(c *context) {
 		if c.context.AccessStorage(addr, slot) == tosca.ColdAccess {
 			costs = 2100
 		}
-		if !c.useGas(costs) {
+		if err := c.useGas(costs); err != nil {
 			c.signalError()
 			return
 		}
@@ -394,7 +394,7 @@ func opCallDataCopy(c *context) {
 	// Charge for the copy costs
 	words := tosca.SizeInWords(length64)
 	price := tosca.Gas(3 * words)
-	if !c.useGas(price) {
+	if err := c.useGas(price); err != nil {
 		c.signalError()
 		return
 	}
@@ -596,7 +596,7 @@ func opSMod(c *context) {
 
 func opExp(c *context) {
 	base, exponent := c.stack.pop(), c.stack.peek()
-	if !c.useGas(tosca.Gas(50 * exponent.ByteLen())) {
+	if err := c.useGas(tosca.Gas(50 * exponent.ByteLen())); err != nil {
 		c.signalError()
 		return
 	}
@@ -623,7 +623,7 @@ func opSha3(c *context) {
 	// charge dynamic gas price
 	words := tosca.SizeInWords(size.Uint64())
 	price := tosca.Gas(6 * words)
-	if !c.useGas(price) {
+	if err := c.useGas(price); err != nil {
 		c.signalError()
 		return
 	}
@@ -743,7 +743,7 @@ func opSelfdestruct(c *context) {
 	cost += selfDestructNewAccountCost(c.context.AccountExists(beneficiary),
 		c.context.GetBalance(c.params.Recipient))
 	// even death is not for free
-	if !c.useGas(cost) {
+	if err := c.useGas(cost); err != nil {
 		c.signalError()
 		return
 	}
@@ -832,7 +832,7 @@ func opCodeCopy(c *context) {
 
 	// Charge for length of copied code
 	words := tosca.SizeInWords(length.Uint64())
-	if !c.useGas(tosca.Gas(3 * words)) {
+	if err := c.useGas(tosca.Gas(3 * words)); err != nil {
 		c.signalError()
 		return
 	}
@@ -873,10 +873,10 @@ func opExtcodehash(c *context) {
 }
 
 // checkInitCodeSize checks the size of the init code.
-// if size is greater than MaxInitCodeSize, gas is consumed and returns false.
-// if not enough gas is available, returns false.
-// caller should handle false return value by stopping the execution.
-func checkInitCodeSize(c *context, size *uint256.Int) bool {
+// An error is returned if size is greater than MaxInitCodeSize, or
+// if not enough gas is available.
+// Caller should handle error return and stop the execution.
+func checkInitCodeSize(c *context, size *uint256.Int) error {
 	const (
 		MaxCodeSize     = 24576           // Maximum bytecode to permit for a contract
 		MaxInitCodeSize = 2 * MaxCodeSize // Maximum initcode to permit in a creation transaction and create instructions
@@ -884,11 +884,12 @@ func checkInitCodeSize(c *context, size *uint256.Int) bool {
 	)
 
 	if !c.isAtLeast(tosca.R12_Shanghai) {
-		return true
+		return nil
 	}
 	if !size.IsUint64() || size.Uint64() > MaxInitCodeSize {
 		c.useGas(c.gas)
-		return false
+		c.signalError()
+		return errOutOfGas
 	}
 	return c.useGas(tosca.Gas(InitCodeWordGas * tosca.SizeInWords(size.Uint64())))
 }
@@ -929,7 +930,7 @@ func genericCreate(c *context, kind tosca.CallKind) {
 		return
 	}
 
-	if !checkInitCodeSize(c, size) {
+	if err := checkInitCodeSize(c, size); err != nil {
 		c.signalError()
 		return
 	}
@@ -937,7 +938,7 @@ func genericCreate(c *context, kind tosca.CallKind) {
 	if kind == tosca.Create2 {
 		// Charge for hashing the init code to compute the target address.
 		words := tosca.SizeInWords(size.Uint64())
-		if !c.useGas(tosca.Gas(6 * words)) {
+		if c.useGas(tosca.Gas(6*words)) != nil {
 			c.signalError()
 			return
 		}
@@ -959,7 +960,7 @@ func genericCreate(c *context, kind tosca.CallKind) {
 	// Apply EIP150
 	gas := c.gas
 	gas -= gas / 64
-	if !c.useGas(gas) {
+	if c.useGas(gas) != nil {
 		c.signalError()
 		return
 	}
@@ -1019,7 +1020,7 @@ func opExtCodeCopy(c *context) {
 
 	// Charge for length of copied code
 	words := tosca.SizeInWords(length.Uint64())
-	if !c.useGas(tosca.Gas(3 * words)) {
+	if err := c.useGas(tosca.Gas(3 * words)); err != nil {
 		c.signalError()
 		return
 	}
@@ -1134,7 +1135,7 @@ func genericCall(c *context, kind tosca.CallKind) {
 	}
 
 	cost := callGas(c.gas, baseGas, provided_gas)
-	if !c.useGas(baseGas + cost) {
+	if err := c.useGas(baseGas + cost); err != nil {
 		c.signalError()
 		return
 	}
@@ -1260,7 +1261,7 @@ func opReturnDataCopy(c *context) {
 	}
 
 	words := tosca.SizeInWords(length.Uint64())
-	if !c.useGas(tosca.Gas(3 * words)) {
+	if err := c.useGas(tosca.Gas(3 * words)); err != nil {
 		c.signalError()
 		return
 	}
@@ -1297,7 +1298,7 @@ func opLog(c *context, size int) {
 	log_size := mSize.Uint64()
 
 	// charge for log size
-	if !c.useGas(tosca.Gas(8 * log_size)) {
+	if err := c.useGas(tosca.Gas(8 * log_size)); err != nil {
 		c.signalError()
 		return
 	}

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -888,7 +888,6 @@ func checkInitCodeSize(c *context, size *uint256.Int) error {
 	}
 	if !size.IsUint64() || size.Uint64() > MaxInitCodeSize {
 		c.useGas(c.gas)
-		c.signalError()
 		return errInitCodeTooLarge
 	}
 	return c.useGas(tosca.Gas(InitCodeWordGas * tosca.SizeInWords(size.Uint64())))

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -838,7 +838,7 @@ func TestExpansionCostOverflow(t *testing.T) {
 			stackSize:  4,
 			memIndexes: []int{0, 2},
 			setup: func(runContext *tosca.MockRunContext) {
-				runContext.EXPECT().IsAddressInAccessList(gomock.Any()).AnyTimes().Return(true)
+				runContext.EXPECT().AccessAccount(gomock.Any()).AnyTimes().Return(tosca.WarmAccess)
 				runContext.EXPECT().GetCode(gomock.Any()).AnyTimes().Return([]byte{0x01, 0x02, 0x03, 0x04})
 			},
 		},

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -62,13 +62,13 @@ type context struct {
 // below zero, the caller should stop the execution with an error status. The function
 // returns true if sufficient gas was available and execution can continue,
 // false otherwise.
-func (c *context) useGas(amount tosca.Gas) bool {
+func (c *context) useGas(amount tosca.Gas) error {
 	if c.gas < 0 || amount < 0 || c.gas < amount {
 		c.gas = 0
-		return false
+		return errOutOfGas
 	}
 	c.gas -= amount
-	return true
+	return nil
 }
 
 // signalError informs the context that an error was encountered that should
@@ -245,7 +245,7 @@ func steps(c *context, oneStepOnly bool) {
 		}
 
 		// Consume static gas price for instruction before execution
-		if !c.useGas(staticGasPrices.get(op)) {
+		if err := c.useGas(staticGasPrices.get(op)); err != nil {
 			c.signalError()
 			return
 		}

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -53,18 +53,22 @@ func TestContext_useGas_HandlesTerminationIfOutOfGas(t *testing.T) {
 				status: statusRunning,
 				gas:    test.available,
 			}
-			success := ctx.useGas(test.required)
+			err := ctx.useGas(test.required)
 
 			// Check that the result of UseGas indicates whether there was
 			// enough gas.
-			want := test.required >= 0 && test.available >= test.required
-			if want != success {
-				t.Errorf("expected UseGas to return %v, got %v", want, success)
+			want := error(nil)
+			// TODO: remove status check once #772 is merged
+			if test.required < 0 || test.available < test.required {
+				want = errOutOfGas
+			}
+			if want != err {
+				t.Errorf("expected UseGas to return %v, got %v", want, err)
 			}
 
 			// Check that the remaining gas is correct.
 			wantGas := tosca.Gas(0)
-			if success {
+			if err == nil {
 				wantGas = test.available - test.required
 			}
 			if ctx.gas != wantGas {

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -60,7 +60,7 @@ func TestContext_useGas_HandlesTerminationIfOutOfGas(t *testing.T) {
 			want := test.required >= 0 && test.available >= test.required
 			success := err == nil
 			if want != success {
-				t.Errorf("expected UseGas to return %v, got %v", want, err)
+				t.Errorf("expected UseGas to return %v, got %v", want, success)
 			}
 
 			// Check that the remaining gas is correct.

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -57,12 +57,9 @@ func TestContext_useGas_HandlesTerminationIfOutOfGas(t *testing.T) {
 
 			// Check that the result of UseGas indicates whether there was
 			// enough gas.
-			want := error(nil)
-			// TODO: remove status check once #772 is merged
-			if test.required < 0 || test.available < test.required {
-				want = errOutOfGas
-			}
-			if want != err {
+			want := test.required >= 0 && test.available >= test.required
+			success := err == nil
+			if want != success {
 				t.Errorf("expected UseGas to return %v, got %v", want, err)
 			}
 

--- a/go/interpreter/lfvm/memory.go
+++ b/go/interpreter/lfvm/memory.go
@@ -83,8 +83,8 @@ func (m *Memory) expandMemory(offset, size uint64, c *context) error {
 	}
 	if m.length() < needed {
 		fee := m.getExpansionCosts(needed)
-		if !c.useGas(fee) {
-			return errOutOfGas
+		if err := c.useGas(fee); err != nil {
+			return err
 		}
 		m.expandMemoryWithoutCharging(needed)
 	}


### PR DESCRIPTION
`useGas` used to return `bool`, to inform whether it was successful or not, in Go this should be done using `error`, for error propagation. 
This PR does just that, changes the return type from `bool` to `error` and checks whether this error is nil or not in all the call places. 
This PR should be carefully rebased with #772 since they are both about errors, but this change seemed big enough, conceptually, to be its own PR. 