### PR TITLE
LFVM Differentiate logic errors from execution errors

### DIFF
--- a/go/interpreter/lfvm/ct_test.go
+++ b/go/interpreter/lfvm/ct_test.go
@@ -67,6 +67,7 @@ func TestConvertToLfvm_StatusCode(t *testing.T) {
 		statusReturned:       st.Stopped,
 		statusStopped:        st.Stopped,
 		statusSelfDestructed: st.Stopped,
+		statusFailed:         st.Failed,
 	}
 
 	for status, test := range tests {
@@ -81,7 +82,7 @@ func TestConvertToLfvm_StatusCode(t *testing.T) {
 }
 
 func TestConvertToLfvm_StatusCodeFailsOnUnknownStatus(t *testing.T) {
-	_, err := convertLfvmStatusToCtStatus(statusSelfDestructed + 1)
+	_, err := convertLfvmStatusToCtStatus(statusFailed + 1)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}

--- a/go/interpreter/lfvm/instruction_logger.go
+++ b/go/interpreter/lfvm/instruction_logger.go
@@ -40,7 +40,6 @@ func (l loggingRunner) run(c *context) (status, error) {
 			if l.log != nil {
 				_, err = l.log.Write([]byte(fmt.Sprintf("%v, %d, %v\n", c.code[c.pc].opcode, c.gas, top)))
 				if err != nil {
-					// TODO: rework this error to be handled differently than step errors
 					return status, err
 				}
 			}

--- a/go/interpreter/lfvm/instruction_logger.go
+++ b/go/interpreter/lfvm/instruction_logger.go
@@ -45,10 +45,7 @@ func (l loggingRunner) run(c *context) (status, error) {
 				}
 			}
 		}
-		status, err = step(c)
-		if err != nil {
-			return status, err
-		}
+		status = execute(c, true)
 	}
 	return status, nil
 }

--- a/go/interpreter/lfvm/instruction_statistics.go
+++ b/go/interpreter/lfvm/instruction_statistics.go
@@ -27,15 +27,11 @@ type statisticRunner struct {
 func (s *statisticRunner) run(c *context) (status, error) {
 	stats := statsCollector{stats: newStatistics()}
 	status := statusRunning
-	var executionError error
 	for status == statusRunning {
 		if c.pc < int32(len(c.code)) {
 			stats.nextOp(c.code[c.pc].opcode)
 		}
-		status, executionError = step(c)
-		if executionError != nil {
-			break
-		}
+		status = execute(c, true)
 	}
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
@@ -43,7 +39,7 @@ func (s *statisticRunner) run(c *context) (status, error) {
 		s.stats = newStatistics()
 	}
 	s.stats.insert(stats.stats)
-	return status, executionError
+	return status, nil
 }
 
 // getSummary returns a summary of the collected statistics in a human-readable

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -551,6 +551,22 @@ func TestInterpreter_InstructionsFailWhenExecutedInRevisionsEarlierThanIntroduce
 	}
 }
 
+func TestInterpreter_ExecuteReturnsFailureOnExecutionError(t *testing.T) {
+
+	ctxt := context{
+		code:  generateCodeFor(INVALID),
+		stack: NewStack(),
+	}
+
+	status := execute(&ctxt, false)
+	if want, got := statusFailed, status; want != got {
+		t.Errorf("unexpected status: want %v, got %v", want, got)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Benchmarks
+
 func BenchmarkFib10(b *testing.B) {
 	benchmarkFib(b, 10, false)
 }
@@ -797,18 +813,5 @@ func forEachRevision(
 		t.Run(revision.String(), func(t *testing.T) {
 			f(t, revision)
 		})
-	}
-}
-
-func TestInterpreter_ExecuteReturnsFailureOnExecutionError(t *testing.T) {
-
-	ctxt := context{
-		code:  generateCodeFor(INVALID),
-		stack: NewStack(),
-	}
-
-	status := execute(&ctxt, false)
-	if want, got := statusFailed, status; want != got {
-		t.Errorf("unexpected status: want %v, got %v", want, got)
 	}
 }

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -241,19 +241,19 @@ func TestInterpreter_ExecutionTerminates(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 
-			c := getEmptyContext()
-			c.code = test.code
-			c.stack.push(uint256.NewInt(1))
-			c.stack.push(uint256.NewInt(2))
-			c.stack.push(uint256.NewInt(3))
+			ctxt := getEmptyContext()
+			ctxt.code = test.code
+			ctxt.stack.push(uint256.NewInt(1))
+			ctxt.stack.push(uint256.NewInt(2))
+			ctxt.stack.push(uint256.NewInt(3))
 			// runcontext is needed for selfdestruct
 			mockContext := tosca.NewMockRunContext(gomock.NewController(t))
 			mockContext.EXPECT().AccountExists(gomock.Any()).Return(true).AnyTimes()
 			mockContext.EXPECT().GetBalance(gomock.Any()).Return(tosca.Value{1}).AnyTimes()
 			mockContext.EXPECT().SelfDestruct(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-			c.context = mockContext
+			ctxt.context = mockContext
 
-			status, err := steps(&c, false)
+			status, err := steps(&ctxt, false)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -361,6 +361,12 @@ func TestRun_GenerateResult(t *testing.T) {
 				Output:    nil,
 				GasLeft:   baseGas,
 				GasRefund: baseRefund,
+			},
+		},
+		"failure": {
+			status: statusFailed,
+			expectedResult: tosca.Result{
+				Success: false,
 			},
 		},
 		"unknown status": {

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -370,8 +370,8 @@ func TestRun_GenerateResult(t *testing.T) {
 			},
 		},
 		"unknown status": {
-			status:         statusSelfDestructed + 1,
-			expectedErr:    fmt.Errorf("unexpected error in interpreter, unknown status: %v", statusSelfDestructed+1),
+			status:         statusFailed + 1,
+			expectedErr:    fmt.Errorf("unexpected error in interpreter, unknown status: %v", statusFailed+1),
 			expectedResult: tosca.Result{},
 		},
 	}
@@ -386,7 +386,7 @@ func TestRun_GenerateResult(t *testing.T) {
 
 			res, err := generateResult(test.status, &ctxt)
 
-			if err != nil && test.expectedErr != nil && strings.Compare(err.Error(), test.expectedErr.Error()) != 0 {
+			if test.expectedErr != nil && strings.Compare(err.Error(), test.expectedErr.Error()) != 0 {
 				t.Errorf("unexpected error: want \"%v\", got \"%v\"", test.expectedErr, err)
 			}
 			if !reflect.DeepEqual(res, test.expectedResult) {

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -13,6 +13,7 @@ package lfvm
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -313,6 +314,23 @@ func TestInterpreter_EmptyCodeBypassesRunnerAndSucceeds(t *testing.T) {
 
 	if !result.Success {
 		t.Errorf("unexpected result: want success, got %v", result.Success)
+	}
+}
+
+func TestInterpreter_run_ReturnsErrorOnRuntimeError(t *testing.T) {
+
+	runner := NewMockrunner(gomock.NewController(t))
+	code := []Instruction{{JUMPDEST, 0}}
+	params := tosca.Parameters{Gas: 20}
+	config := interpreterConfig{runner: runner}
+
+	expectedError := fmt.Errorf("runtime error")
+
+	runner.EXPECT().run(gomock.Any()).Return(statusFailed, expectedError)
+
+	_, err := run(config, params, code)
+	if !errors.Is(err, expectedError) {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -799,3 +799,16 @@ func forEachRevision(
 		})
 	}
 }
+
+func TestInterpreter_ExecuteReturnsFailureOnExecutionError(t *testing.T) {
+
+	ctxt := context{
+		code:  generateCodeFor(INVALID),
+		stack: NewStack(),
+	}
+
+	status := execute(&ctxt, false)
+	if want, got := statusFailed, status; want != got {
+		t.Errorf("unexpected status: want %v, got %v", want, got)
+	}
+}


### PR DESCRIPTION
This is a minimal change that addresses the problem detected in #818. 
The issue being the impossibility to differentiate logical errors (execution violations, program errors) that turn into a failed but still valid execution from runtime errors that are outside from the domain of valid executions (namely the possibility of not being able to write into the file when logging an execution) 

This PR is intentional minimal because there are many helper tools inside the VM using errors to flag execution violations and the error type is the most convenient way to do such. 
alternatives considered were:
- use an enum type for VM logical errors: this would have needed a successful default value and replace all the comparisons `!= nul` with `!= Ok`, Changes would be large, code will be verbose, and future changes could modify states. 
- move error codes into status like evmc does:  this would require writing status and forwarding current status in many places or to do a context status variable again. I consider the latter very error-prone and would like to avoid it.
- Use an error like type which is not error:  nullable to repeat patterns, but incompatible with standard error. This seems quite ad-hoc to me, after all the error type does exactly that. 

The current change defines a boundary function between the VM where only logic errors can happen, and an external interface where status (maybe failure)  or a runtime error can be returned. As long as the VM cannot return a runtime error (current case)  this change keeps the error propagation inside the gas/memory/call routines idiomatic and easy to understand. 
