### PR TITLE
LFVM: Remove use of gas on use gas failure.

### DIFF
--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -57,7 +57,6 @@ type context struct {
 // false otherwise.
 func (c *context) useGas(amount tosca.Gas) error {
 	if c.gas < 0 || amount < 0 || c.gas < amount {
-		c.gas = 0
 		return errOutOfGas
 	}
 	c.gas -= amount

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -28,7 +28,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestContext_useGas_ReturnsErrorIfOutOfGasAndConsumesAllRemainingGas(t *testing.T) {
+func TestContext_useGas_ReturnsErrorIfOutOfGasOrNegativeCost(t *testing.T) {
 	tests := map[string]struct {
 		available tosca.Gas
 		required  tosca.Gas
@@ -60,15 +60,6 @@ func TestContext_useGas_ReturnsErrorIfOutOfGasAndConsumesAllRemainingGas(t *test
 			success := err == nil
 			if want != success {
 				t.Errorf("expected UseGas to return %v, got %v", want, success)
-			}
-
-			// Check that the remaining gas is correct.
-			wantGas := tosca.Gas(0)
-			if err == nil {
-				wantGas = test.available - test.required
-			}
-			if ctx.gas != wantGas {
-				t.Errorf("expected gas to be %v, got %v", wantGas, ctx.gas)
 			}
 		})
 	}


### PR DESCRIPTION
The normal handling of stop conditions in the VM is to return an error and stop execution. Errors triggered by the VM are equally critical and results on all the gas being consumed. There is no reason to consume the gas for Out of gas scenarios but not for any of the other stopping conditions, therefore this logic is somewhere else and doing it at this point in execution is redundant and error-prone.

The real place where gas gets consumed is [here](https://github.com/Fantom-foundation/Tosca/blob/db1b6de32735886de9f8e7796f5830ddb27f3229/go/interpreter/lfvm/interpreter.go#L115)