### PR TITLE
Add unit tests for code conversion

### DIFF
--- a/go/interpreter/lfvm/converter.go
+++ b/go/interpreter/lfvm/converter.go
@@ -12,6 +12,7 @@ package lfvm
 
 import (
 	"math"
+	"unsafe"
 
 	"github.com/Fantom-foundation/Tosca/go/ct/common"
 	"github.com/Fantom-foundation/Tosca/go/tosca"
@@ -47,7 +48,8 @@ func NewConverter(config ConversionConfig) (*Converter, error) {
 	var cache *lru.Cache[tosca.Hash, Code]
 	if config.CacheSize > 0 {
 		var err error
-		capacity := config.CacheSize / maxCachedCodeLength
+		const instructionSize = int(unsafe.Sizeof(Instruction{}))
+		capacity := config.CacheSize / maxCachedCodeLength / instructionSize
 		cache, err = lru.New[tosca.Hash, Code](capacity)
 		if err != nil {
 			return nil, err

--- a/go/interpreter/lfvm/converter_fuzz_test.go
+++ b/go/interpreter/lfvm/converter_fuzz_test.go
@@ -11,10 +11,14 @@
 package lfvm
 
 import (
+	"math"
 	"testing"
 
 	"github.com/Fantom-foundation/Tosca/go/tosca/vm"
 )
+
+// To run this fuzzer use the following command:
+// go test ./interpreter/lfvm -run none -fuzz LfvmConverter --fuzztime 10m
 
 func FuzzLfvmConverter(f *testing.F) {
 
@@ -32,17 +36,14 @@ func FuzzLfvmConverter(f *testing.F) {
 		// also the limit for the conversion code (due to a 16-bit PC
 		// counter representation in the PC instruction). Thus, we test
 		// the code up to this level.
-		maxCodeSize := 1<<16 - 1
+		maxCodeSize := math.MaxUint16
 		if len(toscaCode) > maxCodeSize {
 			t.Skip()
 		}
 
-		type pair struct {
-			originalPos, lfvmPos int
-		}
-		var pairs []pair
+		mapping := make([]int, len(toscaCode))
 		lfvmCode := convertWithObserver(toscaCode, ConversionConfig{}, func(evm, lfvm int) {
-			pairs = append(pairs, pair{evm, lfvm})
+			mapping[evm] = lfvm
 		})
 
 		// Check that no super-instructions have been used.
@@ -53,28 +54,39 @@ func FuzzLfvmConverter(f *testing.F) {
 		}
 
 		// Check that all operations are mapped to matching operations.
-		for _, p := range pairs {
+		for i := 0; i < len(toscaCode); i++ {
+			originalPos := i
+			lfvmPos := mapping[originalPos]
 
-			toscaOpCode := vm.OpCode(toscaCode[p.originalPos])
-			lfvmOpCode := lfvmCode[p.lfvmPos].opcode
+			toscaOpCode := vm.OpCode(toscaCode[originalPos])
+			lfvmOpCode := lfvmCode[lfvmPos].opcode
 
-			if !vm.IsValid(toscaOpCode) && lfvmOpCode != INVALID {
-				t.Errorf("Expected INVALID, got %v", lfvmOpCode.String())
+			if !lfvmOpCode.isBaseInstruction() {
+				t.Errorf("Expected base instructions only, got %v", lfvmOpCode)
 			}
 
-			if vm.IsValid(toscaOpCode) {
-				if got, want := lfvmOpCode, OpCode(toscaOpCode); got != want {
-					t.Errorf("Expected %v, got %v", want, got)
+			if vm.OpCode(lfvmOpCode) != toscaOpCode {
+				t.Errorf("Invalid conversion from %v to %v", toscaOpCode, lfvmOpCode)
+			}
+
+			// Check that the position of JUMPDEST ops are preserved.
+			if toscaOpCode == vm.JUMPDEST {
+				if originalPos != lfvmPos {
+					t.Errorf("Expected JUMPDEST at %d, got %d", originalPos, lfvmPos)
 				}
 			}
-		}
 
-		// Check that the position of JUMPDEST ops are preserved.
-		for _, p := range pairs {
-			if vm.OpCode(toscaCode[p.originalPos]) == vm.JUMPDEST {
-				if p.originalPos != p.lfvmPos {
-					t.Errorf("Expected JUMPDEST at %d, got %d", p.originalPos, p.lfvmPos)
+			// Check that PC instructions point to the correct target.
+			if toscaOpCode == vm.PC {
+				target := int(lfvmCode[lfvmPos].arg)
+				if target != originalPos {
+					t.Errorf("Invalid PC target, wanted %d, got %d", originalPos, target)
 				}
+			}
+
+			// Skip the data section of PUSH instructions.
+			if vm.PUSH1 <= toscaOpCode && toscaOpCode <= vm.PUSH32 {
+				i += int(toscaOpCode-vm.PUSH1) + 1
 			}
 		}
 

--- a/go/interpreter/lfvm/instruction.go
+++ b/go/interpreter/lfvm/instruction.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 )
 
-// The encoding of each instruction for the MACRO EVM
+// Instruction encodes an instruction for the long-form virtual machine (LFVM).
 type Instruction struct {
 	// The op-code of this instruction.
 	opcode OpCode
@@ -23,7 +23,7 @@ type Instruction struct {
 	arg uint16
 }
 
-// Code for the macro EVM is a slice of instructions
+// Code for the LFVM is a slice of instructions.
 type Code []Instruction
 
 func (i Instruction) String() string {

--- a/go/interpreter/lfvm/opcode.go
+++ b/go/interpreter/lfvm/opcode.go
@@ -318,6 +318,10 @@ func (o OpCode) HasArgument() bool {
 	return false
 }
 
+func (o OpCode) isBaseInstruction() bool {
+	return o < 0x100
+}
+
 func (o OpCode) isSuperInstruction() bool {
 	return o.decompose() != nil
 }

--- a/go/interpreter/lfvm/opcode.go
+++ b/go/interpreter/lfvm/opcode.go
@@ -218,9 +218,40 @@ const (
 // original EVM.
 const (
 	// long-form EVM special instructions
+
+	// JUMP_TO is a special instruction that is used to jump to the end of the
+	// current basic block.
+	//
+	// Since due to the usage of immediate arguments in instructions like PUSH2
+	// the code size of basic blocks can shrink compared to the original EVM,
+	// gaps can appear between the end of a basic block and the beginning of the
+	// next one indicated by a JUMPDEST instruction. Since all JUMPDEST
+	// instructions have to remain at the same position in the code as in the
+	// original EVM code, since jump-destinations of JUMP and JUMPI  operations
+	// are computed dynamically, these gaps have to be filled with NOOP
+	// instructions. To avoid having to process long sequences of NOOPs,
+	// JUMP_TO instructions are used to skip them in a single step.
+	//
+	// The following restrictions are imposed on JUMP_TO instructions:
+	//  - they must target the immediate succeeding JUMPDEST instruction
+	//  - all instructions between the JUMP_TO and the JUMPDEST must be NOOPs
+	//
+	// These restrictions are enforced during the EVM to LFVM code conversion.
 	JUMP_TO OpCode = iota + 0x100
-	DATA
+
+	// NOOP is a special instruction that does nothing. It is used as a filler
+	// instruction to pad basic blocks to the correct size.
 	NOOP
+
+	// DATA is a special instruction that is used to extend the size of OpCodes
+	// that require more than the available 2-byte immediate arguments.
+	// For instance, [PUSH4, 1, 2, 3, 4] in the original EVM code gets converted
+	// to [(PUSH4, 1<<8 | 2),(DATA, 3<<8 | 4)].
+	// Since DATA is marked explicitly as such, jump-destination checks can be
+	// conducted in O(1) by checking the OpCode of an instruction. In the
+	// implicit data encoding of EVM byte code, this would require a linear
+	// search (which could be cached to amortize costs).
+	DATA
 
 	// Super-instructions
 	SWAP2_SWAP1_POP_JUMP

--- a/go/interpreter/lfvm/testdata/fuzz/FuzzLfvmConverter/353ba911ad2dc191
+++ b/go/interpreter/lfvm/testdata/fuzz/FuzzLfvmConverter/353ba911ad2dc191
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("a00")

--- a/go/interpreter/lfvm/testdata/fuzz/FuzzLfvmConverter/6e0463cbdc2d559f
+++ b/go/interpreter/lfvm/testdata/fuzz/FuzzLfvmConverter/6e0463cbdc2d559f
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("a0")

--- a/go/interpreter/lfvm/testdata/fuzz/FuzzLfvmConverter/8b15f710f79d31dd
+++ b/go/interpreter/lfvm/testdata/fuzz/FuzzLfvmConverter/8b15f710f79d31dd
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("a[")

--- a/go/interpreter/lfvm/testdata/fuzz/FuzzLfvmConverter/c94ac12daf9859fd
+++ b/go/interpreter/lfvm/testdata/fuzz/FuzzLfvmConverter/c94ac12daf9859fd
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("!")


### PR DESCRIPTION
This PR adds unit tests for the following code conversion properties:
- all JUMPDEST instructions remain at the same position as in the input code
- base instructions are converted to their corresponding LFVM instruction if super instructions are disabled
- push operations are encoded and automatically zero-padded to their full length
- all JUMP_TO instructions point to their immediate JUMPDEST successor
- super instructions are ignored if disabled
- super instructions are identified if enabled

The PR also strengthens the checks covered by the code conversion fuzzer.

By reviewing the tests the following bug was identified:
- the size of codes in cache was computed assuming each instruction only takes 1 byte; actually it takes 4