### PR TITLE
LFVM: make super-instruction configuration experimental

### DIFF
--- a/go/interpreter/lfvm/lfvm.go
+++ b/go/interpreter/lfvm/lfvm.go
@@ -35,12 +35,7 @@ func NewInterpreter(Config) (*lfvm, error) {
 // Registers the long-form EVM as a possible interpreter implementation.
 func init() {
 	tosca.MustRegisterInterpreterFactory("lfvm", func(any) (tosca.Interpreter, error) {
-		return newVm(config{
-			ConversionConfig: ConversionConfig{
-				WithSuperInstructions: false,
-			},
-			WithShaCache: true,
-		})
+		return NewInterpreter(Config{})
 	})
 }
 

--- a/go/interpreter/lfvm/lfvm.go
+++ b/go/interpreter/lfvm/lfvm.go
@@ -34,40 +34,14 @@ func NewInterpreter(Config) (*lfvm, error) {
 
 // Registers the long-form EVM as a possible interpreter implementation.
 func init() {
-
-	configs := map[string]config{
-		// This is the officially supported LFVM interpreter configuration to be
-		// used for production purposes.
-		"lfvm": {
+	tosca.MustRegisterInterpreterFactory("lfvm", func(any) (tosca.Interpreter, error) {
+		return newVm(config{
 			ConversionConfig: ConversionConfig{
 				WithSuperInstructions: false,
 			},
 			WithShaCache: true,
-		},
-
-		// This is an unofficial LFVM interpreter configuration that uses super
-		// instructions. It is currently exported by default since Aida's nightly
-		// tests are depending on it and Aida is not yet importing experimental
-		// configurations explicitly. Once Aida has been updated to import
-		// experimental configurations explicitly, this configuration should be
-		// removed from the default exports.
-		//
-		// TODO(#763): remove once Aida has been updated to import experimental
-		// configurations explicitly.
-		"lfvm-si": {
-			ConversionConfig: ConversionConfig{
-				WithSuperInstructions: true,
-			},
-			WithShaCache: true,
-		},
-	}
-
-	for name, config := range configs {
-		config := config
-		tosca.MustRegisterInterpreterFactory(name, func(any) (tosca.Interpreter, error) {
-			return newVm(config)
 		})
-	}
+	})
 }
 
 // RegisterExperimentalInterpreterConfigurations registers all experimental
@@ -95,7 +69,7 @@ func RegisterExperimentalInterpreterConfigurations() error {
 				}
 
 				name := "lfvm" + si + shaCache + mode
-				if name != "lfvm" && name != "lfvm-si" {
+				if name != "lfvm" {
 					err := tosca.RegisterInterpreterFactory(
 						name,
 						func(any) (tosca.Interpreter, error) {


### PR DESCRIPTION
This PR removes the super-instruction version from the list of officially supported versions and adds it to the experimental configuration set.

This is part of #687 