### PR TITLE
rustrs: Add rust driver crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -123,6 +123,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "driver"
+version = "0.1.0"
+dependencies = [
+ "evmc-vm",
+ "evmrs",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +168,7 @@ version = "0.1.0"
 dependencies = [
  "bnum",
  "evmc-vm",
+ "evmrs",
  "mockall",
  "sha3",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,15 +1,24 @@
+[workspace]
+members = ["driver"]
+
 [package]
 name = "evmrs"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+# workaround for enabling mock feature also in integration tests
+mock = ["dep:mockall"]
+
 [dependencies]
 bnum = "0.11.0"
 evmc-vm = { git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
+mockall = { version = "0.13.0", optional = true }
 sha3 = "0.10.8"
 
 [dev-dependencies]
-mockall = "0.13.0"
+# workaround for enabling mock feature also in integration tests
+evmrs = { path = ".", features = ["mock"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-# workaround for enabling mock feature also in integration tests
+# Flag mock enables code generation for test mocking. This allows generating mocks for other build configuration but "test". 
 mock = ["dep:mockall"]
 
 [dependencies]

--- a/rust/driver/Cargo.toml
+++ b/rust/driver/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "driver"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+mock = ["evmrs/mock"]
+
+[dependencies]
+evmc-vm = { git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
+evmrs = { path = "..", optional = true }

--- a/rust/driver/src/host_interface.rs
+++ b/rust/driver/src/host_interface.rs
@@ -1,0 +1,206 @@
+use evmc_vm::ffi::evmc_host_interface;
+
+#[cfg(feature = "mock")]
+mod mock_callbacks {
+    use std::{ffi, slice};
+
+    use evmc_vm::{
+        ffi::{evmc_message, evmc_result, evmc_tx_context},
+        AccessStatus, Address, StorageStatus, Uint256,
+    };
+    use evmrs::{ExecutionContextTrait, MockExecutionContextTrait};
+
+    pub extern "C" fn account_exists(context: *mut ffi::c_void, addr: *const Address) -> bool {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        let addr = unsafe { &*addr };
+        mock.account_exists(addr)
+    }
+
+    pub extern "C" fn get_storage(
+        context: *mut ffi::c_void,
+        addr: *const Address,
+        key: *const Uint256,
+    ) -> Uint256 {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        let addr = unsafe { &*addr };
+        let key = unsafe { &*key };
+        mock.get_storage(addr, key)
+    }
+
+    pub extern "C" fn set_storage(
+        context: *mut ffi::c_void,
+        addr: *const Address,
+        key: *const Uint256,
+        value: *const Uint256,
+    ) -> StorageStatus {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        let addr = unsafe { &*addr };
+        let key = unsafe { &*key };
+        let value = unsafe { &*value };
+        mock.set_storage(addr, key, value)
+    }
+
+    pub extern "C" fn get_balance(context: *mut ffi::c_void, addr: *const Address) -> Uint256 {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        let addr = unsafe { &*addr };
+        mock.get_balance(addr)
+    }
+
+    pub extern "C" fn get_code_size(context: *mut ffi::c_void, addr: *const Address) -> usize {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        let addr = unsafe { &*addr };
+        mock.get_code_size(addr)
+    }
+
+    pub extern "C" fn get_code_hash(context: *mut ffi::c_void, addr: *const Address) -> Uint256 {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        let addr = unsafe { &*addr };
+        mock.get_code_hash(addr)
+    }
+
+    pub extern "C" fn copy_code(
+        context: *mut ffi::c_void,
+        addr: *const Address,
+        code_offset: usize,
+        buffer: *mut u8,
+        buffer_len: usize,
+    ) -> usize {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        let addr = unsafe { &*addr };
+        let buffer = unsafe { slice::from_raw_parts_mut(buffer, buffer_len) };
+        mock.copy_code(addr, code_offset, buffer)
+    }
+
+    pub extern "C" fn selfdestruct(
+        context: *mut ffi::c_void,
+        addr: *const Address,
+        beneficiary: *const Address,
+    ) -> bool {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        let addr = unsafe { &*addr };
+        let beneficiary = unsafe { &*beneficiary };
+        mock.selfdestruct(addr, beneficiary)
+    }
+
+    pub unsafe extern "C" fn call(
+        context: *mut ffi::c_void,
+        message: *const evmc_message,
+    ) -> evmc_result {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        let message = (unsafe { &*message }).into();
+        mock.call(&message).into()
+    }
+
+    pub unsafe extern "C" fn get_tx_context(context: *mut ffi::c_void) -> evmc_tx_context {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        *mock.get_tx_context()
+    }
+
+    pub extern "C" fn get_block_hash(context: *mut ffi::c_void, num: i64) -> Uint256 {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        mock.get_block_hash(num)
+    }
+
+    pub unsafe extern "C" fn emit_log(
+        context: *mut ffi::c_void,
+        addr: *const Address,
+        data: *const u8,
+        data_len: usize,
+        topic: *const Uint256,
+        topic_len: usize,
+    ) {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        let addr = unsafe { &*addr };
+        let data = unsafe { slice::from_raw_parts(data, data_len) };
+        let topic = unsafe { slice::from_raw_parts(topic, topic_len) };
+        mock.emit_log(addr, data, topic);
+    }
+
+    pub extern "C" fn access_account(
+        context: *mut ffi::c_void,
+        addr: *const Address,
+    ) -> AccessStatus {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        let addr = unsafe { &*addr };
+        mock.access_account(addr)
+    }
+
+    pub extern "C" fn access_storage(
+        context: *mut ffi::c_void,
+        addr: *const Address,
+        key: *const Uint256,
+    ) -> AccessStatus {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        let addr = unsafe { &*addr };
+        let key = unsafe { &*key };
+        mock.access_storage(addr, key)
+    }
+
+    pub extern "C" fn get_transient_storage(
+        context: *mut ffi::c_void,
+        addr: *const Address,
+        key: *const Uint256,
+    ) -> Uint256 {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        let addr = unsafe { &*addr };
+        let key = unsafe { &*key };
+        mock.get_transient_storage(addr, key)
+    }
+
+    pub unsafe extern "C" fn set_transient_storage(
+        context: *mut ffi::c_void,
+        addr: *const Address,
+        key: *const Uint256,
+        value: *const Uint256,
+    ) {
+        let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };
+        let addr = unsafe { &*addr };
+        let key = unsafe { &*key };
+        let value = unsafe { &*value };
+        mock.set_transient_storage(addr, key, value);
+    }
+}
+
+#[cfg(feature = "mock")]
+pub fn mocked_host_interface() -> evmc_host_interface {
+    use mock_callbacks::*;
+    evmc_host_interface {
+        account_exists: Some(account_exists),
+        get_storage: Some(get_storage),
+        set_storage: Some(set_storage),
+        get_balance: Some(get_balance),
+        get_code_size: Some(get_code_size),
+        get_code_hash: Some(get_code_hash),
+        copy_code: Some(copy_code),
+        selfdestruct: Some(selfdestruct),
+        call: Some(call),
+        get_tx_context: Some(get_tx_context),
+        get_block_hash: Some(get_block_hash),
+        emit_log: Some(emit_log),
+        access_account: Some(access_account),
+        access_storage: Some(access_storage),
+        get_transient_storage: Some(get_transient_storage),
+        set_transient_storage: Some(set_transient_storage),
+    }
+}
+
+pub fn null_ptr_host_interface() -> evmc_host_interface {
+    evmc_host_interface {
+        account_exists: None,
+        get_storage: None,
+        set_storage: None,
+        get_balance: None,
+        get_code_size: None,
+        get_code_hash: None,
+        copy_code: None,
+        selfdestruct: None,
+        call: None,
+        get_tx_context: None,
+        get_block_hash: None,
+        emit_log: None,
+        access_account: None,
+        access_storage: None,
+        get_transient_storage: None,
+        set_transient_storage: None,
+    }
+}

--- a/rust/driver/src/lib.rs
+++ b/rust/driver/src/lib.rs
@@ -1,0 +1,238 @@
+use std::{ffi, ptr};
+
+use evmc_vm::{
+    ffi::{
+        evmc_host_interface, evmc_message, evmc_result, evmc_step_result, evmc_step_status_code,
+        evmc_tx_context, evmc_vm as evmc_vm_t, evmc_vm_steppable,
+    },
+    Address, Revision, Uint256,
+};
+#[cfg(feature = "mock")]
+use evmrs::MockExecutionMessage;
+
+pub mod host_interface;
+
+extern "C" {
+    fn evmc_create_evmrs() -> *const evmc_vm_t;
+    fn evmc_create_steppable_evmrs() -> *const evmc_vm_steppable;
+}
+
+pub const ZERO: Uint256 = Uint256 { bytes: [0; 32] };
+pub const ZERO_ADDR: Address = Address { bytes: [0; 20] };
+
+pub const TX_CONTEXT_ZEROED: evmc_tx_context = evmc_tx_context {
+    tx_gas_price: ZERO,
+    tx_origin: ZERO_ADDR,
+    block_coinbase: ZERO_ADDR,
+    block_number: 0,
+    block_timestamp: 0,
+    block_gas_limit: 0,
+    block_prev_randao: ZERO,
+    chain_id: ZERO,
+    block_base_fee: ZERO,
+    blob_base_fee: ZERO,
+    blob_hashes: ptr::null(),
+    blob_hashes_count: 0,
+    initcodes: ptr::null(),
+    initcodes_count: 0,
+};
+
+/// # Safety
+///
+/// The value of the pointer is not used because a constant value is returned.
+pub unsafe extern "C" fn get_tx_context_zeroed(_context: *mut ffi::c_void) -> evmc_tx_context {
+    TX_CONTEXT_ZEROED
+}
+
+#[cfg(feature = "mock")]
+pub fn to_evmc_message(message: &MockExecutionMessage) -> evmc_message {
+    evmc_message {
+        kind: message.kind,
+        flags: message.flags,
+        depth: message.depth,
+        gas: message.gas,
+        recipient: message.recipient,
+        sender: message.sender,
+        input_data: message.input.map(<[u8]>::as_ptr).unwrap_or(ptr::null()),
+        input_size: message.input.map(<[u8]>::len).unwrap_or_default(),
+        value: message.value,
+        create2_salt: message.create2_salt,
+        code_address: message.code_address,
+        code: message.code.map(<[u8]>::as_ptr).unwrap_or(ptr::null()),
+        code_size: message.code.map(<[u8]>::len).unwrap_or_default(),
+        code_hash: ptr::null(),
+    }
+}
+
+/// # Safety
+///
+/// All pointers must be valid, except for `context` which can be null if the `evmc_host_interface`
+/// accepts null pointers as context.
+pub unsafe fn run_raw(
+    host: *const evmc_host_interface,
+    context: *mut ffi::c_void,
+    revision: Revision,
+    message: *const evmc_message,
+    code: *const u8,
+    code_len: usize,
+) -> evmc_result {
+    let instance = evmc_create_evmrs();
+    if instance.is_null() {
+        panic!("vm instance is null")
+    }
+    // SAFETY:
+    // `instance is not null`. `evmc_create_evmrs` must return a valid pointer to an `evmc_vm_t`.
+    let instance = unsafe { &mut *(instance as *mut evmc_vm_t) };
+
+    let execute = instance.execute.unwrap();
+    let destroy = instance.destroy.unwrap();
+
+    let result = unsafe { execute(instance, host, context, revision, message, code, code_len) };
+
+    unsafe {
+        destroy(instance);
+    }
+
+    result
+}
+
+/// # Safety
+///
+/// All pointers must be valid, except for `context` which can be null if the `evmc_host_interface`
+/// accepts null pointers as context.
+pub unsafe fn run(
+    host: *const evmc_host_interface,
+    context: *mut ffi::c_void,
+    revision: Revision,
+    message: *const evmc_message,
+    code: &[u8],
+) -> evmc_result {
+    run_raw(
+        host,
+        context,
+        revision,
+        message,
+        if code.is_empty() {
+            ptr::null()
+        } else {
+            code.as_ptr()
+        },
+        code.len(),
+    )
+}
+
+/// # Safety
+///
+/// All pointers must be valid, except for `context` which can be null if the `evmc_host_interface`
+/// accepts null pointers as context.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn run_steppable_raw(
+    host: *const evmc_host_interface,
+    context: *mut ffi::c_void,
+    revision: Revision,
+    message: *const evmc_message,
+    code: *const u8,
+    code_len: usize,
+    status: evmc_step_status_code,
+    pc: u64,
+    gas_refunds: i64,
+    stack: *mut Uint256,
+    stack_len: usize,
+    memory: *mut u8,
+    memory_len: usize,
+    last_call_result_data: *mut u8,
+    last_call_result_data_len: usize,
+    steps: i32,
+) -> evmc_step_result {
+    let instance = evmc_create_steppable_evmrs();
+    if instance.is_null() {
+        panic!("vm instance is null")
+    }
+    let instance = unsafe { &mut *(instance as *mut evmc_vm_steppable) };
+
+    let step_n = instance.step_n.unwrap();
+    let destroy = instance.destroy.unwrap();
+
+    let result = unsafe {
+        step_n(
+            instance,
+            host,
+            context,
+            revision,
+            message,
+            code,
+            code_len,
+            status,
+            pc,
+            gas_refunds,
+            stack,
+            stack_len,
+            memory,
+            memory_len,
+            last_call_result_data,
+            last_call_result_data_len,
+            steps,
+        )
+    };
+
+    unsafe {
+        destroy(instance);
+    }
+
+    result
+}
+
+/// # Safety
+///
+/// All pointers must be valid, except for `context` which can be null if the `evmc_host_interface`
+/// accepts null pointers as context.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn run_steppable(
+    host: evmc_host_interface,
+    context: *mut ffi::c_void,
+    revision: Revision,
+    message: *const evmc_message,
+    code: &[u8],
+    status: evmc_step_status_code,
+    pc: u64,
+    gas_refunds: i64,
+    stack: &mut [Uint256],
+    memory: &mut [u8],
+    last_call_result_data: &mut [u8],
+    steps: i32,
+) -> evmc_step_result {
+    run_steppable_raw(
+        &host,
+        context,
+        revision,
+        message,
+        if code.is_empty() {
+            ptr::null()
+        } else {
+            code.as_ptr()
+        },
+        code.len(),
+        status,
+        pc,
+        gas_refunds,
+        if stack.is_empty() {
+            ptr::null_mut()
+        } else {
+            stack.as_mut_ptr()
+        },
+        stack.len(),
+        if memory.is_empty() {
+            ptr::null_mut()
+        } else {
+            memory.as_mut_ptr()
+        },
+        memory.len(),
+        if last_call_result_data.is_empty() {
+            ptr::null_mut()
+        } else {
+            last_call_result_data.as_mut_ptr()
+        },
+        last_call_result_data.len(),
+        steps,
+    )
+}

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -1167,10 +1167,7 @@ mod tests {
 
     use crate::{
         interpreter::Interpreter,
-        types::{
-            u256, Memory, MockExecutionContextTrait, MockExecutionMessage, Opcode, Stack,
-            DEFAULT_INIT_GAS,
-        },
+        types::{u256, Memory, MockExecutionContextTrait, MockExecutionMessage, Opcode, Stack},
     };
 
     #[test]
@@ -1183,7 +1180,7 @@ mod tests {
         assert_eq!(result.step_status_code, StepStatusCode::EVMC_STEP_STOPPED);
         assert_eq!(result.status_code, StatusCode::EVMC_SUCCESS);
         assert_eq!(result.code_reader.pc(), 0);
-        assert_eq!(result.gas_left, DEFAULT_INIT_GAS);
+        assert_eq!(result.gas_left, MockExecutionMessage::DEFAULT_INIT_GAS);
     }
 
     #[test]
@@ -1209,7 +1206,7 @@ mod tests {
         assert_eq!(result.step_status_code, StepStatusCode::EVMC_STEP_STOPPED);
         assert_eq!(result.status_code, StatusCode::EVMC_SUCCESS);
         assert_eq!(result.code_reader.pc(), 1);
-        assert_eq!(result.gas_left, DEFAULT_INIT_GAS);
+        assert_eq!(result.gas_left, MockExecutionMessage::DEFAULT_INIT_GAS);
     }
 
     #[test]
@@ -1252,7 +1249,7 @@ mod tests {
         assert_eq!(result.step_status_code, StepStatusCode::EVMC_STEP_RUNNING);
         assert_eq!(result.status_code, StatusCode::EVMC_SUCCESS);
         assert_eq!(result.code_reader.pc(), 0);
-        assert_eq!(result.gas_left, DEFAULT_INIT_GAS);
+        assert_eq!(result.gas_left, MockExecutionMessage::DEFAULT_INIT_GAS);
     }
 
     #[test]
@@ -1273,7 +1270,7 @@ mod tests {
         assert_eq!(result.step_status_code, StepStatusCode::EVMC_STEP_RUNNING);
         assert_eq!(result.status_code, StatusCode::EVMC_SUCCESS);
         assert_eq!(result.stack.into_inner(), [3u8.into()]);
-        assert_eq!(result.gas_left, DEFAULT_INIT_GAS - 3);
+        assert_eq!(result.gas_left, MockExecutionMessage::DEFAULT_INIT_GAS - 3);
     }
 
     #[test]
@@ -1293,7 +1290,7 @@ mod tests {
         assert_eq!(result.step_status_code, StepStatusCode::EVMC_STEP_STOPPED);
         assert_eq!(result.status_code, StatusCode::EVMC_SUCCESS);
         assert_eq!(result.stack.into_inner(), [3u8.into()]);
-        assert_eq!(result.gas_left, DEFAULT_INIT_GAS - 3);
+        assert_eq!(result.gas_left, MockExecutionMessage::DEFAULT_INIT_GAS - 3);
     }
 
     #[test]
@@ -1313,7 +1310,10 @@ mod tests {
         assert_eq!(result.step_status_code, StepStatusCode::EVMC_STEP_STOPPED);
         assert_eq!(result.status_code, StatusCode::EVMC_SUCCESS);
         assert_eq!(result.stack.into_inner(), [6u8.into()]);
-        assert_eq!(result.gas_left, DEFAULT_INIT_GAS - 2 * 3);
+        assert_eq!(
+            result.gas_left,
+            MockExecutionMessage::DEFAULT_INIT_GAS - 2 * 3
+        );
     }
 
     #[test]
@@ -1418,7 +1418,10 @@ mod tests {
         assert_eq!(result.step_status_code, StepStatusCode::EVMC_STEP_STOPPED);
         assert_eq!(result.status_code, StatusCode::EVMC_SUCCESS);
         assert_eq!(result.code_reader.pc(), 1);
-        assert_eq!(result.gas_left, DEFAULT_INIT_GAS - 700 - gas);
+        assert_eq!(
+            result.gas_left,
+            MockExecutionMessage::DEFAULT_INIT_GAS - 700 - gas
+        );
         assert_eq!(
             result.last_call_return_data.as_deref(),
             Some(ret_data.as_slice())

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -3,3 +3,8 @@ mod ffi;
 mod interpreter;
 mod types;
 mod utils;
+
+#[cfg(feature = "mock")]
+pub use types::{
+    u256, ExecutionContextTrait, MockExecutionContextTrait, MockExecutionMessage, Opcode,
+};

--- a/rust/src/types/execution_context.rs
+++ b/rust/src/types/execution_context.rs
@@ -3,7 +3,7 @@ use evmc_vm::{
     StorageStatus, Uint256,
 };
 
-#[cfg_attr(test, mockall::automock)]
+#[cfg_attr(feature = "mock", mockall::automock)]
 pub trait ExecutionContextTrait {
     /// Retrieve the transaction context.
     fn get_tx_context(&self) -> &ExecutionTxContext;

--- a/rust/src/types/mock_execution_message.rs
+++ b/rust/src/types/mock_execution_message.rs
@@ -2,8 +2,6 @@ use evmc_vm::{Address, ExecutionMessage, MessageKind, Uint256};
 
 use crate::types::u256;
 
-pub const DEFAULT_INIT_GAS: u64 = 1_000_000;
-
 /// The same as ExecutionMessage but with `pub` fields for easier testing.
 #[derive(Debug)]
 pub struct MockExecutionMessage<'a> {
@@ -20,13 +18,17 @@ pub struct MockExecutionMessage<'a> {
     pub code: Option<&'a [u8]>,
 }
 
+impl<'a> MockExecutionMessage<'a> {
+    pub const DEFAULT_INIT_GAS: u64 = 1_000_000;
+}
+
 impl<'a> Default for MockExecutionMessage<'a> {
     fn default() -> Self {
         MockExecutionMessage {
             kind: MessageKind::EVMC_CALL,
             flags: 0,
             depth: 1,
-            gas: DEFAULT_INIT_GAS as i64,
+            gas: Self::DEFAULT_INIT_GAS as i64,
             recipient: u256::ZERO.into(),
             sender: u256::ZERO.into(),
             input: None,

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -2,7 +2,7 @@ mod amount;
 mod code_reader;
 mod execution_context;
 mod memory;
-#[cfg(test)]
+#[cfg(feature = "mock")]
 mod mock_execution_message;
 mod opcode;
 mod stack;
@@ -12,8 +12,8 @@ pub use amount::u256;
 pub use code_reader::{CodeReader, GetOpcodeError};
 pub use execution_context::*;
 pub use memory::Memory;
-#[cfg(test)]
-pub use mock_execution_message::{MockExecutionMessage, DEFAULT_INIT_GAS};
+#[cfg(feature = "mock")]
+pub use mock_execution_message::MockExecutionMessage;
 pub use opcode::*;
 pub use stack::Stack;
 pub use tx_context::ExecutionTxContext;


### PR DESCRIPTION
Add `driver` crate. This crate calls `evmrs` via the C FFI interface. It will be used for integration testing and for benchmarks.