### PR TITLE
LFVM: Return/Revert

### DIFF
--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -96,11 +96,6 @@ func (a *ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 		return nil, err
 	}
 
-	result, err := getOutput(status, ctxt)
-	if err != nil {
-		executionErr = err
-	}
-
 	if executionErr == nil {
 		state.Pc = pcMap.lfvmToEvm[ctxt.pc]
 	}
@@ -114,7 +109,9 @@ func (a *ctAdapter) StepN(state *st.State, numSteps int) (*st.State, error) {
 	state.Stack = convertLfvmStackToCtStack(ctxt.stack, state.Stack)
 	state.Memory = convertLfvmMemoryToCtMemory(ctxt.memory)
 	state.LastCallReturnData = common.NewBytes(ctxt.returnData)
-	state.ReturnData = common.NewBytes(result)
+	if status == statusReturned || status == statusReverted {
+		state.ReturnData = common.NewBytes(ctxt.returnData)
+	}
 
 	return state, nil
 }

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -22,15 +22,7 @@ func opStop() status {
 	return statusStopped
 }
 
-func opRevert(c *context) (status, error) {
-	return genericReturnRevert(c, statusReverted)
-}
-
-func opReturn(c *context) (status, error) {
-	return genericReturnRevert(c, statusReturned)
-}
-
-func genericReturnRevert(c *context, status status) (status, error) {
+func opReturningOp(c *context, status status) (status, error) {
 	offset := *c.stack.pop()
 	size := *c.stack.pop()
 	if err := checkSizeOffsetUint64Overflow(&offset, &size); err != nil {

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -22,15 +22,15 @@ func opStop() status {
 	return statusStopped
 }
 
-func opReturningOp(c *context, status status) (status, error) {
+func opEndWithResult(c *context) error {
 	offset := *c.stack.pop()
 	size := *c.stack.pop()
 	if err := checkSizeOffsetUint64Overflow(&offset, &size); err != nil {
-		return status, err
+		return err
 	}
 	var err error
 	c.returnData, err = c.memory.getSlice(offset.Uint64(), size.Uint64(), c)
-	return status, err
+	return err
 }
 
 func opPc(c *context) {

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1147,32 +1147,28 @@ func TestGenericCreate_MaxInitCodeSizeIsNotCheckedBeforeShanghai(t *testing.T) {
 	}
 }
 
-func TestRevertReturn_ReturnsExpectedState(t *testing.T) {
+func TestOpEndWithResult_ReturnsExpectedState(t *testing.T) {
 	c := getEmptyContext()
 	c.stack.push(uint256.NewInt(1))
 	c.stack.push(uint256.NewInt(1))
 	c.memory.store = []byte{0x1, 0xff, 0x2}
-	wantStatus := statusReverted
 
-	status, err := opReturningOp(&c, wantStatus)
+	err := opEndWithResult(&c)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if status != wantStatus {
-		t.Errorf("unexpected status, wanted %v, got %v", wantStatus, status)
 	}
 	if !bytes.Equal(c.returnData, []byte{0xff}) {
 		t.Errorf("unexpected return data, wanted %v, got %v", []byte{0x1}, c.returnData)
 	}
 }
 
-func TestRevertReturn_ReportOverflow(t *testing.T) {
+func TestOpEndWithResult_ReportOverflow(t *testing.T) {
 	overflow64 := new(uint256.Int).Add(uint256.NewInt(math.MaxUint64), uint256.NewInt(math.MaxUint64))
 	c := getEmptyContext()
 	c.stack.push(overflow64)
 	c.stack.push(overflow64)
 	c.memory.store = []byte{0x1, 0xff, 0x2}
-	_, err := opReturningOp(&c, statusReturned)
+	err := opEndWithResult(&c)
 	if err != errOverflow {
 		t.Fatalf("should have produced overflow error, instead got: %v", err)
 	}

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1148,45 +1148,32 @@ func TestGenericCreate_MaxInitCodeSizeIsNotCheckedBeforeShanghai(t *testing.T) {
 }
 
 func TestRevertReturn_ReturnsExpectedState(t *testing.T) {
+	c := getEmptyContext()
+	c.stack.push(uint256.NewInt(1))
+	c.stack.push(uint256.NewInt(1))
+	c.memory.store = []byte{0x1, 0xff, 0x2}
+	wantStatus := statusReverted
 
-	test := []struct {
-		operation func(c *context) (status, error)
-		status    status
-	}{
-		{operation: opRevert, status: statusReverted},
-		{operation: opReturn, status: statusReturned},
+	status, err := opReturningOp(&c, wantStatus)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-
-	for _, test := range test {
-		c := getEmptyContext()
-		c.stack.push(uint256.NewInt(1))
-		c.stack.push(uint256.NewInt(1))
-		c.memory.store = []byte{0x1, 0xff, 0x2}
-
-		status, err := test.operation(&c)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if status != test.status {
-			t.Errorf("unexpected status, wanted %v, got %v", test.status, status)
-		}
-		if !bytes.Equal(c.returnData, []byte{0xff}) {
-			t.Errorf("unexpected return data, wanted %v, got %v", []byte{0x1}, c.returnData)
-		}
+	if status != wantStatus {
+		t.Errorf("unexpected status, wanted %v, got %v", wantStatus, status)
+	}
+	if !bytes.Equal(c.returnData, []byte{0xff}) {
+		t.Errorf("unexpected return data, wanted %v, got %v", []byte{0x1}, c.returnData)
 	}
 }
 
 func TestRevertReturn_ReportOverflow(t *testing.T) {
-	funcs := []func(*context) (status, error){opRevert, opReturn}
 	overflow64 := new(uint256.Int).Add(uint256.NewInt(math.MaxUint64), uint256.NewInt(math.MaxUint64))
-	for _, fun := range funcs {
-		c := getEmptyContext()
-		c.stack.push(overflow64)
-		c.stack.push(overflow64)
-		c.memory.store = []byte{0x1, 0xff, 0x2}
-		_, err := fun(&c)
-		if err != errOverflow {
-			t.Fatalf("should have produced overflow error, instead got: %v", err)
-		}
+	c := getEmptyContext()
+	c.stack.push(overflow64)
+	c.stack.push(overflow64)
+	c.memory.store = []byte{0x1, 0xff, 0x2}
+	_, err := opReturningOp(&c, statusReturned)
+	if err != errOverflow {
+		t.Fatalf("should have produced overflow error, instead got: %v", err)
 	}
 }

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -425,9 +425,11 @@ func steps(c *context, oneStepOnly bool) (status, error) {
 		case DUP16:
 			opDup(c, 16)
 		case RETURN:
-			status, err = opReturningOp(c, statusReturned)
+			err = opEndWithResult(c)
+			status = statusReturned
 		case REVERT:
-			status, err = opReturningOp(c, statusReverted)
+			status = statusReverted
+			err = opEndWithResult(c)
 		case JUMP_TO:
 			opJumpTo(c)
 		case SLOAD:

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -425,9 +425,9 @@ func steps(c *context, oneStepOnly bool) (status, error) {
 		case DUP16:
 			opDup(c, 16)
 		case RETURN:
-			status, err = opReturn(c)
+			status, err = opReturningOp(c, statusReturned)
 		case REVERT:
-			status, err = opRevert(c)
+			status, err = opReturningOp(c, statusReverted)
 		case JUMP_TO:
 			opJumpTo(c)
 		case SLOAD:

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -11,12 +11,11 @@
 package lfvm
 
 import (
+	"bytes"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"os"
 	"reflect"
 	"regexp"
@@ -411,24 +410,15 @@ func TestRunGenerateResult(t *testing.T) {
 	baseGas := tosca.Gas(2)
 	baseRefund := tosca.Gas(3)
 
-	getCtxt := func() context {
-		ctxt := getEmptyContext()
-		ctxt.gas = baseGas
-		ctxt.refund = baseRefund
-		ctxt.memory = NewMemory()
-		ctxt.memory.store = baseOutput
-		ctxt.resultSize = uint256.Int{uint64(len(baseOutput))}
-		return ctxt
-	}
-
 	tests := map[string]struct {
-		setup          func(ctx *context)
 		status         status
+		returnData     []byte
 		expectedErr    error
 		expectedResult tosca.Result
 	}{
 		"returned": {
-			status: statusReturned,
+			status:     statusReturned,
+			returnData: baseOutput,
 			expectedResult: tosca.Result{
 				Success:   true,
 				Output:    baseOutput,
@@ -437,7 +427,8 @@ func TestRunGenerateResult(t *testing.T) {
 			},
 		},
 		"reverted": {
-			status: statusReverted,
+			status:     statusReverted,
+			returnData: baseOutput,
 			expectedResult: tosca.Result{
 				Success:   false,
 				Output:    baseOutput,
@@ -449,7 +440,6 @@ func TestRunGenerateResult(t *testing.T) {
 			status: statusStopped,
 			expectedResult: tosca.Result{
 				Success:   true,
-				Output:    nil,
 				GasLeft:   baseGas,
 				GasRefund: baseRefund,
 			},
@@ -468,23 +458,13 @@ func TestRunGenerateResult(t *testing.T) {
 			expectedErr:    fmt.Errorf("unexpected error in interpreter, unknown status: %v", statusSelfDestructed+1),
 			expectedResult: tosca.Result{},
 		},
-		"getOutput fail": {
-			setup: func(ctx *context) {
-				ctx.resultSize = uint256.Int{1, 1}
-			},
-			expectedResult: tosca.Result{
-				Success: false,
-			},
-		},
 	}
 
 	for name, test := range tests {
 		t.Run(fmt.Sprintf("%v", name), func(t *testing.T) {
 
-			ctxt := getCtxt()
-			if test.setup != nil {
-				test.setup(&ctxt)
-			}
+			ctxt := context{}
+			ctxt.returnData = bytes.Clone(baseOutput)
 
 			res, err := generateResult(test.status, &ctxt)
 
@@ -493,45 +473,6 @@ func TestRunGenerateResult(t *testing.T) {
 			}
 			if !reflect.DeepEqual(res, test.expectedResult) {
 				t.Errorf("unexpected result: want %v, got %v", test.expectedResult, res)
-			}
-		})
-	}
-}
-
-func TestGetOutputReturnsExpectedErrors(t *testing.T) {
-
-	tests := map[string]struct {
-		setup       func(*context)
-		expectedErr error
-	}{
-		"size overflow": {
-			setup:       func(ctx *context) { ctx.resultSize = uint256.Int{1, 1} },
-			expectedErr: errOverflow,
-		},
-		"offset overflow": {
-			setup: func(ctx *context) {
-				ctx.resultSize = uint256.Int{1}
-				ctx.resultOffset = uint256.Int{1, 1}
-			},
-			expectedErr: errOverflow,
-		},
-		"memory overflow": {
-			setup: func(ctx *context) {
-				ctx.resultSize = uint256.Int{math.MaxUint64 - 1}
-				ctx.resultOffset = uint256.Int{2}
-			},
-			expectedErr: errOverflow,
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(fmt.Sprintf("%v", name), func(t *testing.T) {
-			ctxt := getEmptyContext()
-			test.setup(&ctxt)
-
-			_, err := getOutput(statusReturned, &ctxt)
-			if !errors.Is(err, test.expectedErr) {
-				t.Errorf("unexpected error: want error, got nil")
 			}
 		})
 	}
@@ -753,17 +694,7 @@ func benchmarkFib(b *testing.B, arg int, with_super_instructions bool) {
 			b.Fatalf("execution failed: status is %v", status)
 		}
 
-		size := ctxt.resultSize
-		if size.Uint64() != 32 {
-			b.Fatalf("unexpected length of end; wanted 32, got %d", size.Uint64())
-		}
-		res := make([]byte, size.Uint64())
-		offset := ctxt.resultOffset
-
-		data, err := ctxt.memory.getSlice(offset.Uint64(), size.Uint64(), &ctxt)
-		if err != nil {
-			b.Fatalf("unexpected error: %v", err)
-		}
+		res := make([]byte, len(ctxt.returnData))
 		copy(res, data)
 
 		got := (int(res[28]) << 24) | (int(res[29]) << 16) | (int(res[30]) << 8) | (int(res[31]) << 0)

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -404,7 +404,7 @@ func TestInterpreter_Vanilla_RunsWithoutOutput(t *testing.T) {
 	}
 }
 
-func TestRunGenerateResult(t *testing.T) {
+func TestRun_GenerateResult(t *testing.T) {
 
 	baseOutput := []byte{0x1, 0x2, 0x3}
 	baseGas := tosca.Gas(2)
@@ -412,13 +412,11 @@ func TestRunGenerateResult(t *testing.T) {
 
 	tests := map[string]struct {
 		status         status
-		returnData     []byte
 		expectedErr    error
 		expectedResult tosca.Result
 	}{
 		"returned": {
-			status:     statusReturned,
-			returnData: baseOutput,
+			status: statusReturned,
 			expectedResult: tosca.Result{
 				Success:   true,
 				Output:    baseOutput,
@@ -427,8 +425,7 @@ func TestRunGenerateResult(t *testing.T) {
 			},
 		},
 		"reverted": {
-			status:     statusReverted,
-			returnData: baseOutput,
+			status: statusReverted,
 			expectedResult: tosca.Result{
 				Success:   false,
 				Output:    baseOutput,
@@ -440,6 +437,7 @@ func TestRunGenerateResult(t *testing.T) {
 			status: statusStopped,
 			expectedResult: tosca.Result{
 				Success:   true,
+				Output:    nil,
 				GasLeft:   baseGas,
 				GasRefund: baseRefund,
 			},
@@ -464,6 +462,8 @@ func TestRunGenerateResult(t *testing.T) {
 		t.Run(fmt.Sprintf("%v", name), func(t *testing.T) {
 
 			ctxt := context{}
+			ctxt.refund = baseRefund
+			ctxt.gas = baseGas
 			ctxt.returnData = bytes.Clone(baseOutput)
 
 			res, err := generateResult(test.status, &ctxt)
@@ -694,7 +694,7 @@ func benchmarkFib(b *testing.B, arg int, with_super_instructions bool) {
 			b.Fatalf("execution failed: status is %v", status)
 		}
 
-		res := make([]byte, len(ctxt.returnData))
+		res := ctxt.returnData
 		copy(res, data)
 
 		got := (int(res[28]) << 24) | (int(res[29]) << 16) | (int(res[30]) << 8) | (int(res[31]) << 0)


### PR DESCRIPTION
In evm.codes it states that both `RETURN` and `REVERT` much charge for the memory expansion cost. However in our previous implementation this was done as part of getting the data from the context to build the `tosca.Result` at the end of a `run`. 
This PR:
- moves that memory expansion into the corresponding operation implementations, adding a function for the common parts and testing it. 
- CT conversion used to rely on a previous function called `getOutput` to also get the `ReturnData`, this now has it's own implementation. 