### PR TITLE
LFVM: genericCreate tests 

### DIFF
--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -844,6 +844,8 @@ func genericCreate(c *context, kind tosca.CallKind) error {
 	gas := c.gas
 	gas -= gas / 64
 	if err := c.useGas(gas); err != nil {
+		// this usage can never fail because the endowment is at most
+		// 63/64 of the current gas level.
 		return err
 	}
 

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -821,11 +821,6 @@ func genericCreate(c *context, kind tosca.CallKind) error {
 		}
 	}
 
-	input, err := c.memory.getSlice(offset.Uint64(), sizeU64, c)
-	if err != nil {
-		return err
-	}
-
 	if !value.IsZero() {
 		balance := c.context.GetBalance(c.params.Recipient)
 		balanceU256 := new(uint256.Int).SetBytes(balance[:])

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -837,7 +837,7 @@ func genericCreate(c *context, kind tosca.CallKind) error {
 		}
 	}
 
-	// Apply EIP150
+	// compute and apply eip150 https://eips.ethereum.org/EIPS/eip-150
 	nestedCallGas := c.gas
 	nestedCallGas -= nestedCallGas / 64
 

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -781,14 +781,6 @@ func opExtcodehash(c *context) error {
 	return nil
 }
 
-func opCreate(c *context) error {
-	return genericCreate(c, tosca.Create)
-}
-
-func opCreate2(c *context) error {
-	return genericCreate(c, tosca.Create2)
-}
-
 func genericCreate(c *context, kind tosca.CallKind) error {
 
 	// Create is a write instruction, it shall not be executed in static mode.

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1165,12 +1165,14 @@ func TestGenericCreate_ReportsErrors(t *testing.T) {
 			offset:        *one,
 			size:          *uint256.NewInt(31),
 			revision:      tosca.R12_Shanghai,
+			kind:          tosca.Create,
 			expectedError: errOutOfGas,
 		},
 		"gas not checked for max code size before shanghai": {
 			offset:        *one,
 			size:          *uint256.NewInt(31),
 			revision:      tosca.R11_Paris,
+			kind:          tosca.Create,
 			expectedError: nil,
 		},
 		"not enough gas for create2 init code hashing": {

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1212,6 +1212,11 @@ func TestGenericCreate_ReportsErrors(t *testing.T) {
 			size:          *one,
 			expectedError: errOverflow,
 		},
+		"size zero ignores offset overflow": {
+			offset:        *u64Overflow,
+			size:          *uint256.NewInt(0),
+			expectedError: nil,
+		},
 		"size overflow": {
 			offset:        *uint256.NewInt(0),
 			size:          *u64Overflow,
@@ -1286,7 +1291,7 @@ func TestGenericCreate_ResultIsWrittenToStack(t *testing.T) {
 		}
 		want := uint256.NewInt(0)
 		if success {
-			want = uint256.NewInt(1)
+			want = new(uint256.Int).SetBytes(CreatedAddress[:])
 		}
 		if got := ctxt.stack.peek(); !want.Eq(got) {
 			t.Errorf("unexpected return value, wanted %v, got %v", want, got)

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -497,9 +497,9 @@ func steps(c *context, oneStepOnly bool) (status, error) {
 		case STOP:
 			status = opStop()
 		case CREATE:
-			err = opCreate(c)
+			err = genericCreate(c, tosca.Create)
 		case CREATE2:
-			err = opCreate2(c)
+			err = genericCreate(c, tosca.Create2)
 		case LOG0:
 			err = opLog(c, 0)
 		case LOG1:


### PR DESCRIPTION
part of #751 

This PR adds tests for `genericCreate`:
- In all error cases, out of gas due to different checks depending on revision and create kind.
- ensuring result of creation is properly saved in stack