### PR TITLE
lfvm: sha3 tests

### DIFF
--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1974,7 +1974,14 @@ func TestInstructions_Sha3_ReportsOutOfGasa(t *testing.T) {
 	}
 }
 
-func TestInstructions_Sha3(t *testing.T) {
+func TestInstructions_Sha3_WritesCorrectHashInStack(t *testing.T) {
+
+	want := tosca.Hash{
+		0xbc, 0x36, 0x78, 0x9e, 0x7a, 0x1e, 0x28, 0x14,
+		0x36, 0x46, 0x42, 0x29, 0x82, 0x8f, 0x81, 0x7d,
+		0x66, 0x12, 0xf7, 0xb4, 0x77, 0xd6, 0x65, 0x91,
+		0xff, 0x96, 0xa9, 0xe0, 0x64, 0xbc, 0xc9, 0x8a}
+
 	ctxt := getEmptyContext()
 	ctxt.withShaCache = false
 	ctxt.stack.push(uint256.NewInt(1))
@@ -1986,6 +1993,9 @@ func TestInstructions_Sha3(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	firstHash := ctxt.stack.pop()
+	if !bytes.Equal(firstHash.Bytes(), want[:]) {
+		t.Errorf("unexpected hash, wanted %x, got %x", want, firstHash.Bytes())
+	}
 
 	// with cache
 	ctxt.withShaCache = true
@@ -1996,9 +2006,8 @@ func TestInstructions_Sha3(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	secondHash := ctxt.stack.pop()
-
-	if !firstHash.Eq(secondHash) {
-		t.Errorf("hashes do not match, %v != %v", firstHash, secondHash)
+	if !bytes.Equal(secondHash.Bytes(), want[:]) {
+		t.Errorf("unexpected hash, wanted %v, got %v", want, secondHash)
 	}
 }
 

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1944,7 +1944,7 @@ func TestOpExp_ReportsOutOfGas(t *testing.T) {
 	}
 }
 
-func TestInstructions_Sha3_ReportsOutOfGasa(t *testing.T) {
+func TestInstructions_Sha3_ReportsOutOfGas(t *testing.T) {
 	tests := map[string]struct {
 		size          uint64
 		expectedError error
@@ -1982,32 +1982,21 @@ func TestInstructions_Sha3_WritesCorrectHashInStack(t *testing.T) {
 		0x66, 0x12, 0xf7, 0xb4, 0x77, 0xd6, 0x65, 0x91,
 		0xff, 0x96, 0xa9, 0xe0, 0x64, 0xbc, 0xc9, 0x8a}
 
-	ctxt := getEmptyContext()
-	ctxt.withShaCache = false
-	ctxt.stack.push(uint256.NewInt(1))
-	ctxt.stack.push(uint256.NewInt(0))
+	for _, withShaCache := range []bool{true, false} {
+		ctxt := getEmptyContext()
+		ctxt.withShaCache = withShaCache
+		ctxt.stack.push(uint256.NewInt(1))
+		ctxt.stack.push(uint256.NewInt(0))
 
-	// without cache
-	err := opSha3(&ctxt)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	firstHash := ctxt.stack.pop()
-	if !bytes.Equal(firstHash.Bytes(), want[:]) {
-		t.Errorf("unexpected hash, wanted %x, got %x", want, firstHash.Bytes())
-	}
-
-	// with cache
-	ctxt.withShaCache = true
-	ctxt.stack.push(uint256.NewInt(1))
-	ctxt.stack.push(uint256.NewInt(0))
-	err = opSha3(&ctxt)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	secondHash := ctxt.stack.pop()
-	if !bytes.Equal(secondHash.Bytes(), want[:]) {
-		t.Errorf("unexpected hash, wanted %v, got %v", want, secondHash)
+		// without cache
+		err := opSha3(&ctxt)
+		if err != nil {
+			t.Fatalf("unexpected when withShaCache is %v, error: %v", withShaCache, err)
+		}
+		got := ctxt.stack.pop()
+		if !bytes.Equal(got.Bytes(), want[:]) {
+			t.Errorf("unexpected hash when withShaCache is %v, wanted %x, got %x", withShaCache, want, got.Bytes())
+		}
 	}
 }
 

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1983,20 +1983,22 @@ func TestInstructions_Sha3_WritesCorrectHashInStack(t *testing.T) {
 		0xff, 0x96, 0xa9, 0xe0, 0x64, 0xbc, 0xc9, 0x8a}
 
 	for _, withShaCache := range []bool{true, false} {
-		ctxt := getEmptyContext()
-		ctxt.withShaCache = withShaCache
-		ctxt.stack.push(uint256.NewInt(1))
-		ctxt.stack.push(uint256.NewInt(0))
+		t.Run(fmt.Sprintf("withShaCache:%v", withShaCache), func(t *testing.T) {
+			ctxt := getEmptyContext()
+			ctxt.withShaCache = withShaCache
+			ctxt.stack.push(uint256.NewInt(1))
+			ctxt.stack.push(uint256.NewInt(0))
 
-		// without cache
-		err := opSha3(&ctxt)
-		if err != nil {
-			t.Fatalf("unexpected when withShaCache is %v, error: %v", withShaCache, err)
-		}
-		got := ctxt.stack.pop()
-		if !bytes.Equal(got.Bytes(), want[:]) {
-			t.Errorf("unexpected hash when withShaCache is %v, wanted %x, got %x", withShaCache, want, got.Bytes())
-		}
+			// without cache
+			err := opSha3(&ctxt)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			got := ctxt.stack.pop()
+			if !bytes.Equal(got.Bytes(), want[:]) {
+				t.Errorf("unexpected hash wanted %x, got %x", want, got.Bytes())
+			}
+		})
 	}
 }
 

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1976,11 +1976,7 @@ func TestInstructions_Sha3_ReportsOutOfGas(t *testing.T) {
 
 func TestInstructions_Sha3_WritesCorrectHashInStack(t *testing.T) {
 
-	want := tosca.Hash{
-		0xbc, 0x36, 0x78, 0x9e, 0x7a, 0x1e, 0x28, 0x14,
-		0x36, 0x46, 0x42, 0x29, 0x82, 0x8f, 0x81, 0x7d,
-		0x66, 0x12, 0xf7, 0xb4, 0x77, 0xd6, 0x65, 0x91,
-		0xff, 0x96, 0xa9, 0xe0, 0x64, 0xbc, 0xc9, 0x8a}
+	want := Keccak256([]byte{0})
 
 	for _, withShaCache := range []bool{true, false} {
 		t.Run(fmt.Sprintf("withShaCache:%v", withShaCache), func(t *testing.T) {
@@ -1989,7 +1985,6 @@ func TestInstructions_Sha3_WritesCorrectHashInStack(t *testing.T) {
 			ctxt.stack.push(uint256.NewInt(1))
 			ctxt.stack.push(uint256.NewInt(0))
 
-			// without cache
 			err := opSha3(&ctxt)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
Part of #751 

Adds 2 tests, one checking out of gas scenarios, another checking the same hash produced regardless of using hash cache or not. 