### PR TITLE
LFVM: selfdestruct out of gas check

### DIFF
--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1095,7 +1095,7 @@ func TestSelfDestruct_ExistingAccountToNewBeneficiary(t *testing.T) {
 	}
 }
 
-func TestSelfDestruct_ProperlyReportsNotEnughGas(t *testing.T) {
+func TestSelfDestruct_ProperlyReportsNotEnoughGas(t *testing.T) {
 	for _, beneficiaryAccess := range []tosca.AccessStatus{tosca.WarmAccess, tosca.ColdAccess} {
 		for _, beneficiaryExists := range []bool{true, false} {
 			t.Run(fmt.Sprintf("beneficiaryAccess:%v_beneficiaryExists:%v", beneficiaryAccess, beneficiaryExists), func(t *testing.T) {
@@ -1129,13 +1129,11 @@ func TestSelfDestruct_ProperlyReportsNotEnughGas(t *testing.T) {
 
 				ctxt.stack.push(new(uint256.Int).SetBytes(beneficiaryAddress[:]))
 
-				status, err := opSelfdestruct(&ctxt)
+				_, err := opSelfdestruct(&ctxt)
 				if err != errOutOfGas {
 					t.Fatalf("expected error, got nil")
 				}
-				if want, got := statusStopped, status; want != got {
-					t.Fatalf("unexpected status, wanted %v, got %v", want, got)
-				}
+
 			})
 		}
 	}

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1105,7 +1105,7 @@ func TestSelfDestruct_ProperlyReportsNotEnoughGas(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				runContext := tosca.NewMockRunContext(ctrl)
 				runContext.EXPECT().AccessAccount(beneficiaryAddress).Return(beneficiaryAccess)
-				runContext.EXPECT().AccountExists(beneficiaryAddress).Return(false)
+				runContext.EXPECT().AccountExists(beneficiaryAddress).Return(beneficiaryExists)
 				runContext.EXPECT().GetBalance(selfAddress).Return(tosca.Value{1})
 
 				ctxt := context{

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1097,15 +1097,15 @@ func TestSelfDestruct_ExistingAccountToNewBeneficiary(t *testing.T) {
 
 func TestSelfDestruct_ProperlyReportsNotEnoughGas(t *testing.T) {
 	for _, beneficiaryAccess := range []tosca.AccessStatus{tosca.WarmAccess, tosca.ColdAccess} {
-		for _, beneficiaryExists := range []bool{true, false} {
-			t.Run(fmt.Sprintf("beneficiaryAccess:%v_beneficiaryExists:%v", beneficiaryAccess, beneficiaryExists), func(t *testing.T) {
+		for _, accountExists := range []bool{true, false} {
+			t.Run(fmt.Sprintf("beneficiaryAccess:%v_accountExists:%v", beneficiaryAccess, accountExists), func(t *testing.T) {
 				beneficiaryAddress := tosca.Address{1}
 				selfAddress := tosca.Address{2}
 
 				ctrl := gomock.NewController(t)
 				runContext := tosca.NewMockRunContext(ctrl)
 				runContext.EXPECT().AccessAccount(beneficiaryAddress).Return(beneficiaryAccess)
-				runContext.EXPECT().AccountExists(beneficiaryAddress).Return(beneficiaryExists)
+				runContext.EXPECT().AccountExists(beneficiaryAddress).Return(accountExists)
 				runContext.EXPECT().GetBalance(selfAddress).Return(tosca.Value{1})
 
 				ctxt := context{
@@ -1122,7 +1122,7 @@ func TestSelfDestruct_ProperlyReportsNotEnoughGas(t *testing.T) {
 				if beneficiaryAccess == tosca.ColdAccess {
 					ctxt.gas += 2600
 				}
-				if !beneficiaryExists {
+				if !accountExists {
 					ctxt.gas += 25000
 				}
 				ctxt.gas -= 1
@@ -1131,7 +1131,7 @@ func TestSelfDestruct_ProperlyReportsNotEnoughGas(t *testing.T) {
 
 				_, err := opSelfdestruct(&ctxt)
 				if err != errOutOfGas {
-					t.Fatalf("expected error, got nil")
+					t.Fatalf("expected out of gas but got %v", err)
 				}
 
 			})


### PR DESCRIPTION
During the refactor of self destruct gas checking, no test checking out of gas was introduced, this PR fixes that. 