### PR TITLE
LFVM: Refactor Run method to return tuple (status, error)

### DIFF
--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -72,7 +72,6 @@ func (a *ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 		refund:     tosca.Gas(state.GasRefund),
 		stack:      convertCtStackToLfvmStack(state.Stack),
 		memory:     memory,
-		status:     statusRunning,
 		code:       converted,
 		returnData: state.LastCallReturnData.ToBytes(),
 	}
@@ -82,22 +81,32 @@ func (a *ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 	}()
 
 	// Run interpreter.
-	for i := 0; ctxt.status == statusRunning && i < numSteps; i++ {
-		step(ctxt)
-	}
-
-	result, err := getOutput(ctxt)
-	if err != nil {
-		ctxt.status = statusError
+	status := statusRunning
+	var executionErr error
+	for i := 0; status == statusRunning && i < numSteps; i++ {
+		status, executionErr = step(ctxt)
+		if executionErr != nil {
+			break
+		}
 	}
 
 	// Update the resulting state.
-	state.Status, err = convertLfvmStatusToCtStatus(ctxt.status)
+	state.Status, err = convertLfvmStatusToCtStatus(status)
 	if err != nil {
 		return nil, err
 	}
-	if ctxt.status == statusRunning {
+
+	result, err := getOutput(status, ctxt)
+	if err != nil {
+		executionErr = err
+	}
+
+	if executionErr == nil {
 		state.Pc = pcMap.lfvmToEvm[ctxt.pc]
+	}
+
+	if executionErr != nil {
+		state.Status = st.Failed
 	}
 
 	state.Gas = ctxt.gas
@@ -177,8 +186,6 @@ func convertLfvmStatusToCtStatus(status status) (st.StatusCode, error) {
 		return st.Reverted, nil
 	case statusSelfDestructed:
 		return st.Stopped, nil
-	case statusError:
-		return st.Failed, nil
 	default:
 		return st.Failed, fmt.Errorf("unable to convert lfvm status %v to ct status", status)
 	}

--- a/go/interpreter/lfvm/ct_test.go
+++ b/go/interpreter/lfvm/ct_test.go
@@ -61,7 +61,7 @@ func TestCtAdapter_Interface(t *testing.T) {
 
 func TestConvertToLfvm_StatusCode(t *testing.T) {
 
-	expected := map[status]st.StatusCode{
+	tests := map[status]st.StatusCode{
 		statusRunning:        st.Running,
 		statusReverted:       st.Reverted,
 		statusReturned:       st.Stopped,
@@ -69,22 +69,21 @@ func TestConvertToLfvm_StatusCode(t *testing.T) {
 		statusSelfDestructed: st.Stopped,
 	}
 
-	for i := 0; i < 100; i++ {
-		status := status(i)
-		want, found := expected[status]
-		if !found {
-			want = st.Failed
-		}
+	for status, test := range tests {
 		got, err := convertLfvmStatusToCtStatus(status)
 		if err != nil {
-			if found {
-				t.Errorf("failed conversion of %v, wanted %v, got error %v", status, want, err)
-			}
-		} else {
-			if want != got {
-				t.Errorf("invalid conversion of %v, expected %v, got %v", status, want, got)
-			}
+			t.Fatalf("unexpected error: %v", err)
 		}
+		if want, got := test, got; want != got {
+			t.Errorf("unexpected conversion, wanted %v, got %v", want, got)
+		}
+	}
+}
+
+func TestConvertToLfvm_StatusCodeFailsOnUnknownStatus(t *testing.T) {
+	_, err := convertLfvmStatusToCtStatus(statusSelfDestructed + 1)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
 	}
 }
 

--- a/go/interpreter/lfvm/instruction_statistcs_test.go
+++ b/go/interpreter/lfvm/instruction_statistcs_test.go
@@ -32,10 +32,10 @@ func TestStatisticsRunner_RunWithStatistics(t *testing.T) {
 	statsRunner := &statisticRunner{
 		stats: newStatistics(),
 	}
-	// Run testing code
-	_, err := run(interpreterConfig{
+	config := interpreterConfig{
 		runner: statsRunner,
-	}, params, code)
+	}
+	_, err := run(config, params, code)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/go/interpreter/lfvm/instruction_statistics.go
+++ b/go/interpreter/lfvm/instruction_statistics.go
@@ -27,14 +27,14 @@ type statisticRunner struct {
 func (s *statisticRunner) run(c *context) (status, error) {
 	stats := statsCollector{stats: newStatistics()}
 	status := statusRunning
-	var err error
+	var executionError error
 	for status == statusRunning {
 		if c.pc < int32(len(c.code)) {
 			stats.nextOp(c.code[c.pc].opcode)
 		}
-		status, err = step(c)
-		if err != nil {
-			return status, err
+		status, executionError = step(c)
+		if executionError != nil {
+			break
 		}
 	}
 	s.mutex.Lock()
@@ -43,7 +43,7 @@ func (s *statisticRunner) run(c *context) (status, error) {
 		s.stats = newStatistics()
 	}
 	s.stats.insert(stats.stats)
-	return status, nil
+	return status, executionError
 }
 
 // getSummary returns a summary of the collected statistics in a human-readable

--- a/go/interpreter/lfvm/instruction_statistics.go
+++ b/go/interpreter/lfvm/instruction_statistics.go
@@ -24,13 +24,18 @@ type statisticRunner struct {
 	stats *statistics
 }
 
-func (s *statisticRunner) run(c *context) {
+func (s *statisticRunner) run(c *context) (status, error) {
 	stats := statsCollector{stats: newStatistics()}
-	for c.status == statusRunning {
+	status := statusRunning
+	var err error
+	for status == statusRunning {
 		if c.pc < int32(len(c.code)) {
 			stats.nextOp(c.code[c.pc].opcode)
 		}
-		step(c)
+		status, err = step(c)
+		if err != nil {
+			return status, err
+		}
 	}
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
@@ -38,6 +43,7 @@ func (s *statisticRunner) run(c *context) {
 		s.stats = newStatistics()
 	}
 	s.stats.insert(stats.stats)
+	return status, nil
 }
 
 // getSummary returns a summary of the collected statistics in a human-readable

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1121,7 +1121,6 @@ func TestGenericCreate_MaxInitCodeSizeIsNotCheckedBeforeShanghai(t *testing.T) {
 			runContext.EXPECT().Call(tosca.Create, gomock.Any()).Return(tosca.CallResult{}, nil).AnyTimes()
 
 			ctxt := context{
-				status: statusRunning,
 				params: tosca.Parameters{
 					BlockParameters: tosca.BlockParameters{
 						Revision: test.revision,

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -26,7 +26,6 @@ const (
 	statusReverted                     // < execution stopped with a REVERT
 	statusReturned                     // < execution stopped with a RETURN
 	statusSelfDestructed               // < execution stopped with a SELF-DESTRUCT
-	statusError                        // < execution stopped with an error (e.g. stack underflow, out-of-gas, invalid-opcode)
 )
 
 // context is the execution environment of an interpreter run. It contains all
@@ -40,9 +39,6 @@ type context struct {
 	code    Code // the contract code in LFVM format
 
 	// Execution state
-
-	// Deprecated: status is to be returned from the interpreter step, not stored in the context.
-	status status
 	pc     int32
 	gas    tosca.Gas
 	refund tosca.Gas
@@ -82,7 +78,7 @@ func (c *context) isAtLeast(revision tosca.Revision) bool {
 // --- Interpreter ---
 
 type runner interface {
-	run(*context)
+	run(*context) (status, error)
 }
 
 type interpreterConfig struct {
@@ -114,27 +110,30 @@ func run(
 		code:         code,
 		withShaCache: config.withShaCache,
 	}
-
 	defer ReturnStack(ctxt.stack)
 
-	// Run interpreter.
 	if config.runner == nil {
 		config.runner = vanillaRunner{}
 	}
-	config.runner.run(&ctxt)
+	status, err := config.runner.run(&ctxt)
+	if err != nil {
+		return tosca.Result{
+			Success: false,
+		}, nil
+	}
 
-	return generateResult(&ctxt)
+	return generateResult(status, &ctxt)
 }
 
-func generateResult(ctxt *context) (tosca.Result, error) {
+func generateResult(status status, ctxt *context) (tosca.Result, error) {
 
-	res, err := getOutput(ctxt)
+	res, err := getOutput(status, ctxt)
 	if err != nil {
 		return tosca.Result{Success: false}, nil
 	}
 
 	// Handle return status
-	switch ctxt.status {
+	switch status {
 	case statusStopped, statusSelfDestructed:
 		return tosca.Result{
 			Success:   true,
@@ -154,18 +153,14 @@ func generateResult(ctxt *context) (tosca.Result, error) {
 			Output:  res,
 			GasLeft: ctxt.gas,
 		}, nil
-	case statusError:
-		return tosca.Result{
-			Success: false,
-		}, nil
 	default:
-		return tosca.Result{}, fmt.Errorf("unexpected error in interpreter, unknown status: %v", ctxt.status)
+		return tosca.Result{}, fmt.Errorf("unexpected error in interpreter, unknown status: %v", status)
 	}
 }
 
-func getOutput(ctxt *context) ([]byte, error) {
+func getOutput(status status, ctxt *context) ([]byte, error) {
 	var res []byte
-	if ctxt.status == statusReturned || ctxt.status == statusReverted {
+	if status == statusReturned || status == statusReverted {
 		size, overflow := ctxt.resultSize.Uint64WithOverflow()
 		if overflow {
 			return nil, errOverflow
@@ -200,21 +195,18 @@ func getOutput(ctxt *context) ([]byte, error) {
 // any additional features.
 type vanillaRunner struct{}
 
-func (r vanillaRunner) run(c *context) {
-	status, err := steps(c, false)
-	if err != nil {
-		c.status = statusError
-	} else {
-		c.status = status
-	}
+func (r vanillaRunner) run(c *context) (status, error) {
+	return steps(c, false)
 }
 
 // loggingRunner is a runner that logs the execution of the contract code to
 // stdout. It is used for debugging purposes.
 type loggingRunner struct{}
 
-func (r loggingRunner) run(c *context) {
-	for c.status == statusRunning {
+func (r loggingRunner) run(c *context) (status, error) {
+	status := statusRunning
+	var err error
+	for status == statusRunning {
 		// log format: <op>, <gas>, <top-of-stack>\n
 		if int(c.pc) < len(c.code) {
 			top := "-empty-"
@@ -223,25 +215,21 @@ func (r loggingRunner) run(c *context) {
 			}
 			fmt.Printf("%v, %d, %v\n", c.code[c.pc].opcode, c.gas, top)
 		}
-		step(c)
+		status, err = step(c)
+		if err != nil {
+			return status, err
+		}
 	}
+	return status, nil
 }
 
 // --- Execution ---
 
-func step(c *context) {
-	status, err := steps(c, true)
-	// FIXME: c.status is marked for deletion, this is a temporary workaround
-	// to facilitate review of the transition.
-	if err != nil {
-		c.status = statusError
-	} else {
-		c.status = status
-	}
+func step(c *context) (status, error) {
+	return steps(c, true)
 }
 
 func steps(c *context, oneStepOnly bool) (status, error) {
-	// Idea: handle static gas price in static dispatch below (saves an array lookup)
 	staticGasPrices := getStaticGasPrices(c.params.Revision)
 
 	status := statusRunning
@@ -259,7 +247,7 @@ func steps(c *context, oneStepOnly bool) (status, error) {
 
 		// Consume static gas price for instruction before execution
 		if err := c.useGas(staticGasPrices.get(op)); err != nil {
-			return statusError, err
+			return status, errNotEnoughStaticGas
 		}
 
 		var err error
@@ -608,11 +596,12 @@ func steps(c *context, oneStepOnly bool) (status, error) {
 		default:
 			err = errInvalidOpCode
 		}
-		c.pc++
 
 		if err != nil {
-			return statusError, err
+			return status, err
 		}
+
+		c.pc++
 
 		if oneStepOnly {
 			return status, nil


### PR DESCRIPTION
This refactor facilitates #684 

The change removes `context.status` and `statusError` in favor of a `(status, error)` return type for the complete execution of the lfvm.

- A extra change in the interpreter was needed to correct program counter position after error. This was not a problem in main so far because `statusError` was returned. Since it does not exist anymore, the program counter was read at the wrong position. 
- Benchmarks have been reordered, to follow order of relevance. 

The most delicate change is in [go/interpreter/lfvm/ct.go](https://github.com/Fantom-foundation/Tosca/pull/795/files#diff-8732597f25fb78bbf7cc4df47e41abef29441a1e8690763ea444bc4c37c15f45), where the (status, error) pair needs to be converted into (*st.State, error). This has a semantic difference because Error inside the VM is a valid state (outOfGas, staticModeViolation...) but error in the ct adapter is a conversion error, where unsupported states are translated to ct code. For this reason both `state` and `error` are collected and errors are translated into a `failed state`



TODO:

- [x] ct
- [x] benchmarks
