### PR TITLE
evmrs: fix&improve ci

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -31,6 +31,10 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt
+    - name: load cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: rust
     - name: cargo fmt
       working-directory: rust
       run: cargo fmt --check
@@ -46,11 +50,15 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy
+    - name: load cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: rust
     - name: install cargo-hack
       run: cargo install cargo-hack
     - name: cargo clippy
       working-directory: rust
-      run: cargo hack --workspace --feature-powerset clippy --examples --tests -- --deny warnings
+      run: cargo hack --workspace --feature-powerset clippy --examples --tests --benches -- --deny warnings
     
   doc:
     name: doc
@@ -63,6 +71,8 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
     - name: load cache
       uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: rust
     - name: install cargo-hack
       run: cargo install cargo-hack
     - name: cargo doc
@@ -82,6 +92,8 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
     - name: load cache
       uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: rust
     - name: install cargo-hack
       run: cargo install cargo-hack
     - name: cargo build
@@ -99,6 +111,8 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
     - name: load cache
       uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: rust
     - name: install cargo-hack
       run: cargo install cargo-hack
     - name: cargo test
@@ -114,6 +128,8 @@ jobs:
       uses: actions/checkout@v4
     - name: load cache
       uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: rust
     - name: install cargo-machete
       run: cargo install cargo-machete
     - name: cargo machete


### PR DESCRIPTION
- fix rust-cache action: because there is no `Cargo.toml` in the root it always failed. With an explicit path to the workspace it should now hopefully work.
- add rust-cache action to all jobs
- run clippy also work benchmarks