### PR TITLE
evmrs: pass feature sets to bench.sh and document usage in BUILD.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,6 @@
 # vendor/
 build/
 
-/rust/target
-
 # IDE files
 .vscode/
 

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,4 @@
+/target
+
+# output of scripts
+/output 

--- a/rust/BUILD.md
+++ b/rust/BUILD.md
@@ -76,9 +76,7 @@ cargo build --features mimalloc,stack-array
 1. Identify a possible optimization opportunity by
     - running the Go VM benchmarks and comparing them, in cases where `evmrs` is slower than the other interpreters
         ```sh
-        # assuming you are in Tosca
-        cd ..
-        ./Tosca/rust/scripts/bench.sh performance
+        ./scripts/bench.sh performance
         ```
     - running a profiler of you choice and identifying a bottleneck
 1. Add a feature in [Cargo.toml](Cargo.toml)
@@ -90,9 +88,7 @@ cargo build --features mimalloc,stack-array
    This will run the Rust benchmarks and generate flamegraphs for all currently implemented features and for all currently implemented features and the new feature
 1. Run Go VM Benchmarks 
     ```sh
-    # assuming you are in Tosca
-    cd ..
-    ./Tosca/rust/scripts/bench.sh performance performance,my-new-feature
+    ./scripts/bench.sh performance performance,my-new-feature
     ```
 1. If all benchmarks indicate that the performance with the optimization is better that before, add the feature name to the features enabled by the `performance` feature in [Cargo.toml](Cargo.toml).
 
@@ -111,9 +107,7 @@ cargo build --features mimalloc,stack-array
     ```
     To run benchmarks for evmzero, lfvm, geth and evmrs with different feature sets run:
     ```sh
-    # assuming you are in Tosca
-    cd ..
-    ./Tosca/rust/scripts/bench.sh <feature-set-1> <feature-set-2>
+    ./scripts/bench.sh <feature-set-1> <feature-set-2>
     ```
 
 ## Profiling

--- a/rust/BUILD.md
+++ b/rust/BUILD.md
@@ -74,7 +74,7 @@ cargo build --features mimalloc,stack-array
 ### Optimization Workflow
 
 1. Identify a possible optimization opportunity by
-    - running the Go VM benchmarks and comparing in which cases `evmrs` is slower than the other interpreters
+    - running the Go VM benchmarks and comparing them, in cases where `evmrs` is slower than the other interpreters
         ```sh
         # assuming you are in Tosca
         cd ..

--- a/rust/BUILD.md
+++ b/rust/BUILD.md
@@ -75,6 +75,11 @@ cargo build --features mimalloc,stack-array
 
 1. Identify a possible optimization opportunity by
     - running the Go VM benchmarks and comparing in which cases `evmrs` is slower than the other interpreters
+        ```sh
+        # assuming you are in Tosca
+        cd ..
+        ./Tosca/rust/scripts/bench.sh performance
+        ```
     - running a profiler of you choice and identifying a bottleneck
 1. Add a feature in [Cargo.toml](Cargo.toml)
 1. Implement the optimization and put it behind this new feature
@@ -85,14 +90,9 @@ cargo build --features mimalloc,stack-array
    This will run the Rust benchmarks and generate flamegraphs for all currently implemented features and for all currently implemented features and the new feature
 1. Run Go VM Benchmarks 
     ```sh
-    cargo build --release --features performance
-    go test ../go/integration_test/interpreter \
-        --run none --bench ^Benchmark[a-zA-Z]+/./evmrs \
-        --timeout 1h --count 20
-    cargo build --release --features performance,my-new-feature
-    go test ../go/integration_test/interpreter \
-        --run none --bench ^Benchmark[a-zA-Z]+/./evmrs \
-        --timeout 1h --count 20
+    # assuming you are in Tosca
+    cd ..
+    ./Tosca/rust/scripts/bench.sh performance performance,my-new-feature
     ```
 1. If all benchmarks indicate that the performance with the optimization is better that before, add the feature name to the features enabled by the `performance` feature in [Cargo.toml](Cargo.toml).
 
@@ -109,15 +109,11 @@ cargo build --features mimalloc,stack-array
         --run none --bench ^Benchmark[a-zA-Z]+/./evmrs \
         --timeout 1h --count 20
     ```
-    Note: 
-    As mentioned in [../BUILD.md](../BUILD.md#diffing-benchmarks) you can use `benchstat` to compare different benchmark runs.
-    However, the benchmarks names must match up.
-    Because the benchmark names contain the name of the interpreter, you have to remove the interpreter name beforehand.
+    To run benchmarks for evmzero, lfvm, geth and evmrs with different feature sets run:
     ```sh
-    sed -i "s/<interpreter 1 name>-//g" ./my-bench-output-1
-    sed -i "s/<interpreter 2 name>-//g" ./my-bench-output-2
-    ...
-    benchstat ./my-bench-output-1 ./my-bench-output-2 ...
+    # assuming you are in Tosca
+    cd ..
+    ./Tosca/rust/scripts/bench.sh <feature-set-1> <feature-set-2>
     ```
 
 ## Profiling

--- a/rust/scripts/bench.sh
+++ b/rust/scripts/bench.sh
@@ -1,48 +1,72 @@
 #!/bin/bash
 
-# Run Go interpreter benchmarks for evmzero, lfvm and geth in as well as for evmrs with different features in branch origin/evmrs-main.
-# This script must be called from the parent directory of Tosca.
+# Run Go interpreter benchmarks for evmzero, lfvm and geth as well as for evmrs with different feature sets on branch origin/evmrs-main.
+# This script must be called from the parent directory of Tosca with a list of feature sets.
+
+# Requirements:
+# go install golang.org/x/perf/cmd/benchstat@latest
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 [--evmrs-only] <feature-set> [<feature-set> ...]"
+    exit 1
+fi
+
+EVMRS_ONLY=0
+
+if [ "$1" == "--evmrs-only" ]; then
+    EVMRS_ONLY=1
+    shift
+
+    if [ $# -eq 0 ]; then
+        echo "Usage: $0 [--evmrs-only] <feature-set> [<feature-set> ...]"
+        exit 1
+    fi
+fi
 
 RUNS=20
 TIMEOUT=1h
 BRANCH="origin/evmrs-main"
 
-DATE=$(date +'%Y-%m-%dT%H:%M')
-
-BENCH_DIR=benches/$DATE
-mkdir -p $BENCH_DIR
-
 cd Tosca
 
 git fetch --all
-git checkout ${BRANCH}
-GIT_REF=$(git show-ref --hash=7 ${BRANCH})
+git checkout $BRANCH
 
-make
+DATE=$(date +'%Y-%m-%dT%H:%M')
+GIT_REF=$(git show-ref --hash=7 $BRANCH)
 
-# bench all non Rust interpreters
-INTERPRETERS=("evmzero" "lfvm" "geth")
-for INTERPRETER in "${INTERPRETERS[@]}"; do
-    BENCH_NAME=$(basename ${GIT_REF})-${INTERPRETER}-${RUNS}
-    echo running ${BENCH_NAME}
-    go test ./go/integration_test/interpreter \
-        --run none --bench ^Benchmark[a-zA-Z]+/./${INTERPRETER}$ \
-        --timeout $TIMEOUT --count $RUNS | tee ../${BENCH_DIR}/${BENCH_NAME}
-    sed -i "s/${INTERPRETER}-//g" ../${BENCH_DIR}/${BENCH_NAME}
-done
+OUTPUT_DIR=../benches/$DATE#$GIT_REF#$RUNS
+mkdir -p $OUTPUT_DIR
 
-# bench evmrs with different features
+if [ ! $EVMRS_ONLY ]; then
+    make
+
+    INTERPRETERS=("evmzero" "lfvm" "geth")
+    for INTERPRETER in "${INTERPRETERS[@]}"; do
+        echo running $INTERPRETER
+
+        OUTPUT_FILE=$OUTPUT_DIR/$INTERPRETER
+        go test ./go/integration_test/interpreter \
+            --run none --bench ^Benchmark[a-zA-Z]+/./$INTERPRETER$ \
+            --timeout $TIMEOUT --count $RUNS | tee $OUTPUT_FILE
+        sed -i "s/$INTERPRETER-//g" $OUTPUT_FILE
+    done
+fi
+
 INTERPRETER="evmrs"
-FEATURES_LIST=("" "performance")
-for FEATURES in "${FEATURES_LIST[@]}"; do
+for FEATURES in "$@"; do
+    echo running $INTERPRETER with features: $FEATURES
+
     cd rust
     cargo build --lib --release --features "$FEATURES"
     cd ..
 
-    BENCH_NAME=$(basename ${GIT_REF})-${INTERPRETER}-${FEATURES}-${RUNS}
-    echo running ${BENCH_NAME}
+    OUTPUT_FILE=$OUTPUT_DIR/$INTERPRETER-$FEATURES
     go test ./go/integration_test/interpreter \
-        --run none --bench ^Benchmark[a-zA-Z]+/./${INTERPRETER}$ \
-        --timeout $TIMEOUT --count $RUNS | tee ../${BENCH_DIR}/${BENCH_NAME}
-    sed -i "s/${INTERPRETER}-//g" ../${BENCH_DIR}/${BENCH_NAME}
+        --run none --bench ^Benchmark[a-zA-Z]+/./$INTERPRETER$ \
+        --timeout $TIMEOUT --count $RUNS | tee $OUTPUT_FILE
+    sed -i "s/$INTERPRETER-//g" $OUTPUT_FILE
 done
+
+cd $OUTPUT_DIR
+benchstat * | tee comparison

--- a/rust/scripts/bench.sh
+++ b/rust/scripts/bench.sh
@@ -36,9 +36,9 @@ GIT_REF=$(git show-ref --hash=7 $BRANCH)
 OUTPUT_DIR=output/benches/$DATE#$GIT_REF#$RUNS
 mkdir -p $OUTPUT_DIR
 
-if [ ! $EVMRS_ONLY ]; then
-    make -C ..
+make -C ..
 
+if [ ! $EVMRS_ONLY ]; then
     INTERPRETERS=("evmzero" "lfvm" "geth")
     for INTERPRETER in "${INTERPRETERS[@]}"; do
         echo running $INTERPRETER

--- a/rust/scripts/compare-features.sh
+++ b/rust/scripts/compare-features.sh
@@ -12,7 +12,7 @@ if [ $(cat /proc/sys/kernel/perf_event_paranoid) -ne 0 ]; then
 fi
 
 DATE=$(date +'%Y-%m-%dT%H:%M')
-GIT_REF=$(git show-ref --hash=7 $BRANCH)
+GIT_REF=$(git show-ref --hash=7 --head ^HEAD)
 
 OUTPUT_DIR=output/profiling/$DATE#$GIT_REF
 mkdir -p $OUTPUT_DIR

--- a/rust/scripts/compare-features.sh
+++ b/rust/scripts/compare-features.sh
@@ -11,7 +11,10 @@ if [ $(cat /proc/sys/kernel/perf_event_paranoid) -ne 0 ]; then
     echo 0 | sudo tee /proc/sys/kernel/perf_event_paranoid
 fi
 
-OUTPUT_DIR=profiling-results
+DATE=$(date +'%Y-%m-%dT%H:%M')
+GIT_REF=$(git show-ref --hash=7 $BRANCH)
+
+OUTPUT_DIR=output/profiling/$DATE#$GIT_REF
 mkdir -p $OUTPUT_DIR
 
 INTERPRETER="evmrs"

--- a/rust/scripts/coverage.sh
+++ b/rust/scripts/coverage.sh
@@ -20,6 +20,7 @@ cargo clean
 mkdir -p $CT_COV_TARGET
 mkdir -p $CT_COV
 
+make -C ..
 # build evmrs with coverage instrumentation
 RUSTFLAGS="-C instrument-coverage" cargo build --release --features dump-cov
 # run CT

--- a/rust/scripts/coverage.sh
+++ b/rust/scripts/coverage.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# Run CT with evmrs and collect coverage data. This script must be called from Tosca/rust.
-# It requires that llvm-tools-preview is installed:
+# Run CT with evmrs and collect coverage data.
+# This script must be called from Tosca/rust.
+
+# Requirements:
 # rustup component add llvm-tools-preview
 
 INTERACTIVE=0

--- a/rust/scripts/test.sh
+++ b/rust/scripts/test.sh
@@ -1,21 +1,22 @@
 #!/bin/bash
 
 # Run Go tests and CT for evmrs on branch origin/evmrs-main.
-# This script must be called from the parent directory of Tosca.
-
-mkdir -p tests
-
-cd Tosca
-git fetch --all
+# This script must be called from Tosca/rust.
 
 BRANCH="origin/evmrs-main"
 
-git checkout ${BRANCH}
-make clean-rust
-make tosca-rust
+git fetch --all
+git checkout $BRANCH
 
-GIT_REF=$(git show-ref --hash=7 ${BRANCH})
+DATE=$(date +'%Y-%m-%dT%H:%M')
+GIT_REF=$(git show-ref --hash=7 $BRANCH)
+
+OUTPUT_DIR=output/tests/$DATE#$GIT_REF
+mkdir -p $OUTPUT_DIR
+
+make -C .. clean-rust
+make -C .. tosca-rust
 
 export RUST_BACKTRACE=full
-go test ./go/... | tee ../tests/ct-full-${GIT_REF}
-go run ./go/ct/driver run --full-mode evmrs | tee ../tests/go-test-${GIT_REF}
+go test ../go/... | tee $OUTPUT_DIR/ct-full
+go run ../go/ct/driver run --full-mode evmrs | tee $OUTPUT_DIR/go-test

--- a/rust/scripts/test.sh
+++ b/rust/scripts/test.sh
@@ -18,5 +18,5 @@ make -C .. clean-rust
 make -C .. tosca-rust
 
 export RUST_BACKTRACE=full
-go test ../go/... | tee $OUTPUT_DIR/ct-full
-go run ../go/ct/driver run --full-mode evmrs | tee $OUTPUT_DIR/go-test
+go test ../go/... | tee $OUTPUT_DIR/go-test
+go run ../go/ct/driver run --full-mode evmrs | tee $OUTPUT_DIR/ct-full


### PR DESCRIPTION
This PR changes bench.sh such that it accepts a list of feature sets for evmrs to run the Go VM benchmarks and documents how to use this script in BUILD.md