### PR TITLE
LFVM: genericCall errors test

### DIFF
--- a/go/interpreter/lfvm/gas.go
+++ b/go/interpreter/lfvm/gas.go
@@ -12,7 +12,6 @@ package lfvm
 
 import (
 	"github.com/Fantom-foundation/Tosca/go/tosca"
-	"github.com/holiman/uint256"
 )
 
 const (
@@ -234,22 +233,6 @@ func getStaticGasPriceInternal(op OpCode) tosca.Gas {
 	}
 
 	return UNKNOWN_GAS_PRICE
-}
-
-// callGas returns the actual gas cost of the call.
-//
-// The cost of gas was changed during the homestead price change HF.
-// As part of EIP 150 (TangerineWhistle), the returned gas is gas - base * 63 / 64.
-func callGas(availableGas, base tosca.Gas, callCost *uint256.Int) tosca.Gas {
-	availableGas = availableGas - base
-	if availableGas < 0 {
-		return base
-	}
-	gas := availableGas - availableGas/64
-	if !callCost.IsUint64() || (gas < tosca.Gas(callCost.Uint64())) {
-		return gas
-	}
-	return tosca.Gas(callCost.Uint64())
 }
 
 func getDynamicCostsForSstore(

--- a/go/interpreter/lfvm/gas_test.go
+++ b/go/interpreter/lfvm/gas_test.go
@@ -14,51 +14,7 @@ import (
 	"testing"
 
 	"github.com/Fantom-foundation/Tosca/go/tosca"
-	"github.com/holiman/uint256"
 )
-
-func TestGas_CallGasCalculation(t *testing.T) {
-	tests := map[string]struct {
-		available tosca.Gas    // < the gas available in the current context
-		baseCosts tosca.Gas    // < the costs for setting up the call
-		provided  *uint256.Int // < the gas to be provided to the nested call
-		want      tosca.Gas    // < the gas costs for the call
-	}{
-		"available_is_more_than_provided": {
-			available: tosca.Gas(200),
-			baseCosts: tosca.Gas(20),
-			provided:  uint256.NewInt(30),
-			want:      30, // < limited by gas to be provided to nested call
-		},
-		"available_is_less_than_provided": {
-			available: tosca.Gas(200),
-			baseCosts: tosca.Gas(20),
-			provided:  uint256.NewInt(300),
-			want:      (200 - 20) - (200-20)/64, //  < limited by 63/64 of the available gas after the base costs
-		},
-		"available_is_less_than_provided_exceeding_maxUint64": {
-			available: tosca.Gas(200),
-			baseCosts: tosca.Gas(20),
-			provided:  new(uint256.Int).Lsh(uint256.NewInt(1), 64),
-			want:      (200 - 20) - (200-20)/64, //  < limited by 63/64 of the available gas after the base costs
-		},
-		"base_costs_higher_than_available": {
-			available: tosca.Gas(20),
-			baseCosts: tosca.Gas(200),
-			provided:  uint256.NewInt(300),
-			want:      200, //  < the base costs
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			got := callGas(test.available, test.baseCosts, test.provided)
-			if want := test.want; want != got {
-				t.Errorf("unexpected result, wanted %d, got %d", want, got)
-			}
-		})
-	}
-}
 
 // --- SStore ---
 

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -1098,19 +1098,18 @@ func genericCall(c *context, kind tosca.CallKind) error {
 
 	// The Homestead hard-fork introduced a limit on the amount of gas that can be
 	// forwarded to recursive calls. EIP-150 (https://eips.ethereum.org/EIPS/eip-150)
-	// defines that at but one 64th of the available gas in one scope may be passed
+	// defines that at all but one 64th of the available gas in one scope may be passed
 	// to a nested call.
-	endowment := tosca.Gas(c.gas - c.gas/64)
-	if provided_gas.IsUint64() && (endowment >= tosca.Gas(provided_gas.Uint64())) {
-		endowment = tosca.Gas(provided_gas.Uint64())
+	nestedCallGas := tosca.Gas(c.gas - c.gas/64)
+	if provided_gas.IsUint64() && (nestedCallGas >= tosca.Gas(provided_gas.Uint64())) {
+		nestedCallGas = tosca.Gas(provided_gas.Uint64())
 	}
-	if err := c.useGas(endowment); err != nil {
-		// this usage can never fail because, since the endowment is at most
+	if err := c.useGas(nestedCallGas); err != nil {
+		// this usage can never fail because the endowment is at most
 		// 63/64 of the current gas level.
 		return err
 	}
 
-	nestedCallGas := endowment
 	// first use static and dynamic gas cost and then resize the memory
 	// when out of gas is happening, then mem should not be resized
 	if !value.IsZero() {

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1508,41 +1508,21 @@ func TestGenericCall_ProperlyReportsErrors(t *testing.T) {
 			ctxt.context = runContext
 			ctxt.params.Revision = tosca.R13_Cancun
 			ctxt.gas = test.gas
-			// retSize, retOffset, inSize, inOffset, value, address, provided_gas
-			for i := 0; i < 7; i++ {
-				push := uint256.NewInt(0)
-				switch i {
-				case 0:
-					if test.retSize != nil {
-						push = test.retSize
-					}
-				case 1:
-					if test.retOffset != nil {
-						push = test.retOffset
-					}
-				case 2:
-					if test.inSize != nil {
-						push = test.inSize
-					}
-				case 3:
-					if test.inOffset != nil {
-						push = test.inOffset
-					}
-				case 4:
-					if test.value != nil {
-						push = test.value
-					}
-				case 5:
-					if test.address != nil {
-						push = test.address
-					}
-				case 6:
-					if test.provided_gas != nil {
-						push = test.provided_gas
-					}
+
+			getValueOrZeroOf := func(i *uint256.Int) *uint256.Int {
+				if i == nil {
+					return uint256.NewInt(0)
 				}
-				ctxt.stack.push(push)
+				return i
 			}
+
+			ctxt.stack.push(getValueOrZeroOf(test.retSize))
+			ctxt.stack.push(getValueOrZeroOf(test.retOffset))
+			ctxt.stack.push(getValueOrZeroOf(test.inSize))
+			ctxt.stack.push(getValueOrZeroOf(test.inOffset))
+			ctxt.stack.push(getValueOrZeroOf(test.value))
+			ctxt.stack.push(getValueOrZeroOf(test.address))
+			ctxt.stack.push(getValueOrZeroOf(test.provided_gas))
 
 			err := genericCall(&ctxt, tosca.Call)
 

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1420,7 +1420,7 @@ func TestGetData(t *testing.T) {
 	}
 }
 
-func TestCheckSizeOffsetUintOverflow_ReturnsAsExpected(t *testing.T) {
+func TestCheckSizeOffsetUintOverflow(t *testing.T) {
 
 	zero := uint256.NewInt(0)
 	one := uint256.NewInt(1)

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1443,6 +1443,10 @@ func TestCheckSizeOFfsetUintOverflow_ReturnsAsExpected(t *testing.T) {
 	if want, got := error(nil), checkSizeOffsetUint64Overflow(one, one); want != got {
 		t.Errorf("unexpected status after call, wanted %v, got %v", want, got)
 	}
+	// size+offset overflow is reported
+	if want, got := errOverflow, checkSizeOffsetUint64Overflow(uint256.NewInt(math.MaxUint64-1), uint256.NewInt(2)); want != got {
+		t.Errorf("unexpected status after call, wanted %v, got %v", want, got)
+	}
 
 }
 

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1534,15 +1534,15 @@ func TestGenericCall_ProperlyReportsErrors(t *testing.T) {
 }
 
 func TestGenericCall_CallKindPropagatesStaticMode(t *testing.T) {
-	for _, callKind := range []tosca.CallKind{tosca.Call, tosca.StaticCall} {
-		runContext := tosca.NewMockRunContext(gomock.NewController(t))
-		runContext.EXPECT().Call(callKind, gomock.Any()).Return(tosca.CallResult{}, nil)
-
-		ctxt := getEmptyContext()
-		ctxt.context = runContext
-		ctxt.params.Static = callKind == tosca.StaticCall
-		ctxt.stack.stackPointer = 7
-		_ = genericCall(&ctxt, tosca.Call)
+	runContext := tosca.NewMockRunContext(gomock.NewController(t))
+	runContext.EXPECT().Call(tosca.StaticCall, gomock.Any()).Return(tosca.CallResult{}, nil)
+	ctxt := getEmptyContext()
+	ctxt.context = runContext
+	ctxt.params.Static = true
+	ctxt.stack.stackPointer = 7
+	err := genericCall(&ctxt, tosca.Call)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
To ensure that each early returned is behaving as expected, we test it.
This PR adds:
- test for `checkSizeOffsetUint64Overflow` all 4 cases.
- removes `checkGas` from `genericCall` and replaces it for calls to `c.useGas` this way we do not need to check for overflow when adding each expense. 
- inlines function `CallGas`  and removes its test.
- adds a test for all the error cases of `genericCall`
- adds test for static context propagation
- adds test for internal call result propagation in the stack