### PR TITLE
LFVM: refactor loggerRunner to accept io.Writer instead of printing to stdout. 

### DIFF
--- a/go/interpreter/lfvm/instruction_logger.go
+++ b/go/interpreter/lfvm/instruction_logger.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package lfvm
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// loggingRunner is a runner that logs the execution of the contract code to
+// stdout. It is used for debugging purposes.
+type loggingRunner struct {
+	log io.Writer
+}
+
+// NewLoggingRunner creates a new logging runner.
+func NewLoggingRunner(writer io.Writer) loggingRunner {
+	return loggingRunner{log: writer}
+}
+
+func (l loggingRunner) run(c *context) (status, error) {
+	if l.log == nil {
+		l.log = os.Stderr
+	}
+	status := statusRunning
+	var err error
+	for status == statusRunning {
+		// log format: <op>, <gas>, <top-of-stack>\n
+		if int(c.pc) < len(c.code) {
+			top := "-empty-"
+			if c.stack.len() > 0 {
+				top = c.stack.peek().ToBig().String()
+			}
+			l.log.Write([]byte(fmt.Sprintf("%v, %d, %v\n", c.code[c.pc].opcode, c.gas, top)))
+		}
+		status, err = step(c)
+		if err != nil {
+			return status, err
+		}
+	}
+	return status, nil
+}

--- a/go/interpreter/lfvm/instruction_logger.go
+++ b/go/interpreter/lfvm/instruction_logger.go
@@ -41,6 +41,7 @@ func (l loggingRunner) run(c *context) (status, error) {
 			if l.log != nil {
 				_, err = l.log.Write([]byte(fmt.Sprintf("%v, %d, %v\n", c.code[c.pc].opcode, c.gas, top)))
 				if err != nil {
+					// TODO: rework this error to be handled differently than step errors
 					return status, err
 				}
 			}

--- a/go/interpreter/lfvm/instruction_logger.go
+++ b/go/interpreter/lfvm/instruction_logger.go
@@ -16,7 +16,7 @@ import (
 )
 
 // loggingRunner is a runner that logs the execution of the contract code to an io.Writer.
-// If no writter is provided with NewLoggingRunner, nothing will be logged.
+// If the output log is nil, nothing is logged.
 type loggingRunner struct {
 	log io.Writer
 }

--- a/go/interpreter/lfvm/instruction_logger.go
+++ b/go/interpreter/lfvm/instruction_logger.go
@@ -15,9 +15,8 @@ import (
 	"io"
 )
 
-// loggingRunner is a runner that logs the execution of the contract code to
-// an io.Writer. If no writter is provided with NewLoggingRunner, the log will
-// be written to os.Stderr.
+// loggingRunner is a runner that logs the execution of the contract code to an io.Writer.
+// If no writter is provided with NewLoggingRunner, nothing will be logged.
 type loggingRunner struct {
 	log io.Writer
 }

--- a/go/interpreter/lfvm/instruction_logger_test.go
+++ b/go/interpreter/lfvm/instruction_logger_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package lfvm
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+)
+
+func TestLogger_ExecutesCodeAndLogs(t *testing.T) {
+
+	tests := map[string]struct {
+		code []Instruction
+		want string
+	}{
+		"empty": {},
+		"stop": {
+			code: []Instruction{{STOP, 0}},
+			want: "STOP, 10, -empty-\n",
+		},
+		"multiple codes": {
+			code: []Instruction{{PUSH4, 0}, {DATA, 1}, {STOP, 0}},
+			want: "PUSH4, 10, -empty-\nSTOP, 7, 1\n",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			// Get tosca.Parameters
+			params := tosca.Parameters{
+				Input:  []byte{},
+				Static: true,
+				Gas:    10,
+				Code:   []byte{byte(STOP), 0},
+			}
+			code := test.code
+			buffer := bytes.NewBuffer([]byte{})
+			logger := NewLoggingRunner(buffer)
+			config := interpreterConfig{
+				runner: logger,
+			}
+			_, err := run(config, params, code)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if strings.Compare(string(buffer.String()), test.want) != 0 {
+				t.Errorf("unexpected log: want %v, got %v", test.want, buffer.String())
+			}
+		})
+	}
+}

--- a/go/interpreter/lfvm/instruction_logger_test.go
+++ b/go/interpreter/lfvm/instruction_logger_test.go
@@ -50,10 +50,7 @@ func TestInterpreter_Logger_ExecutesCodeAndLogs(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			// Get tosca.Parameters
-			params := tosca.Parameters{
-				Gas:  3,
-				Code: []byte{byte(STOP), 0},
-			}
+			params := tosca.Parameters{Gas: 3}
 			code := test.code
 			buffer := bytes.NewBuffer([]byte{})
 			logger := newLogger(buffer)
@@ -75,9 +72,7 @@ func TestInterpreter_Logger_ExecutesCodeAndLogs(t *testing.T) {
 func TestInterpreter_Logger_RunsWithoutOutput(t *testing.T) {
 
 	// Get tosca.Parameters
-	params := tosca.Parameters{
-		Code: []byte{byte(STOP), 0},
-	}
+	params := tosca.Parameters{}
 	code := []Instruction{{STOP, 0}}
 
 	// redirect stdout

--- a/go/interpreter/lfvm/instruction_logger_test.go
+++ b/go/interpreter/lfvm/instruction_logger_test.go
@@ -67,7 +67,7 @@ func TestInterpreter_Logger_ExecutesCodeAndLogs(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 
-			if strings.Compare(string(buffer.String()), test.want) != 0 {
+			if strings.Compare(buffer.String(), test.want) != 0 {
 				t.Errorf("unexpected log: want %v, got %v", test.want, buffer.String())
 			}
 		})

--- a/go/interpreter/lfvm/instruction_logger_test.go
+++ b/go/interpreter/lfvm/instruction_logger_test.go
@@ -51,10 +51,8 @@ func TestInterpreter_Logger_ExecutesCodeAndLogs(t *testing.T) {
 
 			// Get tosca.Parameters
 			params := tosca.Parameters{
-				Input:  []byte{},
-				Static: true,
-				Gas:    3,
-				Code:   []byte{byte(STOP), 0},
+				Gas:  3,
+				Code: []byte{byte(STOP), 0},
 			}
 			code := test.code
 			buffer := bytes.NewBuffer([]byte{})
@@ -78,10 +76,7 @@ func TestInterpreter_Logger_RunsWithoutOutput(t *testing.T) {
 
 	// Get tosca.Parameters
 	params := tosca.Parameters{
-		Input:  []byte{},
-		Static: true,
-		Gas:    10,
-		Code:   []byte{byte(STOP), 0},
+		Code: []byte{byte(STOP), 0},
 	}
 	code := []Instruction{{STOP, 0}}
 
@@ -107,13 +102,19 @@ func TestInterpreter_Logger_RunsWithoutOutput(t *testing.T) {
 	}
 
 	err = wOut.Close()
-	outOut, _ := io.ReadAll(rOut)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	outOut, err := io.ReadAll(rOut)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
 	err = wErr.Close()
-	outErr, _ := io.ReadAll(rErr)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	outErr, err := io.ReadAll(rErr)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/go/interpreter/lfvm/instruction_logger_test.go
+++ b/go/interpreter/lfvm/instruction_logger_test.go
@@ -29,11 +29,20 @@ func TestLogger_ExecutesCodeAndLogs(t *testing.T) {
 		"empty": {},
 		"stop": {
 			code: []Instruction{{STOP, 0}},
-			want: "STOP, 10, -empty-\n",
+			want: "STOP, 3, -empty-\n",
 		},
 		"multiple codes": {
 			code: []Instruction{{PUSH4, 0}, {DATA, 1}, {STOP, 0}},
-			want: "PUSH4, 10, -empty-\nSTOP, 7, 1\n",
+			want: "PUSH4, 3, -empty-\nSTOP, 0, 1\n",
+		},
+		"out of gas": {
+			code: []Instruction{
+				{PUSH1, 0},
+				{PUSH1, 64},
+				{MSTORE8, 0},
+				{STOP, 0},
+			},
+			want: "PUSH1, 3, -empty-\nPUSH1, 0, 0\n",
 		},
 	}
 
@@ -44,7 +53,7 @@ func TestLogger_ExecutesCodeAndLogs(t *testing.T) {
 			params := tosca.Parameters{
 				Input:  []byte{},
 				Static: true,
-				Gas:    10,
+				Gas:    3,
 				Code:   []byte{byte(STOP), 0},
 			}
 			code := test.code

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -156,30 +156,6 @@ func (r vanillaRunner) run(c *context) (status, error) {
 	return steps(c, false)
 }
 
-// loggingRunner is a runner that logs the execution of the contract code to
-// stdout. It is used for debugging purposes.
-type loggingRunner struct{}
-
-func (r loggingRunner) run(c *context) (status, error) {
-	status := statusRunning
-	var err error
-	for status == statusRunning {
-		// log format: <op>, <gas>, <top-of-stack>\n
-		if int(c.pc) < len(c.code) {
-			top := "-empty-"
-			if c.stack.len() > 0 {
-				top = c.stack.peek().ToBig().String()
-			}
-			fmt.Printf("%v, %d, %v\n", c.code[c.pc].opcode, c.gas, top)
-		}
-		status, err = step(c)
-		if err != nil {
-			return status, err
-		}
-	}
-	return status, nil
-}
-
 // --- Execution ---
 
 func step(c *context) (status, error) {

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -86,7 +86,7 @@ func run(
 	code Code,
 ) (tosca.Result, error) {
 	// Don't bother with the execution if there's no code.
-	if len(params.Code) == 0 {
+	if len(code) == 0 {
 		return tosca.Result{
 			Output:  nil,
 			GasLeft: params.Gas,

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -264,43 +264,6 @@ func TestInterpreter_ExecutionTerminates(t *testing.T) {
 	}
 }
 
-func TestInterpreter_Logging_PrintsToSTDOUT(t *testing.T) {
-	code := []Instruction{
-		{PUSH1, 1},
-		{STOP, 0},
-	}
-
-	params := tosca.Parameters{
-		Input:  []byte{},
-		Static: true,
-		Gas:    10,
-		Code:   []byte{0x0},
-	}
-
-	// redirect stdout
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	// Run testing code
-	_, err := run(interpreterConfig{
-		runner: loggingRunner{},
-	}, params, code)
-	// read the output
-	_ = w.Close() // ignore error in test
-	out, _ := io.ReadAll(r)
-	os.Stdout = old
-
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	// check the output
-	if !strings.Contains(string(out), "STOP") {
-		t.Errorf("unexpected output: want STOP, got %v", string(out))
-	}
-}
-
 func TestInterpreter_Vanilla_RunsWithoutOutput(t *testing.T) {
 
 	code := []Instruction{

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -176,54 +176,52 @@ func TestInterpreter_step_DetectsUpperStackLimitViolation(t *testing.T) {
 
 func TestInterpreter_CanDispatchExecutableInstructions(t *testing.T) {
 
-	for _, runner := range []runner{vanillaRunner{}, loggingRunner{}, &statisticRunner{}} {
-		for _, op := range allOpCodesWhere(isExecutable) {
-			t.Run(fmt.Sprintf("%v/%v", runner, op.String()), func(t *testing.T) {
-				forEachRevision(t, op, func(t *testing.T, revision tosca.Revision) {
+	for _, op := range allOpCodesWhere(isExecutable) {
+		t.Run(op.String(), func(t *testing.T) {
+			forEachRevision(t, op, func(t *testing.T, revision tosca.Revision) {
 
-					ctrl := gomock.NewController(t)
-					mock := tosca.NewMockRunContext(ctrl)
-					// mock all to satisfy any instruction
-					mock.EXPECT().AccessAccount(gomock.Any()).Return(tosca.WarmAccess).AnyTimes()
-					mock.EXPECT().GetBalance(gomock.Any()).AnyTimes()
-					mock.EXPECT().IsAddressInAccessList(gomock.Any()).AnyTimes()
-					mock.EXPECT().GetCodeSize(gomock.Any()).AnyTimes()
-					mock.EXPECT().GetCode(gomock.Any()).AnyTimes()
-					mock.EXPECT().AccountExists(gomock.Any()).AnyTimes()
-					mock.EXPECT().AccessStorage(gomock.Any(), gomock.Any()).AnyTimes()
-					mock.EXPECT().GetStorage(gomock.Any(), gomock.Any()).AnyTimes()
-					mock.EXPECT().SetStorage(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-					mock.EXPECT().Call(gomock.Any(), gomock.Any()).AnyTimes()
-					mock.EXPECT().EmitLog(gomock.Any()).AnyTimes()
-					mock.EXPECT().SelfDestruct(gomock.Any(), gomock.Any()).AnyTimes()
-					mock.EXPECT().GetTransientStorage(gomock.Any(), gomock.Any()).AnyTimes()
-					mock.EXPECT().SetTransientStorage(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				ctrl := gomock.NewController(t)
+				mock := tosca.NewMockRunContext(ctrl)
+				// mock all to satisfy any instruction
+				mock.EXPECT().AccessAccount(gomock.Any()).Return(tosca.WarmAccess).AnyTimes()
+				mock.EXPECT().GetBalance(gomock.Any()).AnyTimes()
+				mock.EXPECT().IsAddressInAccessList(gomock.Any()).AnyTimes()
+				mock.EXPECT().GetCodeSize(gomock.Any()).AnyTimes()
+				mock.EXPECT().GetCode(gomock.Any()).AnyTimes()
+				mock.EXPECT().AccountExists(gomock.Any()).AnyTimes()
+				mock.EXPECT().AccessStorage(gomock.Any(), gomock.Any()).AnyTimes()
+				mock.EXPECT().GetStorage(gomock.Any(), gomock.Any()).AnyTimes()
+				mock.EXPECT().SetStorage(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				mock.EXPECT().Call(gomock.Any(), gomock.Any()).AnyTimes()
+				mock.EXPECT().EmitLog(gomock.Any()).AnyTimes()
+				mock.EXPECT().SelfDestruct(gomock.Any(), gomock.Any()).AnyTimes()
+				mock.EXPECT().GetTransientStorage(gomock.Any(), gomock.Any()).AnyTimes()
+				mock.EXPECT().SetTransientStorage(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-					ctx := context{
-						params: tosca.Parameters{
-							BlockParameters: tosca.BlockParameters{
-								Revision: revision,
-							},
+				ctx := context{
+					params: tosca.Parameters{
+						BlockParameters: tosca.BlockParameters{
+							Revision: revision,
 						},
-						context: mock,
-						// enough gas to satisfy any instruction
-						gas:    1 << 32,
-						stack:  NewStack(),
-						memory: NewMemory(),
-						code:   generateCodeFor(op),
-					}
-					err := fillStackFor(op, ctx.stack, ctx.code)
-					if err != nil {
-						t.Fatalf("unexpected creating stack: %v", err)
-					}
+					},
+					context: mock,
+					// enough gas to satisfy any instruction
+					gas:    1 << 32,
+					stack:  NewStack(),
+					memory: NewMemory(),
+					code:   generateCodeFor(op),
+				}
+				err := fillStackFor(op, ctx.stack, ctx.code)
+				if err != nil {
+					t.Fatalf("unexpected creating stack: %v", err)
+				}
 
-					_, err = runner.run(&ctx)
-					if err != nil {
-						t.Errorf("execution failed: %v", err)
-					}
-				})
+				_, err = vanillaRunner{}.run(&ctx)
+				if err != nil {
+					t.Errorf("execution failed: %v", err)
+				}
 			})
-		}
+		})
 	}
 }
 

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -176,9 +176,9 @@ func TestInterpreter_step_DetectsUpperStackLimitViolation(t *testing.T) {
 
 func TestInterpreter_CanDispatchExecutableInstructions(t *testing.T) {
 
-	for _, runner := range []runner{vanillaRunner{}, loggingRunner{}} {
+	for _, runner := range []runner{vanillaRunner{}, loggingRunner{}, &statisticRunner{}} {
 		for _, op := range allOpCodesWhere(isExecutable) {
-			t.Run(op.String(), func(t *testing.T) {
+			t.Run(fmt.Sprintf("%v/%v", runner, op.String()), func(t *testing.T) {
 				forEachRevision(t, op, func(t *testing.T, revision tosca.Revision) {
 
 					ctrl := gomock.NewController(t)

--- a/go/interpreter/lfvm/lfvm.go
+++ b/go/interpreter/lfvm/lfvm.go
@@ -12,6 +12,7 @@ package lfvm
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 )
@@ -60,7 +61,9 @@ func RegisterExperimentalInterpreterConfigurations() error {
 						stats: newStatistics(),
 					}
 				} else if mode == "-logging" {
-					config.runner = loggingRunner{}
+					config.runner = loggingRunner{
+						log: os.Stdout,
+					}
 				}
 
 				name := "lfvm" + si + shaCache + mode


### PR DESCRIPTION
We want to add the flexibility of choosing whether logging should be done to a file or stdout/err.
For this we change the `loggerRunner` to take an `io.Writter` and log in there. If no writter is provided then nothing will be logged. 