### PR TITLE
LFVM: add tests for statistics runner

### DIFF
--- a/go/interpreter/lfvm/instruction_statistcs_test.go
+++ b/go/interpreter/lfvm/instruction_statistcs_test.go
@@ -134,11 +134,13 @@ func TestStatisticsRunner_runInitializesNewStatsWhenUninitialized(t *testing.T) 
 	}
 }
 
-func TestStatisticsRunner_statisticsStopsWhenExecutiounErrorEnocuntered(t *testing.T) {
+func TestStatisticsRunner_statisticsStopsWhenExecutionEncountersAnError(t *testing.T) {
 	statsRunner := &statisticRunner{
 		stats: nil,
 	}
 	_, _ = statsRunner.run(&context{
+		// this code should not reach a STOP since MCOPY should fail because
+		// there are not enough items on the stack
 		code:  []Instruction{{MCOPY, 0}, {STOP, 0}},
 		stack: NewStack(),
 	})

--- a/go/interpreter/lfvm/instruction_statistcs_test.go
+++ b/go/interpreter/lfvm/instruction_statistcs_test.go
@@ -161,6 +161,7 @@ func TestStatisticsRunner_print_getTopN_returnFirstNElementsOfManyMore(t *testin
 	stats := statistics{
 		singleCount: map[uint64]uint64{
 			uint64(STOP):  1,
+			uint64(PUSH1): 1,
 			uint64(PUSH2): 2,
 			uint64(PUSH3): 3,
 			uint64(PUSH4): 4,

--- a/go/interpreter/lfvm/instruction_statistcs_test.go
+++ b/go/interpreter/lfvm/instruction_statistcs_test.go
@@ -142,8 +142,8 @@ func TestStatisticsRunner_statisticsStopsWhenExecutiounErrorEnocuntered(t *testi
 		code:  []Instruction{{MCOPY, 0}, {STOP, 0}},
 		stack: NewStack(),
 	})
-	if statsRunner.stats.singleCount[uint64(STOP)] == 1 {
-		t.Errorf("unexpected statistics: want 1 stop, got %v", statsRunner.stats.singleCount[uint64(STOP)])
+	if statsRunner.stats.singleCount[uint64(STOP)] != 0 {
+		t.Errorf("unexpected statistics: stop should not be executed, got %v", statsRunner.stats.singleCount[uint64(STOP)])
 	}
 }
 
@@ -161,7 +161,6 @@ func TestStatisticsRunner_print_getTopN_returnFirstNElementsOfManyMore(t *testin
 	stats := statistics{
 		singleCount: map[uint64]uint64{
 			uint64(STOP):  1,
-			uint64(PUSH1): 1,
 			uint64(PUSH2): 2,
 			uint64(PUSH3): 3,
 			uint64(PUSH4): 4,

--- a/go/interpreter/lfvm/instruction_statistics.go
+++ b/go/interpreter/lfvm/instruction_statistics.go
@@ -115,7 +115,10 @@ func (s *statistics) print() string {
 			list = append(list, entry{k, c})
 		}
 		sort.Slice(list, func(i, j int) bool {
-			return list[i].count > list[j].count
+			if list[i].count != list[j].count {
+				return list[i].count > list[j].count
+			}
+			return list[i].value < list[j].value
 		})
 		if len(list) < n {
 			return list


### PR DESCRIPTION
This PR adds test to check that:
- when we try to record statistics, if there is no `statistics` record, one will be created
- when the record has more than X entries, and there is a call to `getTopN(record, X)`, only the X instructions with the most entries will be shown.