### PR TITLE
LFVM: Test integer overflow from stack values

### DIFF
--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -990,6 +990,13 @@ func opExtCodeCopy(c *context) error {
 		return err
 	}
 
+	var uint64CodeOffset uint64
+	if codeOffset.IsUint64() {
+		uint64CodeOffset = codeOffset.Uint64()
+	} else {
+		uint64CodeOffset = math.MaxUint64
+	}
+
 	// Charge for length of copied code
 	words := tosca.SizeInWords(length.Uint64())
 	if err := c.useGas(tosca.Gas(3 * words)); err != nil {
@@ -1001,12 +1008,6 @@ func opExtCodeCopy(c *context) error {
 		if err := c.useGas(getAccessCost(c.context.AccessAccount(address))); err != nil {
 			return err
 		}
-	}
-	var uint64CodeOffset uint64
-	if codeOffset.IsUint64() {
-		uint64CodeOffset = codeOffset.Uint64()
-	} else {
-		uint64CodeOffset = math.MaxUint64
 	}
 
 	data, err := c.memory.getSlice(memOffset.Uint64(), length.Uint64(), c)

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1625,7 +1625,7 @@ func TestGeneralCall_ResultIsWrittenToStack(t *testing.T) {
 	}
 }
 
-func TestInstructions_InstructionsReturnErrorOnOverflow(t *testing.T) {
+func TestInstructions_InstructionsReturnErrorOnParameterOverflow(t *testing.T) {
 	one := *uint256.NewInt(1)
 	zero := *uint256.NewInt(0)
 	maxUint256 := *uint256.NewInt(0).Sub(uint256.NewInt(0), uint256.NewInt(1))


### PR DESCRIPTION
part of #751 

This test checks operations that fetch values (256 Bits) from the stack for 64 bits operators. 
Both CALL and CREATE family of operators are too complicated for this batch testing, and require to be tested on its own. 

Included refactor:

- Reorder some operations code to prioritize check of operators overflow before more specific operator checks. 
- Remove hard-coded maxuint64 uses. 
- Remove ignored err values, return them instead. 