### PR TITLE
evmrs: create vm instance only once in driver

### DIFF
--- a/rust/benchmarks/benches/interpreter.rs
+++ b/rust/benchmarks/benches/interpreter.rs
@@ -6,8 +6,8 @@ use benchmarks::RunArgs;
 use criterion::{criterion_group, criterion_main, Criterion};
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let args = RunArgs::ffi_overhead();
-    c.bench_function("ffi_overhead", |b| b.iter(|| benchmarks::run(&args)));
+    let mut args = RunArgs::ffi_overhead();
+    c.bench_function("ffi_overhead", |b| b.iter(|| benchmarks::run(&mut args)));
 }
 
 criterion_group!(

--- a/rust/benchmarks/src/main.rs
+++ b/rust/benchmarks/src/main.rs
@@ -1,9 +1,9 @@
 use benchmarks::RunArgs;
 
 fn main() {
-    let args = RunArgs::ffi_overhead();
+    let mut args = RunArgs::ffi_overhead();
     const ITERATIONS: usize = 200_000_000;
     for _ in 0..ITERATIONS {
-        benchmarks::run(&args);
+        benchmarks::run(&mut args);
     }
 }

--- a/rust/driver/src/lib.rs
+++ b/rust/driver/src/lib.rs
@@ -1,4 +1,8 @@
-use std::{ffi, ptr};
+use std::{
+    ffi,
+    ops::{Deref, DerefMut},
+    ptr,
+};
 
 use evmc_vm::{
     ffi::{
@@ -11,8 +15,8 @@ use evmc_vm::{
 pub mod host_interface;
 
 extern "C" {
-    fn evmc_create_evmrs() -> *const evmc_vm_t;
-    fn evmc_create_steppable_evmrs() -> *const evmc_vm_steppable;
+    fn evmc_create_evmrs() -> *mut evmc_vm_t;
+    fn evmc_create_steppable_evmrs() -> *mut evmc_vm_steppable;
 }
 
 pub const ZERO: Uint256 = Uint256 { bytes: [0; 32] };
@@ -42,123 +46,210 @@ pub unsafe extern "C" fn get_tx_context_zeroed(_context: *mut ffi::c_void) -> ev
     TX_CONTEXT_ZEROED
 }
 
-/// # Safety
-///
-/// All pointers must be valid, except for `context` which can be null if the `evmc_host_interface`
-/// accepts null pointers as context.
-pub unsafe fn run_raw(
-    host: *const evmc_host_interface,
-    context: *mut ffi::c_void,
-    revision: Revision,
-    message: *const evmc_message,
-    code: *const u8,
-    code_len: usize,
-) -> evmc_result {
-    let instance = evmc_create_evmrs();
-    if instance.is_null() {
-        panic!("vm instance is null")
+pub struct Instance(&'static mut evmc_vm_t);
+
+impl Deref for Instance {
+    type Target = evmc_vm_t;
+    fn deref(&self) -> &Self::Target {
+        self.0
     }
-    // SAFETY:
-    // `instance is not null`. `evmc_create_evmrs` must return a valid pointer to an `evmc_vm_t`.
-    let instance = unsafe { &mut *(instance as *mut evmc_vm_t) };
-
-    let execute = instance.execute.unwrap();
-    let destroy = instance.destroy.unwrap();
-
-    let result = unsafe { execute(instance, host, context, revision, message, code, code_len) };
-
-    unsafe {
-        destroy(instance);
-    }
-
-    result
 }
 
-pub fn run<T>(
-    host: &evmc_host_interface,
-    context: &mut T,
-    revision: Revision,
-    message: &evmc_message,
-    code: &[u8],
-) -> evmc_result {
-    // SAFETY:
-    // All pointer are valid since they are created from references.
-    unsafe {
-        run_raw(
+impl DerefMut for Instance {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0
+    }
+}
+
+impl Default for Instance {
+    fn default() -> Self {
+        // SAFETY:
+        // `evmc_create_evmrs` must return a valid pointer to an `evmc_vm_t`.
+        let instance = unsafe { evmc_create_evmrs() };
+        if instance.is_null() {
+            panic!("failed to construct evmrs instance")
+        }
+        // SAFETY:
+        // `instance is not null`. `evmc_create_evmrs` must return a valid pointer to an
+        // `evmc_vm_t`.
+        let instance = unsafe { &mut *instance };
+        Self(instance)
+    }
+}
+
+impl Drop for Instance {
+    fn drop(&mut self) {
+        let destroy = self.0.destroy.unwrap();
+        // SAFETY:
+        // The supplied pointer to `evmc_vm_t` is valid because it is created from a reference;
+        unsafe { destroy(self.0) };
+    }
+}
+
+impl Instance {
+    /// Run the interpreter (the `execute` function) with the supplied values. This function is
+    /// unsafe because it takes raw pointers. It intended to be used to verify that the checks in
+    /// the ffi module work as intended.
+    ///
+    /// # Safety
+    ///
+    /// All pointers must be valid, except for `context` which can be null if the
+    /// `evmc_host_interface` accepts null pointers as context.
+    pub unsafe fn run_raw(
+        &mut self,
+        host: *const evmc_host_interface,
+        context: *mut ffi::c_void,
+        revision: Revision,
+        message: *const evmc_message,
+        code: *const u8,
+        code_len: usize,
+    ) -> evmc_result {
+        let execute = self.execute.unwrap();
+
+        execute(
+            &mut **self,
             host,
-            context as *mut T as *mut ffi::c_void,
+            context,
             revision,
             message,
-            if code.is_empty() {
-                ptr::null()
-            } else {
-                code.as_ptr()
-            },
-            code.len(),
+            code,
+            code_len,
         )
+    }
+
+    /// Run the interpreter (the `execute` function) with the supplied values. This is a safe
+    /// wrapper around `Instance::run_raw` which takes references and therefore does not allow null
+    /// pointers to be passed.
+    pub fn run<T>(
+        &mut self,
+        host: &evmc_host_interface,
+        context: &mut T,
+        revision: Revision,
+        message: &evmc_message,
+        code: &[u8],
+    ) -> evmc_result {
+        // SAFETY:
+        // All pointer are valid since they are created from references.
+        unsafe {
+            self.run_raw(
+                host,
+                context as *mut T as *mut ffi::c_void,
+                revision,
+                message,
+                if code.is_empty() {
+                    ptr::null()
+                } else {
+                    code.as_ptr()
+                },
+                code.len(),
+            )
+        }
+    }
+
+    /// Run the interpreter (the `execute` function) with the supplied values. This is a safe
+    /// wrapper around `Instance::run_raw` which takes references and therefore does not allow null
+    /// pointers to be passed. Unlike `Instance::run` this function uses a null pointer as context.
+    pub fn run_with_null_context(
+        &mut self,
+        host: &evmc_host_interface,
+        revision: Revision,
+        message: &evmc_message,
+        code: &[u8],
+    ) -> evmc_result {
+        // SAFETY:
+        // All pointer are valid since they are created from references except for `context` which
+        // is allowed to be null.
+        unsafe {
+            self.run_raw(
+                host,
+                ptr::null_mut(),
+                revision,
+                message,
+                if code.is_empty() {
+                    ptr::null()
+                } else {
+                    code.as_ptr()
+                },
+                code.len(),
+            )
+        }
     }
 }
 
-pub fn run_with_null_context(
-    host: &evmc_host_interface,
-    revision: Revision,
-    message: &evmc_message,
-    code: &[u8],
-) -> evmc_result {
-    // SAFETY:
-    // All pointer are valid since they are created from references except for `context` which is
-    // allowed to be null.
-    unsafe {
-        run_raw(
-            host,
-            ptr::null_mut(),
-            revision,
-            message,
-            if code.is_empty() {
-                ptr::null()
-            } else {
-                code.as_ptr()
-            },
-            code.len(),
-        )
+pub struct SteppableInstance(&'static mut evmc_vm_steppable);
+
+impl Deref for SteppableInstance {
+    type Target = evmc_vm_steppable;
+    fn deref(&self) -> &Self::Target {
+        self.0
     }
 }
 
-/// # Safety
-///
-/// All pointers must be valid, except for `context` which can be null if the `evmc_host_interface`
-/// accepts null pointers as context.
-#[allow(clippy::too_many_arguments)]
-pub unsafe fn run_steppable_raw(
-    host: *const evmc_host_interface,
-    context: *mut ffi::c_void,
-    revision: Revision,
-    message: *const evmc_message,
-    code: *const u8,
-    code_len: usize,
-    status: evmc_step_status_code,
-    pc: u64,
-    gas_refunds: i64,
-    stack: *mut Uint256,
-    stack_len: usize,
-    memory: *mut u8,
-    memory_len: usize,
-    last_call_result_data: *mut u8,
-    last_call_result_data_len: usize,
-    steps: i32,
-) -> evmc_step_result {
-    let instance = evmc_create_steppable_evmrs();
-    if instance.is_null() {
-        panic!("vm instance is null")
+impl DerefMut for SteppableInstance {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0
     }
-    let instance = unsafe { &mut *(instance as *mut evmc_vm_steppable) };
+}
 
-    let step_n = instance.step_n.unwrap();
-    let destroy = instance.destroy.unwrap();
+impl Default for SteppableInstance {
+    fn default() -> Self {
+        // SAFETY:
+        // `evmc_create_steppable_evmrs` must return a valid pointer to an `evmc_vm_steppable`.
+        let instance = unsafe { evmc_create_steppable_evmrs() };
+        if instance.is_null() {
+            panic!("vm instance is null")
+        }
+        // SAFETY:
+        // `instance is not null`. `evmc_create_steppable_evmrs` must return a valid pointer to an
+        // `evmc_vm_steppable`.
+        let instance = unsafe { &mut *instance };
+        Self(instance)
+    }
+}
 
-    let result = unsafe {
+impl Drop for SteppableInstance {
+    fn drop(&mut self) {
+        let destroy = self.0.destroy.unwrap();
+        // SAFETY:
+        // The supplied pointer to `evmc_vm_steppable` is valid because it is created from a
+        // reference;
+        unsafe { destroy(self.0) };
+    }
+}
+
+impl SteppableInstance {
+    /// Run the interpreter (the `step_n` function) with the supplied values. This function is
+    /// unsafe because it takes raw pointers. It intended to be used to verify that the checks in
+    /// the ffi module work as intended.
+    ///
+    /// # Safety
+    ///
+    /// All pointers must be valid, except for `context` which can be null if the
+    /// `evmc_host_interface` accepts null pointers as context.
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn run_raw(
+        &mut self,
+        host: *const evmc_host_interface,
+        context: *mut ffi::c_void,
+        revision: Revision,
+        message: *const evmc_message,
+        code: *const u8,
+        code_len: usize,
+        status: evmc_step_status_code,
+        pc: u64,
+        gas_refunds: i64,
+        stack: *mut Uint256,
+        stack_len: usize,
+        memory: *mut u8,
+        memory_len: usize,
+        last_call_result_data: *mut u8,
+        last_call_result_data_len: usize,
+        steps: i32,
+    ) -> evmc_step_result {
+        let step_n = self.step_n.unwrap();
+
         step_n(
-            instance,
+            &mut **self,
             host,
             context,
             revision,
@@ -176,121 +267,124 @@ pub unsafe fn run_steppable_raw(
             last_call_result_data_len,
             steps,
         )
-    };
-
-    unsafe {
-        destroy(instance);
     }
 
-    result
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn run_steppable<T>(
-    host: &evmc_host_interface,
-    context: &mut T,
-    revision: Revision,
-    message: &evmc_message,
-    code: &[u8],
-    status: evmc_step_status_code,
-    pc: u64,
-    gas_refunds: i64,
-    stack: &mut [Uint256],
-    memory: &mut [u8],
-    last_call_result_data: &mut [u8],
-    steps: i32,
-) -> evmc_step_result {
-    // SAFETY:
-    // All pointer are valid since they are created from references.
-    unsafe {
-        run_steppable_raw(
-            host,
-            context as *mut T as *mut ffi::c_void,
-            revision,
-            message,
-            if code.is_empty() {
-                ptr::null()
-            } else {
-                code.as_ptr()
-            },
-            code.len(),
-            status,
-            pc,
-            gas_refunds,
-            if stack.is_empty() {
-                ptr::null_mut()
-            } else {
-                stack.as_mut_ptr()
-            },
-            stack.len(),
-            if memory.is_empty() {
-                ptr::null_mut()
-            } else {
-                memory.as_mut_ptr()
-            },
-            memory.len(),
-            if last_call_result_data.is_empty() {
-                ptr::null_mut()
-            } else {
-                last_call_result_data.as_mut_ptr()
-            },
-            last_call_result_data.len(),
-            steps,
-        )
+    /// Run the interpreter (the `step_n` function) with the supplied values. This is a safe
+    /// wrapper around `SteppableInstance::run_raw` which takes references and therefore
+    /// does not allow null pointers to be passed.
+    #[allow(clippy::too_many_arguments)]
+    pub fn run<T>(
+        &mut self,
+        host: &evmc_host_interface,
+        context: &mut T,
+        revision: Revision,
+        message: &evmc_message,
+        code: &[u8],
+        status: evmc_step_status_code,
+        pc: u64,
+        gas_refunds: i64,
+        stack: &mut [Uint256],
+        memory: &mut [u8],
+        last_call_result_data: &mut [u8],
+        steps: i32,
+    ) -> evmc_step_result {
+        // SAFETY:
+        // All pointer are valid since they are created from references.
+        unsafe {
+            self.run_raw(
+                host,
+                context as *mut T as *mut ffi::c_void,
+                revision,
+                message,
+                if code.is_empty() {
+                    ptr::null()
+                } else {
+                    code.as_ptr()
+                },
+                code.len(),
+                status,
+                pc,
+                gas_refunds,
+                if stack.is_empty() {
+                    ptr::null_mut()
+                } else {
+                    stack.as_mut_ptr()
+                },
+                stack.len(),
+                if memory.is_empty() {
+                    ptr::null_mut()
+                } else {
+                    memory.as_mut_ptr()
+                },
+                memory.len(),
+                if last_call_result_data.is_empty() {
+                    ptr::null_mut()
+                } else {
+                    last_call_result_data.as_mut_ptr()
+                },
+                last_call_result_data.len(),
+                steps,
+            )
+        }
     }
-}
 
-#[allow(clippy::too_many_arguments)]
-pub fn run_steppable_with_null_context(
-    host: &evmc_host_interface,
-    revision: Revision,
-    message: &evmc_message,
-    code: &[u8],
-    status: evmc_step_status_code,
-    pc: u64,
-    gas_refunds: i64,
-    stack: &mut [Uint256],
-    memory: &mut [u8],
-    last_call_result_data: &mut [u8],
-    steps: i32,
-) -> evmc_step_result {
-    // SAFETY:
-    // All pointer are valid since they are created from references except for `context` which is
-    // allowed to be null.
-    unsafe {
-        run_steppable_raw(
-            host,
-            ptr::null_mut(),
-            revision,
-            message,
-            if code.is_empty() {
-                ptr::null()
-            } else {
-                code.as_ptr()
-            },
-            code.len(),
-            status,
-            pc,
-            gas_refunds,
-            if stack.is_empty() {
-                ptr::null_mut()
-            } else {
-                stack.as_mut_ptr()
-            },
-            stack.len(),
-            if memory.is_empty() {
-                ptr::null_mut()
-            } else {
-                memory.as_mut_ptr()
-            },
-            memory.len(),
-            if last_call_result_data.is_empty() {
-                ptr::null_mut()
-            } else {
-                last_call_result_data.as_mut_ptr()
-            },
-            last_call_result_data.len(),
-            steps,
-        )
+    /// Run the interpreter (the `step_n` function) with the supplied values. This is a safe
+    /// wrapper around `SteppableInstance::run_raw` which takes references and therefore
+    /// does not allow null pointers to be passed. Unlike `SteppableInstance::run` this function
+    /// uses a null pointer as context.
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_with_null_context(
+        &mut self,
+        host: &evmc_host_interface,
+        revision: Revision,
+        message: &evmc_message,
+        code: &[u8],
+        status: evmc_step_status_code,
+        pc: u64,
+        gas_refunds: i64,
+        stack: &mut [Uint256],
+        memory: &mut [u8],
+        last_call_result_data: &mut [u8],
+        steps: i32,
+    ) -> evmc_step_result {
+        // SAFETY:
+        // All pointer are valid since they are created from references except for `context` which
+        // is allowed to be null.
+        unsafe {
+            self.run_raw(
+                host,
+                ptr::null_mut(),
+                revision,
+                message,
+                if code.is_empty() {
+                    ptr::null()
+                } else {
+                    code.as_ptr()
+                },
+                code.len(),
+                status,
+                pc,
+                gas_refunds,
+                if stack.is_empty() {
+                    ptr::null_mut()
+                } else {
+                    stack.as_mut_ptr()
+                },
+                stack.len(),
+                if memory.is_empty() {
+                    ptr::null_mut()
+                } else {
+                    memory.as_mut_ptr()
+                },
+                memory.len(),
+                if last_call_result_data.is_empty() {
+                    ptr::null_mut()
+                } else {
+                    last_call_result_data.as_mut_ptr()
+                },
+                last_call_result_data.len(),
+                steps,
+            )
+        }
     }
 }

--- a/rust/src/ffi/evmc_vm.rs
+++ b/rust/src/ffi/evmc_vm.rs
@@ -79,7 +79,7 @@ extern "C" fn __evmc_set_option(
 }
 
 #[no_mangle]
-pub(super) extern "C" fn evmc_create_evmrs() -> *const evmc_vm_t {
+pub(super) extern "C" fn evmc_create_evmrs() -> *mut evmc_vm_t {
     let new_instance = evmc_vm_t {
         abi_version: EVMC_ABI_VERSION as i32,
         destroy: Some(__evmc_destroy),
@@ -187,7 +187,7 @@ extern "C" fn __evmc_execute(
 
 #[cfg(test)]
 mod tests {
-    use evmc_vm::ffi::{evmc_capabilities_flagset, evmc_set_option_result, evmc_vm as evmc_vm_t};
+    use evmc_vm::ffi::{evmc_capabilities_flagset, evmc_set_option_result};
 
     use crate::ffi::{
         evmc_vm::{__evmc_destroy, __evmc_get_capabilities, __evmc_set_option, evmc_create_evmrs},
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn create_set_option_destroy() {
-        let vm = evmc_create_evmrs() as *mut evmc_vm_t;
+        let vm = evmc_create_evmrs();
         assert_eq!(
             __evmc_get_capabilities(vm),
             EVMC_CAPABILITY as evmc_capabilities_flagset

--- a/rust/src/ffi/steppable_evmc_vm.rs
+++ b/rust/src/ffi/steppable_evmc_vm.rs
@@ -3,7 +3,7 @@ use std::{ffi::c_void, panic, slice};
 use ::evmc_vm::{
     ffi::{
         evmc_bytes32, evmc_capabilities, evmc_host_interface, evmc_message, evmc_revision,
-        evmc_step_result, evmc_step_status_code, evmc_vm as evmc_vm_t, evmc_vm_steppable,
+        evmc_step_result, evmc_step_status_code, evmc_vm_steppable,
     },
     ExecutionContext, ExecutionMessage, StatusCode, StepResult, StepStatusCode,
     SteppableEvmcContainer, SteppableEvmcVm,
@@ -15,9 +15,9 @@ use crate::{
 };
 
 #[no_mangle]
-extern "C" fn evmc_create_steppable_evmrs() -> *const evmc_vm_steppable {
+extern "C" fn evmc_create_steppable_evmrs() -> *mut evmc_vm_steppable {
     let new_instance = evmc_vm_steppable {
-        vm: evmc_vm::evmc_create_evmrs() as *mut evmc_vm_t,
+        vm: evmc_vm::evmc_create_evmrs(),
         step_n: Some(__evmc_step_n),
         destroy: Some(__evmc_steppable_destroy),
     };
@@ -172,13 +172,11 @@ extern "C" fn __evmc_step_n(
 
 #[cfg(test)]
 mod tests {
-    use evmc_vm::ffi::evmc_vm_steppable;
-
     use crate::ffi::steppable_evmc_vm::{__evmc_steppable_destroy, evmc_create_steppable_evmrs};
 
     #[test]
     fn create_destroy() {
-        let vm = evmc_create_steppable_evmrs() as *mut evmc_vm_steppable;
+        let vm = evmc_create_steppable_evmrs();
         __evmc_steppable_destroy(vm);
     }
 }

--- a/rust/tests/ffi.rs
+++ b/rust/tests/ffi.rs
@@ -2,13 +2,14 @@
 use driver::{
     get_tx_context_zeroed,
     host_interface::{self, null_ptr_host_interface},
-    TX_CONTEXT_ZEROED, ZERO,
+    Instance, SteppableInstance, TX_CONTEXT_ZEROED, ZERO,
 };
 use evmc_vm::{Revision, StatusCode, StepStatusCode};
 use evmrs::{MockExecutionContextTrait, MockExecutionMessage, Opcode};
 
 #[test]
 fn execute_can_be_called_with_mocked_context() {
+    let mut instance = Instance::default();
     let host = host_interface::mocked_host_interface();
     let mut context = MockExecutionContextTrait::new();
     context
@@ -18,45 +19,49 @@ fn execute_can_be_called_with_mocked_context() {
     let revision = Revision::EVMC_CANCUN;
     let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[Opcode::Push0 as u8];
-    let result = driver::run(&host, &mut context, revision, &message, code);
+    let result = instance.run(&host, &mut context, revision, &message, code);
     assert_eq!(result.status_code, StatusCode::EVMC_SUCCESS);
 }
 
 #[test]
 fn execute_can_be_called_with_hardcoded_context() {
+    let mut instance = Instance::default();
     let mut host = null_ptr_host_interface();
     host.get_tx_context = Some(get_tx_context_zeroed);
     let revision = Revision::EVMC_CANCUN;
     let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[Opcode::Push0 as u8];
-    let result = driver::run_with_null_context(&host, revision, &message, code);
+    let result = instance.run_with_null_context(&host, revision, &message, code);
     assert_eq!(result.status_code, StatusCode::EVMC_SUCCESS);
 }
 
 #[test]
 fn execute_can_be_called_with_empty_code() {
+    let mut instance = Instance::default();
     let mut host = null_ptr_host_interface();
     host.get_tx_context = Some(get_tx_context_zeroed);
     let revision = Revision::EVMC_CANCUN;
     let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[];
-    let result = driver::run_with_null_context(&host, revision, &message, code);
+    let result = instance.run_with_null_context(&host, revision, &message, code);
     assert_eq!(result.status_code, StatusCode::EVMC_SUCCESS);
 }
 
 #[test]
 fn execute_handles_error_correctly() {
+    let mut instance = Instance::default();
     let mut host = null_ptr_host_interface();
     host.get_tx_context = Some(get_tx_context_zeroed);
     let revision = Revision::EVMC_CANCUN;
     let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[Opcode::Add as u8]; // this will error because the stack is empty
-    let result = driver::run_with_null_context(&host, revision, &message, code);
+    let result = instance.run_with_null_context(&host, revision, &message, code);
     assert_eq!(result.status_code, StatusCode::EVMC_STACK_UNDERFLOW);
 }
 
 #[test]
 fn step_n_can_be_called_with_mocked_context() {
+    let mut instance = SteppableInstance::default();
     let host = host_interface::mocked_host_interface();
     let mut context = MockExecutionContextTrait::new();
     context
@@ -66,7 +71,7 @@ fn step_n_can_be_called_with_mocked_context() {
     let revision = Revision::EVMC_CANCUN;
     let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[Opcode::Push0 as u8];
-    let result = driver::run_steppable(
+    let result = instance.run(
         &host,
         &mut context,
         revision,
@@ -86,12 +91,13 @@ fn step_n_can_be_called_with_mocked_context() {
 
 #[test]
 fn step_n_can_be_called_with_hardcoded_context() {
+    let mut instance = SteppableInstance::default();
     let mut host = null_ptr_host_interface();
     host.get_tx_context = Some(get_tx_context_zeroed);
     let revision = Revision::EVMC_CANCUN;
     let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[Opcode::Push0 as u8];
-    let result = driver::run_steppable_with_null_context(
+    let result = instance.run_with_null_context(
         &host,
         revision,
         &message,
@@ -110,12 +116,13 @@ fn step_n_can_be_called_with_hardcoded_context() {
 
 #[test]
 fn step_n_can_be_called_with_empty_code_and_stack_and_memory_and_last_call_result_data() {
+    let mut instance = SteppableInstance::default();
     let mut host = null_ptr_host_interface();
     host.get_tx_context = Some(get_tx_context_zeroed);
     let revision = Revision::EVMC_CANCUN;
     let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[];
-    let result = driver::run_steppable_with_null_context(
+    let result = instance.run_with_null_context(
         &host,
         revision,
         &message,
@@ -134,12 +141,13 @@ fn step_n_can_be_called_with_empty_code_and_stack_and_memory_and_last_call_resul
 
 #[test]
 fn step_n_handles_error_correctly() {
+    let mut instance = SteppableInstance::default();
     let mut host = null_ptr_host_interface();
     host.get_tx_context = Some(get_tx_context_zeroed);
     let revision = Revision::EVMC_CANCUN;
     let message = MockExecutionMessage::default().to_evmc_message();
     let code = &[Opcode::Add as u8]; // this will error because the stack is empty
-    let result = driver::run_steppable_with_null_context(
+    let result = instance.run_with_null_context(
         &host,
         revision,
         &message,


### PR DESCRIPTION
This PR adds `Instance` and `SteppableInstance` in the driver lib and makes all `run*` functions methods of those structs. They both call the respective create function in their constructor (`Default` impl) and the destroy function in their `Drop` impl.

In the benchmark lib `RunArgs` now have a field of type `Instance`. Therefore it is no longer necessary to call the create function in each benchmark iteration but instead only once, which more closely resembles how `evmrs` would be used.

Additionally `evmc_create_steppable_evmrs` and `evmc_create_evmrs` not return mutable pointers which should have been the case all along.