### PR TITLE
evmrs: add benchmarks

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -12,10 +12,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstyle"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "benchmarks"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "driver",
+ "evmc-vm",
+ "evmrs",
+]
 
 [[package]]
 name = "bindgen"
@@ -26,7 +48,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -62,6 +84,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e31ea183f6ee62ac8b8a8cf7feddd766317adfb13ff469de57ce033efd6a790"
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +111,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +149,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +181,73 @@ checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -197,6 +350,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,12 +375,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "js-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -312,10 +516,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "predicates"
@@ -372,6 +619,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +687,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +767,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +795,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "web-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +879,15 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,10 +1,14 @@
 [workspace]
-members = ["driver"]
+members = ["driver", "benchmarks"]
 
 [package]
 name = "evmrs"
 version = "0.1.0"
 edition = "2021"
+
+[profile.profiling]
+inherits = "release"
+debug = true
 
 [features]
 # Flag mock enables code generation for test mocking. This allows generating mocks for other build configuration but "test". 

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "benchmarks"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+evmc-vm = { git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
+evmrs = { path = ".." }
+driver = { path = "../driver" }
+
+[dev-dependencies]
+criterion = "0.5.1"
+
+[[bench]]
+name = "interpreter"
+harness = false

--- a/rust/benchmarks/benches/interpreter.rs
+++ b/rust/benchmarks/benches/interpreter.rs
@@ -1,0 +1,21 @@
+/// USAGE:
+/// cargo bench --package benchmarks --profile profiling [--features <feature1,feature2,...>]
+use std::time::Duration;
+
+use benchmarks::RunArgs;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let args = RunArgs::ffi_overhead();
+    c.bench_function("ffi_overhead", |b| b.iter(|| benchmarks::run(&args)));
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_secs(5))
+        .measurement_time(Duration::from_secs(20))
+        .sample_size(1000);
+    targets = criterion_benchmark
+);
+criterion_main!(benches);

--- a/rust/benchmarks/src/lib.rs
+++ b/rust/benchmarks/src/lib.rs
@@ -1,0 +1,67 @@
+#![allow(unused_crate_dependencies)]
+
+use core::slice;
+
+use driver::{self, get_tx_context_zeroed, host_interface::null_ptr_host_interface};
+use evmc_vm::{
+    ffi::{evmc_host_interface, evmc_message},
+    Revision, StatusCode,
+};
+use evmrs::{MockExecutionMessage, Opcode};
+
+pub struct RunArgs {
+    pub host: evmc_host_interface,
+    pub revision: Revision,
+    pub message: evmc_message,
+    pub code: &'static [u8],
+}
+
+impl RunArgs {
+    /// Create arguments for the interpreter that outline the FFI overhead.
+    /// In particular those arguments try to trigger all possible allocations that happen because
+    /// pointers get passed via the FFI interface and then the data is copied into a fresh
+    /// allocation on the other side.
+    /// - `ExecutionMessage` contains non-empty input
+    /// - `code` is non-empty so that `CodeReader` must allocate memory to store the jump analysis
+    ///   results
+    /// - `code` contains `Opcode::MStore` so that `memory` is non-empty
+    /// - `code` returns a single word so that `output` is non-empty
+    pub fn ffi_overhead() -> Self {
+        let mut host = null_ptr_host_interface();
+        host.get_tx_context = Some(get_tx_context_zeroed);
+        let message = MockExecutionMessage {
+            input: Some(&[0]),
+            ..Default::default()
+        };
+
+        Self {
+            host,
+            revision: Revision::EVMC_CANCUN,
+            message: message.to_evmc_message(),
+            code: &[
+                Opcode::Push1 as u8,
+                u8::MAX, // value
+                Opcode::Push1 as u8,
+                0, // offset
+                Opcode::MStore as u8,
+                Opcode::Push1 as u8,
+                32, // len
+                Opcode::Push1 as u8,
+                0, // offset
+                Opcode::Return as u8,
+            ],
+        }
+    }
+}
+
+pub fn run(args: &RunArgs) {
+    // SAFETY:
+    // `host` and `message` are valid pointers since they are created from references. `context`
+    // is a null pointer but this is allowed by the evmc interface as long as the host
+    // interface does not require a valid pointer, which is not the case here.
+    let result = driver::run_with_null_context(&args.host, args.revision, &args.message, args.code);
+    assert_eq!(result.status_code, StatusCode::EVMC_SUCCESS);
+    let output = unsafe { slice::from_raw_parts(result.output_data, result.output_size) };
+    assert_eq!(output[..31], [0; 31]);
+    assert_eq!(output[31..], [u8::MAX; 1]);
+}

--- a/rust/benchmarks/src/main.rs
+++ b/rust/benchmarks/src/main.rs
@@ -1,0 +1,9 @@
+use benchmarks::RunArgs;
+
+fn main() {
+    let args = RunArgs::ffi_overhead();
+    const ITERATIONS: usize = 200_000_000;
+    for _ in 0..ITERATIONS {
+        benchmarks::run(&args);
+    }
+}

--- a/rust/driver/src/lib.rs
+++ b/rust/driver/src/lib.rs
@@ -7,8 +7,6 @@ use evmc_vm::{
     },
     Address, Revision, Uint256,
 };
-#[cfg(feature = "mock")]
-use evmrs::MockExecutionMessage;
 
 pub mod host_interface;
 
@@ -42,26 +40,6 @@ pub const TX_CONTEXT_ZEROED: evmc_tx_context = evmc_tx_context {
 /// The value of the pointer is not used because a constant value is returned.
 pub unsafe extern "C" fn get_tx_context_zeroed(_context: *mut ffi::c_void) -> evmc_tx_context {
     TX_CONTEXT_ZEROED
-}
-
-#[cfg(feature = "mock")]
-pub fn to_evmc_message(message: &MockExecutionMessage) -> evmc_message {
-    evmc_message {
-        kind: message.kind,
-        flags: message.flags,
-        depth: message.depth,
-        gas: message.gas,
-        recipient: message.recipient,
-        sender: message.sender,
-        input_data: message.input.map(<[u8]>::as_ptr).unwrap_or(ptr::null()),
-        input_size: message.input.map(<[u8]>::len).unwrap_or_default(),
-        value: message.value,
-        create2_salt: message.create2_salt,
-        code_address: message.code_address,
-        code: message.code.map(<[u8]>::as_ptr).unwrap_or(ptr::null()),
-        code_size: message.code.map(<[u8]>::len).unwrap_or_default(),
-        code_hash: ptr::null(),
-    }
 }
 
 /// # Safety

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6,6 +6,5 @@ mod types;
 mod utils;
 
 #[cfg(feature = "mock")]
-pub use types::{
-    u256, ExecutionContextTrait, MockExecutionContextTrait, MockExecutionMessage, Opcode,
-};
+pub use types::MockExecutionContextTrait;
+pub use types::{u256, ExecutionContextTrait, MockExecutionMessage, Opcode};

--- a/rust/src/types/mock_execution_message.rs
+++ b/rust/src/types/mock_execution_message.rs
@@ -1,4 +1,6 @@
-use evmc_vm::{Address, ExecutionMessage, MessageKind, Uint256};
+use std::ptr;
+
+use evmc_vm::{ffi::evmc_message, Address, ExecutionMessage, MessageKind, Uint256};
 
 use crate::types::u256;
 
@@ -20,6 +22,25 @@ pub struct MockExecutionMessage<'a> {
 
 impl<'a> MockExecutionMessage<'a> {
     pub const DEFAULT_INIT_GAS: u64 = 1_000_000;
+
+    pub fn to_evmc_message(&self) -> evmc_message {
+        evmc_message {
+            kind: self.kind,
+            flags: self.flags,
+            depth: self.depth,
+            gas: self.gas,
+            recipient: self.recipient,
+            sender: self.sender,
+            input_data: self.input.map(<[u8]>::as_ptr).unwrap_or(ptr::null()),
+            input_size: self.input.map(<[u8]>::len).unwrap_or_default(),
+            value: self.value,
+            create2_salt: self.create2_salt,
+            code_address: self.code_address,
+            code: self.code.map(<[u8]>::as_ptr).unwrap_or(ptr::null()),
+            code_size: self.code.map(<[u8]>::len).unwrap_or_default(),
+            code_hash: ptr::null(),
+        }
+    }
 }
 
 impl<'a> Default for MockExecutionMessage<'a> {

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -2,7 +2,6 @@ mod amount;
 mod code_reader;
 mod execution_context;
 mod memory;
-#[cfg(feature = "mock")]
 mod mock_execution_message;
 mod opcode;
 mod stack;
@@ -12,7 +11,6 @@ pub use amount::u256;
 pub use code_reader::{CodeReader, GetOpcodeError};
 pub use execution_context::*;
 pub use memory::Memory;
-#[cfg(feature = "mock")]
 pub use mock_execution_message::MockExecutionMessage;
 pub use opcode::*;
 pub use stack::Stack;

--- a/rust/tests/ffi.rs
+++ b/rust/tests/ffi.rs
@@ -16,7 +16,7 @@ fn execute_can_be_called_with_mocked_context() {
         .times(1)
         .return_const(TX_CONTEXT_ZEROED);
     let revision = Revision::EVMC_CANCUN;
-    let message = driver::to_evmc_message(&MockExecutionMessage::default());
+    let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[Opcode::Push0 as u8];
     let result = driver::run(&host, &mut context, revision, &message, code);
     assert_eq!(result.status_code, StatusCode::EVMC_SUCCESS);
@@ -27,7 +27,7 @@ fn execute_can_be_called_with_hardcoded_context() {
     let mut host = null_ptr_host_interface();
     host.get_tx_context = Some(get_tx_context_zeroed);
     let revision = Revision::EVMC_CANCUN;
-    let message = driver::to_evmc_message(&MockExecutionMessage::default());
+    let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[Opcode::Push0 as u8];
     let result = driver::run_with_null_context(&host, revision, &message, code);
     assert_eq!(result.status_code, StatusCode::EVMC_SUCCESS);
@@ -38,7 +38,7 @@ fn execute_can_be_called_with_empty_code() {
     let mut host = null_ptr_host_interface();
     host.get_tx_context = Some(get_tx_context_zeroed);
     let revision = Revision::EVMC_CANCUN;
-    let message = driver::to_evmc_message(&MockExecutionMessage::default());
+    let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[];
     let result = driver::run_with_null_context(&host, revision, &message, code);
     assert_eq!(result.status_code, StatusCode::EVMC_SUCCESS);
@@ -49,7 +49,7 @@ fn execute_handles_error_correctly() {
     let mut host = null_ptr_host_interface();
     host.get_tx_context = Some(get_tx_context_zeroed);
     let revision = Revision::EVMC_CANCUN;
-    let message = driver::to_evmc_message(&MockExecutionMessage::default());
+    let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[Opcode::Add as u8]; // this will error because the stack is empty
     let result = driver::run_with_null_context(&host, revision, &message, code);
     assert_eq!(result.status_code, StatusCode::EVMC_STACK_UNDERFLOW);
@@ -64,7 +64,7 @@ fn step_n_can_be_called_with_mocked_context() {
         .times(1)
         .return_const(TX_CONTEXT_ZEROED);
     let revision = Revision::EVMC_CANCUN;
-    let message = driver::to_evmc_message(&MockExecutionMessage::default());
+    let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[Opcode::Push0 as u8];
     let result = driver::run_steppable(
         &host,
@@ -89,7 +89,7 @@ fn step_n_can_be_called_with_hardcoded_context() {
     let mut host = null_ptr_host_interface();
     host.get_tx_context = Some(get_tx_context_zeroed);
     let revision = Revision::EVMC_CANCUN;
-    let message = driver::to_evmc_message(&MockExecutionMessage::default());
+    let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[Opcode::Push0 as u8];
     let result = driver::run_steppable_with_null_context(
         &host,
@@ -113,7 +113,7 @@ fn step_n_can_be_called_with_empty_code_and_stack_and_memory_and_last_call_resul
     let mut host = null_ptr_host_interface();
     host.get_tx_context = Some(get_tx_context_zeroed);
     let revision = Revision::EVMC_CANCUN;
-    let message = driver::to_evmc_message(&MockExecutionMessage::default());
+    let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[];
     let result = driver::run_steppable_with_null_context(
         &host,
@@ -137,7 +137,7 @@ fn step_n_handles_error_correctly() {
     let mut host = null_ptr_host_interface();
     host.get_tx_context = Some(get_tx_context_zeroed);
     let revision = Revision::EVMC_CANCUN;
-    let message = driver::to_evmc_message(&MockExecutionMessage::default());
+    let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[Opcode::Add as u8]; // this will error because the stack is empty
     let result = driver::run_steppable_with_null_context(
         &host,


### PR DESCRIPTION
This PR adds the `benchmarks` which contains benchmarks (currently only `ffi_overhead`) for calling from Rust via FFI into evmrs.

The benchmarks can be used in two ways:
- with criterion to compare different features:
  `cargo bench --package benchmarks --profile profiling [--features <feature1>,<feature2>,...]`
- as a standalone executable for profiling
  `cargo build --package benchmarks --profile profiling [--features <feature1>,<feature2>,...]`
  then use `./target/profiling/benchmarks` with the profiler of your choice