### PR TITLE
Add new linter to detect unassigned error returns

### DIFF
--- a/.github/workflows/go-linter.yml
+++ b/.github/workflows/go-linter.yml
@@ -8,28 +8,41 @@
 # On the date above, in accordance with the Business Source License, use of
 # this software will be governed by the GNU Lesser General Public License v3.
 
-name: golangci-lint
+name: lint-go
+
 on:
   push:
     branches: [ "main" ]
     paths:
+      - '.github/workflows/go.yml'
       - 'go/**'
-      - 'go.mod'
+      - Makefile
   pull_request:
     branches: [ "main" ]
     paths:
+      - '.github/workflows/go.yml'
       - 'go/**'
-      - 'go.mod'
+      - Makefile
 
 jobs:
-  ci:
-    name: "lint"
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
         submodules: recursive
-    - uses: dominikh/staticcheck-action@v1
+
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v1.13
       with:
-        version: "latest"
+        cmake-version: '3.27.x'
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.21
+        cache: false
+
+    - name: Lint code
+      run: make lint-go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,9 +47,6 @@ jobs:
       working-directory: ./
       run: diff=`gofmt -s -d ./go`; echo "$diff"; test -z "$diff"
 
-    - name: Go Vet static analysis
-      run: go vet ./go/...
-
     - name: Build
       run: make tosca-go
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,9 +56,7 @@ pipeline {
 
         stage('Lint Go sources') {
             steps {
-                sh 'go vet ./go/...'
-                sh 'go install honnef.co/go/tools/cmd/staticcheck@latest'
-                sh "$HOME/go/bin/staticcheck ./go/..."
+                sh 'make lint-go'
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
         stage('Validate commit') {
             steps {
                 script {
-                    def CHANGE_REPO = sh (script: "basename -s .git `git config --get remote.origin.url`", returnStdout: true).trim()
+                    def CHANGE_REPO = sh(script: 'basename -s .git `git config --get remote.origin.url`', returnStdout: true).trim()
                     build job: '/Utils/Validate-Git-Commit', parameters: [
                         string(name: 'Repo', value: "${CHANGE_REPO}"),
                         string(name: 'Branch', value: "${env.CHANGE_BRANCH}"),
@@ -56,7 +56,9 @@ pipeline {
 
         stage('Lint Go sources') {
             steps {
-                sh 'make lint-go'
+                withEnv(["PATH+GOPATH=${env.HOME}/go/bin"]) {
+                    sh 'make lint-go'
+                }
             }
         }
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ TOSCA_CPP_ASSERT = ON
 TOSCA_CPP_ASAN = OFF
 TOSCA_CPP_COVERAGE = OFF
 
+STATICCHECK_VERSION = 2024.1.1
+ERRCHECK_VERSION = v1.7.0
+
 .PHONY: all tosca tosca-go tosca-cpp test test-go test-cpp test-cpp-asan \
         bench bench-go clean clean-go clean-cpp evmone evmone-clean license-headers
 
@@ -122,3 +125,18 @@ test-coverage: test-go coverage-report
 coverage-report:
 	@go install github.com/vladopajic/go-test-coverage/v2@v2.10.1
 	@go-test-coverage --config .testcoverage.yml
+
+# Linting
+
+vet:
+	go vet ./go/...
+
+staticcheck: 
+	@go install honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION)
+	staticcheck ./go/...
+
+errorcheck:
+	@go install github.com/kisielk/errcheck@$(ERRCHECK_VERSION)
+	errcheck ./go/...
+
+lint-go: vet staticcheck errorcheck

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TOSCA_CPP_ASSERT = ON
 TOSCA_CPP_ASAN = OFF
 TOSCA_CPP_COVERAGE = OFF
 
-STATICCHECK_VERSION = 2024.1.1
+STATICCHECK_VERSION = 2023.1.6
 ERRCHECK_VERSION = v1.7.0
 
 .PHONY: all tosca tosca-go tosca-cpp test test-go test-cpp test-cpp-asan \

--- a/go/integration_test/interpreter/test_config.go
+++ b/go/integration_test/interpreter/test_config.go
@@ -11,6 +11,7 @@
 package interpreter_test
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 
@@ -25,7 +26,10 @@ import (
 func init() {
 	// Experimental LFVM configurations should be covered by integration tests
 	// as they might be used by down-stream tools and for debugging.
-	lfvm.RegisterExperimentalInterpreterConfigurations()
+	err := lfvm.RegisterExperimentalInterpreterConfigurations()
+	if err != nil {
+		panic(fmt.Errorf("failed to register experimental LFVM configurations: %v", err))
+	}
 }
 
 // getAllInterpreterVariantsForTests returns all registered interpreter variants

--- a/go/interpreter/evmone/evmone.go
+++ b/go/interpreter/evmone/evmone.go
@@ -33,10 +33,10 @@ func init() {
 	}
 	// This instance remains in its basic configuration and is registered
 	// as the default "evmone" VM and as the "evmone-basic" tosca.
-	tosca.RegisterInterpreterFactory("evmone", func(any) (tosca.Interpreter, error) {
+	tosca.MustRegisterInterpreterFactory("evmone", func(any) (tosca.Interpreter, error) {
 		return &evmoneInstance{evmone}, nil
 	})
-	tosca.RegisterInterpreterFactory("evmone-basic", func(any) (tosca.Interpreter, error) {
+	tosca.MustRegisterInterpreterFactory("evmone-basic", func(any) (tosca.Interpreter, error) {
 		return &evmoneInstance{evmone}, nil
 	})
 
@@ -48,7 +48,7 @@ func init() {
 	if err := evmone.SetOption("advanced", "on"); err != nil {
 		panic(fmt.Errorf("failed to configure evmone advanced mode: %v", err))
 	}
-	tosca.RegisterInterpreterFactory("evmone-advanced", func(any) (tosca.Interpreter, error) {
+	tosca.MustRegisterInterpreterFactory("evmone-advanced", func(any) (tosca.Interpreter, error) {
 		return &evmoneInstance{evmone}, nil
 	})
 }

--- a/go/interpreter/evmzero/evmzero.go
+++ b/go/interpreter/evmzero/evmzero.go
@@ -36,7 +36,7 @@ func init() {
 			panic(fmt.Errorf("failed to load evmzero library: %s", err))
 		}
 		// This instance remains in its basic configuration.
-		tosca.RegisterInterpreterFactory("evmzero", func(any) (tosca.Interpreter, error) {
+		tosca.MustRegisterInterpreterFactory("evmzero", func(any) (tosca.Interpreter, error) {
 			return &evmzeroInstance{evm}, nil
 		})
 	}
@@ -50,7 +50,7 @@ func init() {
 		if err = evm.SetOption("logging", "true"); err != nil {
 			panic(fmt.Errorf("failed to configure EVM instance: %s", err))
 		}
-		tosca.RegisterInterpreterFactory("evmzero-logging", func(any) (tosca.Interpreter, error) {
+		tosca.MustRegisterInterpreterFactory("evmzero-logging", func(any) (tosca.Interpreter, error) {
 			return &evmzeroInstance{evm}, nil
 		})
 	}
@@ -64,7 +64,7 @@ func init() {
 		if err = evm.SetOption("analysis_cache", "false"); err != nil {
 			panic(fmt.Errorf("failed to configure EVM instance: %s", err))
 		}
-		tosca.RegisterInterpreterFactory("evmzero-no-analysis-cache", func(any) (tosca.Interpreter, error) {
+		tosca.MustRegisterInterpreterFactory("evmzero-no-analysis-cache", func(any) (tosca.Interpreter, error) {
 			return &evmzeroInstance{evm}, nil
 		})
 	}
@@ -78,7 +78,7 @@ func init() {
 		if err = evm.SetOption("sha3_cache", "false"); err != nil {
 			panic(fmt.Errorf("failed to configure EVM instance: %s", err))
 		}
-		tosca.RegisterInterpreterFactory("evmzero-no-sha3-cache", func(any) (tosca.Interpreter, error) {
+		tosca.MustRegisterInterpreterFactory("evmzero-no-sha3-cache", func(any) (tosca.Interpreter, error) {
 			return &evmzeroInstance{evm}, nil
 		})
 	}
@@ -92,7 +92,7 @@ func init() {
 		if err = evm.SetOption("profiling", "true"); err != nil {
 			panic(fmt.Errorf("failed to configure EVM instance: %s", err))
 		}
-		tosca.RegisterInterpreterFactory("evmzero-profiling", func(any) (tosca.Interpreter, error) {
+		tosca.MustRegisterInterpreterFactory("evmzero-profiling", func(any) (tosca.Interpreter, error) {
 			return &evmzeroInstanceWithProfiler{&evmzeroInstance{evm}}, nil
 		})
 	}
@@ -106,7 +106,7 @@ func init() {
 		if err = evm.SetOption("profiling_external", "true"); err != nil {
 			panic(fmt.Errorf("failed to configure EVM instance: %s", err))
 		}
-		tosca.RegisterInterpreterFactory("evmzero-profiling-external", func(any) (tosca.Interpreter, error) {
+		tosca.MustRegisterInterpreterFactory("evmzero-profiling-external", func(any) (tosca.Interpreter, error) {
 			return &evmzeroInstanceWithProfiler{&evmzeroInstance{evm}}, nil
 		})
 	}

--- a/go/interpreter/evmzero/evmzero_test.go
+++ b/go/interpreter/evmzero/evmzero_test.go
@@ -67,7 +67,10 @@ func TestEvmzero_DumpProfile(t *testing.T) {
 func BenchmarkNewEvmcInterpreter(b *testing.B) {
 	b.Run("evmzero", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			tosca.NewInterpreter("evmzero")
+			_, err := tosca.NewInterpreter("evmzero")
+			if err != nil {
+				b.Fatalf("failed to load evmzero interpreter: %v", err)
+			}
 		}
 	})
 }

--- a/go/interpreter/geth/geth.go
+++ b/go/interpreter/geth/geth.go
@@ -29,7 +29,7 @@ import (
 )
 
 func init() {
-	tosca.RegisterInterpreterFactory("geth", func(any) (tosca.Interpreter, error) {
+	tosca.MustRegisterInterpreterFactory("geth", func(any) (tosca.Interpreter, error) {
 		return &gethVm{}, nil
 	})
 }

--- a/go/interpreter/lfvm/instruction_statistcs_test.go
+++ b/go/interpreter/lfvm/instruction_statistcs_test.go
@@ -92,8 +92,11 @@ func TestStatisticsRunner_DumpProfilePrintsExpectedOutput(t *testing.T) {
 			}
 			instance.ResetProfile()
 			//run code
-			instance.Run(tosca.Parameters{Input: []byte{}, Static: true, Gas: 10,
+			_, err = instance.Run(tosca.Parameters{Input: []byte{}, Static: true, Gas: 10,
 				Code: test.code})
+			if err != nil {
+				t.Fatalf("Failed to run code: %v", err)
+			}
 
 			// Run testing code
 			instance.DumpProfile()

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -371,7 +371,7 @@ func TestRunWithLogging(t *testing.T) {
 		runner: loggingRunner{},
 	}, params, code)
 	// read the output
-	w.Close()
+	_ = w.Close() // ignore error in test
 	out, _ := io.ReadAll(r)
 	os.Stdout = old
 
@@ -409,7 +409,7 @@ func TestRunBasic(t *testing.T) {
 	// Run testing code
 	_, err := run(interpreterConfig{}, params, code)
 	// read the output
-	w.Close()
+	_ = w.Close() // ignore error in test
 	out, _ := io.ReadAll(r)
 	os.Stdout = old
 

--- a/go/interpreter/lfvm/keccak.go
+++ b/go/interpreter/lfvm/keccak.go
@@ -36,9 +36,9 @@ var keccakHasherPool = sync.Pool{New: func() any { return sha3.NewLegacyKeccak25
 func keccak256_Go(data []byte) tosca.Hash {
 	hasher := keccakHasherPool.Get().(keccakHasher)
 	hasher.Reset()
-	hasher.Write(data)
+	_, _ = hasher.Write(data) // keccak256 never returns an error
 	var res tosca.Hash
-	hasher.Read(res[:])
+	_, _ = hasher.Read(res[:]) // keccak256 never returns an error
 	keccakHasherPool.Put(hasher)
 	return res
 }

--- a/go/lib/cpp/coverage_test.go
+++ b/go/lib/cpp/coverage_test.go
@@ -25,7 +25,10 @@ func TestDumpCppCoverageData(t *testing.T) {
 
 	// write coverage data into tempDir directory
 	tempDir := t.TempDir()
-	os.Setenv("GCOV_PREFIX", tempDir)
+	err := os.Setenv("GCOV_PREFIX", tempDir)
+	if err != nil {
+		t.Fatalf("Failed to set GCOV_PREFIX: %v", err)
+	}
 
 	// run dump routine
 	DumpCppCoverageData()
@@ -45,7 +48,7 @@ func TestDumpCppCoverageData(t *testing.T) {
 
 	// check that at least one file is generated
 	found := false
-	err := filepath.WalkDir(tempDir, func(s string, _ fs.DirEntry, err error) error {
+	err = filepath.WalkDir(tempDir, func(s string, _ fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/go/tosca/interpreter_registry.go
+++ b/go/tosca/interpreter_registry.go
@@ -111,6 +111,17 @@ func RegisterInterpreterFactory(name string, factory InterpreterFactory) error {
 	return nil
 }
 
+// MustRegisterInterpreterFactory registers a new Interpreter implementation
+// See RegisterInterpreterFactory for more information.
+// This function panics if the registration fails. This function is intended to
+// be used exclusively in package initialization code, where error handling is
+// limited.
+func MustRegisterInterpreterFactory(name string, factory InterpreterFactory) {
+	if err := RegisterInterpreterFactory(name, factory); err != nil {
+		panic(fmt.Errorf("failed to register interpreter factory: %s", err))
+	}
+}
+
 // InterpreterFactory is the type of a function that creates a new Interpreter
 // using a interpreter specific configuration.
 type InterpreterFactory func(config any) (Interpreter, error)


### PR DESCRIPTION
This PR makes more difficult to ignore error returns. 
The problem why this was not working earlier is explained [here](https://www.dolthub.com/blog/2024-07-24-static-analysis/)

Found cases have been fixed with usual methods. 
Only the close call, between an error generation and its use, seems odd. This error in particular is discussed in the [go-PR](https://github.com/golang/go/issues/20148#issuecomment-2148205291) that attempted to enable this check in vet but was rejected. 