### PR TITLE
LFVM: Test interpreter dispatcher

### DIFF
--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -141,7 +141,7 @@ func opPush32(c *context) {
 	z := c.stack.pushUndefined()
 
 	data := c.code[c.pc : c.pc+16]
-	_ = data[15] // causes bound check to be performed only once (may become unneded in the future)
+	_ = data[15] // causes bound check to be performed only once (may become unneeded in the future)
 	z[3] = (uint64(data[0].arg) << 48) | (uint64(data[1].arg) << 32) | (uint64(data[2].arg) << 16) | uint64(data[3].arg)
 	z[2] = (uint64(data[4].arg) << 48) | (uint64(data[5].arg) << 32) | (uint64(data[6].arg) << 16) | uint64(data[7].arg)
 	z[1] = (uint64(data[8].arg) << 48) | (uint64(data[9].arg) << 32) | (uint64(data[10].arg) << 16) | uint64(data[11].arg)

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -679,32 +679,34 @@ func isJump(op OpCode) bool {
 	return idx != -1
 }
 
-var _introducedInRevision = newOpCodePropertyMap(func(op OpCode) tosca.Revision {
-	switch op {
-	case BASEFEE:
-		return tosca.R10_London
-	case PUSH0:
-		return tosca.R12_Shanghai
-	case BLOBHASH:
-		return tosca.R13_Cancun
-	case BLOBBASEFEE:
-		return tosca.R13_Cancun
-	case TLOAD:
-		return tosca.R13_Cancun
-	case TSTORE:
-		return tosca.R13_Cancun
-	case MCOPY:
-		return tosca.R13_Cancun
-	}
-	return tosca.R07_Istanbul
-})
-
+// forEachRevision runs a test for each revision starting from the revision
+// where the operation was introduced.
 func forEachRevision(
 	t *testing.T, op OpCode,
 	f func(t *testing.T, revision tosca.Revision)) {
 
+	introducedIn := newOpCodePropertyMap(func(op OpCode) tosca.Revision {
+		switch op {
+		case BASEFEE:
+			return tosca.R10_London
+		case PUSH0:
+			return tosca.R12_Shanghai
+		case BLOBHASH:
+			return tosca.R13_Cancun
+		case BLOBBASEFEE:
+			return tosca.R13_Cancun
+		case TLOAD:
+			return tosca.R13_Cancun
+		case TSTORE:
+			return tosca.R13_Cancun
+		case MCOPY:
+			return tosca.R13_Cancun
+		}
+		return tosca.R07_Istanbul
+	})
+
 	for revision := tosca.R07_Istanbul; revision <= newestSupportedRevision; revision++ {
-		if revision < _introducedInRevision.get(op) {
+		if revision < introducedIn.get(op) {
 			continue
 		}
 		t.Run(revision.String(), func(t *testing.T) {

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -662,13 +662,13 @@ func fillStackFor(op OpCode, stack *stack, code Code) error {
 	return nil
 }
 
-var _isInvalidOpCodeRegex = regexp.MustCompile(`^op\(0x[0-9A-Fa-f]+\)$`)
+var _isUndefinedOpCodeRegex = regexp.MustCompile(`^op\(0x[0-9A-Fa-f]+\)$`)
 
 func isExecutable(op OpCode) bool {
 	if slices.Contains([]OpCode{INVALID, NOOP, DATA}, op) {
 		return false
 	}
-	return !_isInvalidOpCodeRegex.MatchString(op.String()) && op != INVALID
+	return !_isUndefinedOpCodeRegex.MatchString(op.String())
 }
 
 func isJump(op OpCode) bool {

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -183,11 +183,10 @@ func TestInterpreter_step_DetectsUpperStackLimitViolation(t *testing.T) {
 	}
 }
 
-func TestInterpreter_CanDispatchInstructions(t *testing.T) {
+func TestInterpreter_CanDispatchExecutableInstructions(t *testing.T) {
 
 	for _, op := range allOpCodesWhere(isExecutable) {
 		t.Run(op.String(), func(t *testing.T) {
-
 			forEachRevision(t, op, func(t *testing.T, revision tosca.Revision) {
 
 				ctrl := gomock.NewController(t)


### PR DESCRIPTION
part of #684

This PR adds a unit test to check that every opcode can get dispatched by the interpreter. 
Every opcode gets a context where they can sucessfuly execute. The interpreter will dispatch the opCode to the appropiate handling function. 

Note: 
This change removes an old test, because of the change of paradigm, we are testing properties and not the bulk on instructions here. The one single problem is that the test for STORE and SLOAD will be deleted and such instructions are not yet tested. A plan to test WARM/COLD instructions is in the making here #751 
