### PR TITLE
evmrs: Test Interpreter::run

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
 name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +117,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,8 +160,15 @@ version = "0.1.0"
 dependencies = [
  "bnum",
  "evmc-vm",
+ "mockall",
  "sha3",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "generic-array"
@@ -247,6 +266,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "mockall"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +306,32 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "predicates"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -364,6 +435,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "typenum"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,6 +8,9 @@ bnum = "0.11.0"
 evmc-vm = { git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
 sha3 = "0.10.8"
 
+[dev-dependencies]
+mockall = "0.13.0"
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/rust/src/types/execution_context.rs
+++ b/rust/src/types/execution_context.rs
@@ -1,0 +1,121 @@
+use evmc_vm::{
+    AccessStatus, Address, ExecutionContext, ExecutionMessage, ExecutionResult, ExecutionTxContext,
+    StorageStatus, Uint256,
+};
+
+#[cfg_attr(test, mockall::automock)]
+pub trait ExecutionContextTrait {
+    /// Retrieve the transaction context.
+    fn get_tx_context(&self) -> &ExecutionTxContext;
+
+    /// Check if an account exists.
+    fn account_exists(&self, address: &Address) -> bool;
+
+    /// Read from a storage key.
+    fn get_storage(&self, address: &Address, key: &Uint256) -> Uint256;
+
+    // Set value of a storage key.
+    fn set_storage(&mut self, address: &Address, key: &Uint256, value: &Uint256) -> StorageStatus;
+
+    /// Get balance of an account.
+    fn get_balance(&self, address: &Address) -> Uint256;
+
+    /// Get code size of an account.
+    fn get_code_size(&self, address: &Address) -> usize;
+
+    /// Get code hash of an account.
+    fn get_code_hash(&self, address: &Address) -> Uint256;
+
+    /// Copy code of an account.
+    fn copy_code(&self, address: &Address, code_offset: usize, buffer: &mut [u8]) -> usize;
+
+    /// Self-destruct the current account.
+    fn selfdestruct(&mut self, address: &Address, beneficiary: &Address) -> bool;
+
+    /// Call to another account.
+    fn call(&mut self, message: &ExecutionMessage) -> ExecutionResult;
+
+    /// Get block hash of an account.
+    fn get_block_hash(&self, num: i64) -> Uint256;
+
+    /// Emit a log.
+    fn emit_log(&mut self, address: &Address, data: &[u8], topics: &[Uint256]);
+
+    /// Access an account.
+    fn access_account(&mut self, address: &Address) -> AccessStatus;
+
+    /// Access a storage key.
+    fn access_storage(&mut self, address: &Address, key: &Uint256) -> AccessStatus;
+
+    /// Read from a transient storage key.
+    fn get_transient_storage(&self, address: &Address, key: &Uint256) -> Uint256;
+
+    /// Set value of a transient storage key.
+    fn set_transient_storage(&mut self, address: &Address, key: &Uint256, value: &Uint256);
+}
+
+impl<'a> ExecutionContextTrait for ExecutionContext<'a> {
+    fn get_tx_context(&self) -> &ExecutionTxContext {
+        self.get_tx_context()
+    }
+
+    fn account_exists(&self, address: &Address) -> bool {
+        self.account_exists(address)
+    }
+
+    fn get_storage(&self, address: &Address, key: &Uint256) -> Uint256 {
+        self.get_storage(address, key)
+    }
+
+    fn set_storage(&mut self, address: &Address, key: &Uint256, value: &Uint256) -> StorageStatus {
+        self.set_storage(address, key, value)
+    }
+
+    fn get_balance(&self, address: &Address) -> Uint256 {
+        self.get_balance(address)
+    }
+
+    fn get_code_size(&self, address: &Address) -> usize {
+        self.get_code_size(address)
+    }
+
+    fn get_code_hash(&self, address: &Address) -> Uint256 {
+        self.get_code_hash(address)
+    }
+
+    fn copy_code(&self, address: &Address, code_offset: usize, buffer: &mut [u8]) -> usize {
+        self.copy_code(address, code_offset, buffer)
+    }
+
+    fn selfdestruct(&mut self, address: &Address, beneficiary: &Address) -> bool {
+        self.selfdestruct(address, beneficiary)
+    }
+
+    fn call(&mut self, message: &ExecutionMessage) -> ExecutionResult {
+        self.call(message)
+    }
+
+    fn get_block_hash(&self, num: i64) -> Uint256 {
+        self.get_block_hash(num)
+    }
+
+    fn emit_log(&mut self, address: &Address, data: &[u8], topics: &[Uint256]) {
+        self.emit_log(address, data, topics);
+    }
+
+    fn access_account(&mut self, address: &Address) -> AccessStatus {
+        self.access_account(address)
+    }
+
+    fn access_storage(&mut self, address: &Address, key: &Uint256) -> AccessStatus {
+        self.access_storage(address, key)
+    }
+
+    fn get_transient_storage(&self, address: &Address, key: &Uint256) -> Uint256 {
+        self.get_transient_storage(address, key)
+    }
+
+    fn set_transient_storage(&mut self, address: &Address, key: &Uint256, value: &Uint256) {
+        self.set_transient_storage(address, key, value);
+    }
+}

--- a/rust/src/types/mock_execution_message.rs
+++ b/rust/src/types/mock_execution_message.rs
@@ -1,0 +1,57 @@
+use evmc_vm::{Address, ExecutionMessage, MessageKind, Uint256};
+
+use crate::types::u256;
+
+pub const DEFAULT_INIT_GAS: u64 = 1_000_000;
+
+/// The same as ExecutionMessage but with `pub` fields for easier testing.
+#[derive(Debug)]
+pub struct MockExecutionMessage<'a> {
+    pub kind: MessageKind,
+    pub flags: u32,
+    pub depth: i32,
+    pub gas: i64,
+    pub recipient: Address,
+    pub sender: Address,
+    pub input: Option<&'a [u8]>,
+    pub value: Uint256,
+    pub create2_salt: Uint256,
+    pub code_address: Address,
+    pub code: Option<&'a [u8]>,
+}
+
+impl<'a> Default for MockExecutionMessage<'a> {
+    fn default() -> Self {
+        MockExecutionMessage {
+            kind: MessageKind::EVMC_CALL,
+            flags: 0,
+            depth: 1,
+            gas: DEFAULT_INIT_GAS as i64,
+            recipient: u256::ZERO.into(),
+            sender: u256::ZERO.into(),
+            input: None,
+            value: u256::ZERO.into(),
+            create2_salt: u256::ZERO.into(),
+            code_address: u256::ZERO.into(),
+            code: None,
+        }
+    }
+}
+
+impl<'a> From<MockExecutionMessage<'a>> for ExecutionMessage {
+    fn from(value: MockExecutionMessage) -> Self {
+        Self::new(
+            value.kind,
+            value.flags,
+            value.depth,
+            value.gas,
+            value.recipient,
+            value.sender,
+            value.input,
+            value.value,
+            value.create2_salt,
+            value.code_address,
+            value.code,
+        )
+    }
+}

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -1,13 +1,19 @@
 mod amount;
 mod code_reader;
+mod execution_context;
 mod memory;
+#[cfg(test)]
+mod mock_execution_message;
 mod opcode;
 mod stack;
 mod tx_context;
 
 pub use amount::u256;
 pub use code_reader::{CodeReader, GetOpcodeError};
+pub use execution_context::*;
 pub use memory::Memory;
+#[cfg(test)]
+pub use mock_execution_message::{MockExecutionMessage, DEFAULT_INIT_GAS};
 pub use opcode::*;
 pub use stack::Stack;
 pub use tx_context::ExecutionTxContext;

--- a/rust/src/utils/gas.rs
+++ b/rust/src/utils/gas.rs
@@ -1,6 +1,10 @@
 use evmc_vm::{AccessStatus, Address, Revision, StatusCode};
 
-use crate::{interpreter::Interpreter, types::u256, utils::word_size};
+use crate::{
+    interpreter::Interpreter,
+    types::{u256, ExecutionContextTrait},
+    utils::word_size,
+};
 
 #[inline(always)]
 pub fn consume_gas(gas_left: &mut u64, gas: u64) -> Result<(), StatusCode> {
@@ -20,10 +24,10 @@ pub fn consume_positive_value_cost(value: &u256, gas_left: &mut u64) -> Result<(
 }
 
 #[inline(always)]
-pub fn consume_value_to_empty_account_cost(
+pub fn consume_value_to_empty_account_cost<E: ExecutionContextTrait>(
     value: &u256,
     addr: &Address,
-    state: &mut Interpreter,
+    state: &mut Interpreter<E>,
 ) -> Result<(), StatusCode> {
     if *value != u256::ZERO && !state.context.account_exists(addr) {
         consume_gas(&mut state.gas_left, 25000)?;
@@ -32,9 +36,9 @@ pub fn consume_value_to_empty_account_cost(
 }
 
 #[inline(always)]
-pub fn consume_address_access_cost(
+pub fn consume_address_access_cost<E: ExecutionContextTrait>(
     addr: &Address,
-    state: &mut Interpreter,
+    state: &mut Interpreter<E>,
 ) -> Result<(), StatusCode> {
     if state.revision < Revision::EVMC_BERLIN {
         return Ok(());

--- a/rust/src/utils/helpers.rs
+++ b/rust/src/utils/helpers.rs
@@ -2,7 +2,11 @@ use std::cmp::min;
 
 use evmc_vm::{MessageFlags, Revision, StatusCode};
 
-use crate::{interpreter::Interpreter, types::u256, utils::gas::consume_copy_cost};
+use crate::{
+    interpreter::Interpreter,
+    types::{u256, ExecutionContextTrait},
+    utils::gas::consume_copy_cost,
+};
 
 pub trait SliceExt {
     fn get_within_bounds(&self, offset: u256, len: u64) -> &[u8];
@@ -66,7 +70,10 @@ pub fn check_min_revision(min_revision: Revision, revision: Revision) -> Result<
 }
 
 #[inline(always)]
-pub fn check_not_read_only(state: &Interpreter) -> Result<(), StatusCode> {
+pub fn check_not_read_only<E>(state: &Interpreter<E>) -> Result<(), StatusCode>
+where
+    E: ExecutionContextTrait,
+{
     if state.revision >= Revision::EVMC_BYZANTIUM
         && state.message.flags() == MessageFlags::EVMC_STATIC as u32
     {


### PR DESCRIPTION
- add trait `ExecutionContextTrait` in order to mock `ExecutionContext`
- make all functions which took `ExecutionContext` as an argument generic over `ExecutionContextTrait`
- add `MockExecutionMessage`
- (partially) test `Interpreter::run`