### PR TITLE
CT: Temporary fix for PC on data

### DIFF
--- a/go/ct/driver/run.go
+++ b/go/ct/driver/run.go
@@ -110,9 +110,9 @@ func doRun(context *cli.Context) error {
 			return rlz.ConsumeAbort
 		}
 
-		// TODO: program counter pointing to data not supported by LFVM
-		// converter. Fix this.
-		if evmIdentifier == "lfvm" && !state.Code.IsCode(int(state.Pc)) {
+		// TODO: do not only skip state but change 'pc_on_data_is_ignored' rule to anyEffect
+		// Pc on data is not supported
+		if !state.Code.IsCode(int(state.Pc)) {
 			skippedCount.Add(1)
 			return rlz.ConsumeContinue
 		}


### PR DESCRIPTION
This PR adds a temporary fix for the failed cases when the PC points to data, founded in #660.
In the future, this should not be ignored in the runner but rather the specification rule should be updated.