### PR TITLE
LFVM: successfully terminating code execution

### DIFF
--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -267,7 +267,7 @@ func TestInterpreter_ExecutionTerminates(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 			if status == statusRunning {
-				t.Errorf("exfailed to terminate execution, status is %v", status)
+				t.Errorf("failed to terminate execution, status is %v", status)
 			}
 		})
 	}

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -234,7 +234,8 @@ func TestInterpreter_CanDispatchExecutableInstructions(t *testing.T) {
 	}
 }
 
-func TestInterpreter_ExecutionTerminationCode(t *testing.T) {
+func TestInterpreter_ExecutionTerminates(t *testing.T) {
+
 	tests := map[string]struct {
 		code []Instruction
 	}{
@@ -266,7 +267,7 @@ func TestInterpreter_ExecutionTerminationCode(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 			if status == statusRunning {
-				t.Errorf("execution failed: status is %v", status)
+				t.Errorf("exfailed to terminate execution, status is %v", status)
 			}
 		})
 	}

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -234,29 +234,41 @@ func TestInterpreter_CanDispatchExecutableInstructions(t *testing.T) {
 	}
 }
 
-func TestInterpreter_Run_ReturnsEmptyResultOnEmptyCode(t *testing.T) {
-	// Get tosca.Parameters
-	params := tosca.Parameters{
-		Input:  []byte{},
-		Static: true,
-		Gas:    10,
-	}
-	code := make([]Instruction, 0)
-
-	// Run testing code
-	result, err := run(interpreterConfig{}, params, code)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+func TestInterpreter_ExecutionTerminationCode(t *testing.T) {
+	tests := map[string]struct {
+		code []Instruction
+	}{
+		"empty code":          {code: []Instruction{}},
+		"single stop":         {code: []Instruction{{STOP, 0}}},
+		"pc bigger than code": {code: []Instruction{{PUSH1, 0}}},
+		"revert":              {code: []Instruction{{REVERT, 0}}},
+		"return":              {code: []Instruction{{RETURN, 0}}},
+		"selfdestruct":        {code: []Instruction{{SELFDESTRUCT, 0}}},
 	}
 
-	if result.Output != nil {
-		t.Errorf("unexpected output: want nil, got %v", result.Output)
-	}
-	if want, got := params.Gas, result.GasLeft; want != got {
-		t.Errorf("unexpected gas left: want %v, got %v", want, got)
-	}
-	if !result.Success {
-		t.Errorf("unexpected success: want true, got false")
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			c := getEmptyContext()
+			c.code = test.code
+			c.stack.push(uint256.NewInt(1))
+			c.stack.push(uint256.NewInt(2))
+			c.stack.push(uint256.NewInt(3))
+			// runcontext is needed for selfdestruct
+			mockContext := tosca.NewMockRunContext(gomock.NewController(t))
+			mockContext.EXPECT().AccountExists(gomock.Any()).Return(true).AnyTimes()
+			mockContext.EXPECT().GetBalance(gomock.Any()).Return(tosca.Value{1}).AnyTimes()
+			mockContext.EXPECT().SelfDestruct(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+			c.context = mockContext
+
+			status, err := steps(&c, false)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if status == statusRunning {
+				t.Errorf("execution failed: status is %v", status)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Previously the test `TestRunReturnsEmptyResultOnEmptyCode` only checked that an empty code did not produce output, consumed gas and it was a successful execution. This test is expanded to check that all terminating operations and successful terminating conditions are handled properly, 

This PR contributes to #684