### PR TITLE
LFVM: test EIP2929 warm/cold acceses charging

### DIFF
--- a/go/interpreter/lfvm/gas.go
+++ b/go/interpreter/lfvm/gas.go
@@ -44,13 +44,13 @@ func getBerlinGasPriceInternal(op OpCode) tosca.Gas {
 	case SLOAD:
 		gp = 0
 	case EXTCODECOPY:
-		gp = 100
+		gp = 0
 	case EXTCODESIZE:
-		gp = 100
+		gp = 0
 	case EXTCODEHASH:
-		gp = 100
+		gp = 0
 	case BALANCE:
-		gp = 100
+		gp = 0
 	case CALL:
 		gp = 0
 	case CALLCODE:
@@ -310,14 +310,4 @@ func getRefundForSstore(
 	default:
 		return 0
 	}
-}
-
-func gasEip2929AccountCheck(c *context, address tosca.Address) error {
-	if c.isAtLeast(tosca.R09_Berlin) {
-		// Charge extra for cold locations.
-		if c.context.AccessAccount(address) == tosca.ColdAccess {
-			return c.useGas(ColdAccountAccessCostEIP2929 - WarmStorageReadCostEIP2929)
-		}
-	}
-	return nil
 }

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -249,10 +249,7 @@ func opSstore(c *context) error {
 	cost := tosca.Gas(0)
 	if c.isAtLeast(tosca.R09_Berlin) &&
 		c.context.AccessStorage(c.params.Recipient, key) == tosca.ColdAccess {
-		if err := c.useGas(ColdSloadCostEIP2929); err != nil {
-			// TODO: this error can never be triggered, because if we get here, we already have 2300.
-			return err
-		}
+		cost += 2100
 	}
 
 	storageStatus := c.context.SetStorage(c.params.Recipient, key, value)

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -249,6 +249,7 @@ func opSstore(c *context) error {
 	cost := tosca.Gas(0)
 	if c.isAtLeast(tosca.R09_Berlin) &&
 		c.context.AccessStorage(c.params.Recipient, key) == tosca.ColdAccess {
+		// we do not call useGas here because it is already checked that there is at least 2300 gas available
 		cost += 2100
 	}
 

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -249,7 +249,6 @@ func opSstore(c *context) error {
 	cost := tosca.Gas(0)
 	if c.isAtLeast(tosca.R09_Berlin) &&
 		c.context.AccessStorage(c.params.Recipient, key) == tosca.ColdAccess {
-		// we do not call useGas here because it is already checked that there is at least 2300 gas available
 		cost += 2100
 	}
 

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1174,7 +1174,7 @@ func TestOpEndWithResult_ReportOverflow(t *testing.T) {
 	}
 }
 
-func TestInstructions_EIP2929_staticGasCostForBerlinAndAfterIsZero(t *testing.T) {
+func TestInstructions_EIP2929_staticGasCostIsZero(t *testing.T) {
 	ops := []OpCode{BALANCE, EXTCODECOPY, EXTCODEHASH, EXTCODESIZE, CALL, CALLCODE, DELEGATECALL, STATICCALL}
 	for _, op := range ops {
 		if getBerlinGasPriceInternal(op) != 0 {
@@ -1183,7 +1183,7 @@ func TestInstructions_EIP2929_staticGasCostForBerlinAndAfterIsZero(t *testing.T)
 	}
 }
 
-func TestInstructions_EIP2929_dynamicGasCostForBerlinAndAfterReportsOutOfGas(t *testing.T) {
+func TestInstructions_EIP2929_dynamicGasCostReportsOutOfGas(t *testing.T) {
 	type accessCost struct {
 		warm tosca.Gas
 		cold tosca.Gas
@@ -1283,7 +1283,7 @@ func TestInstructions_EIP2929_dynamicGasCostForBerlinAndAfterReportsOutOfGas(t *
 	}
 }
 
-func TestInstructions_EIP2929_SSTOREReportsOutOfGasAfterBerlin(t *testing.T) {
+func TestInstructions_EIP2929_SSTOREReportsOutOfGas(t *testing.T) {
 	// SSTORE needs to be tested on its own because it demands that at least 2300 gas are available.
 	// Hence we cannot take the same testing approach as for the other operations in EIP-2929.
 

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1287,11 +1287,16 @@ func TestInstructions_EIP2929_SSTOREReportsOutOfGas(t *testing.T) {
 	// SSTORE needs to be tested on its own because it demands that at least 2300 gas are available.
 	// Hence we cannot take the same testing approach as for the other operations in EIP-2929.
 
-	// SSTORE demands at least 2300 gas to be available
-	// 2301 gas is not enough to afford StorageAdded, StorageModified, StorageDeleted.
-	// all other storage status cannot fail in berlin and after because of out of gas.
-	for _, storageStatus := range []tosca.StorageStatus{tosca.StorageAdded, tosca.StorageModified, tosca.StorageDeleted} {
-		for _, availableGas := range []tosca.Gas{2300, 2301} {
+	testGasValues := []tosca.Gas{
+		2300, //< SSTORE demands at least 2300 gas to be available
+		2301, //< not enough to afford StorageAdded, StorageModified, or StorageDeleted.
+	}
+
+	// dynamic gas check can only fail for the following storage status values
+	failsForDynamicGas := []tosca.StorageStatus{tosca.StorageAdded, tosca.StorageModified, tosca.StorageDeleted}
+
+	for _, availableGas := range testGasValues {
+		for _, storageStatus := range failsForDynamicGas {
 			for revision := tosca.R09_Berlin; revision <= newestSupportedRevision; revision++ {
 				for _, access := range []tosca.AccessStatus{tosca.WarmAccess, tosca.ColdAccess} {
 					t.Run(fmt.Sprintf("%v/%v/%v/%v", SSTORE, revision, access, storageStatus), func(t *testing.T) {


### PR DESCRIPTION
Part of #751

This PR fixes and tests many of the changes introduced in EIP-2929 (https://eips.ethereum.org/EIPS/eip-2929) :
- Fixes static costs of BALANCE, EXTCODECOPY, EXTCODESIZE and EXTCODEHASH to zero. All gas for these operations should be dynamically calculated. 
- removes `gasEip2929AccountCheck` because it was duplicated functionality from `getAccessCost`, which is already tested.
- adds test checking for the extra charging of warm/cold accesses in Berlin and after, in the relevant opeations.

NOTE: SelfDestruct is a special case and has its own pre-existing tests.

- [x] ct

