### PR TITLE
LFVM: refactor max init code size check

### DIFF
--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -940,6 +940,8 @@ func genericCreate(c *context, kind tosca.CallKind) error {
 	return nil
 }
 
+// checkInitCodeSize checks the size of the init code.
+// An error is returned if size is greater than MaxInitCodeSize.
 func checkMaxInitCodeSize(size uint64) error {
 	const (
 		maxCodeSize     = 24576           // Maximum bytecode to permit for a contract


### PR DESCRIPTION
the previous `checkInitCodeSize` also did modifications to gas, which was not documented nor in the function name. Since we trying to maintain all `useGas` calls in `opX` functions, this is moved to `genericCreate` along with the revision check, simplifying greatly this function.
