### PR TITLE
LFVM: Add test for BLOCKHASH history logic

### DIFF
--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -766,8 +766,8 @@ func opBlockhash(c *context) {
 	}
 
 	oldestInHistory := uint64(256)
-	if c.params.BlockNumber < 256 {
-		oldestInHistory = uint64(c.params.BlockNumber)
+	if currentBlockNumber < 256 {
+		oldestInHistory = uint64(currentBlockNumber)
 	}
 	oldestInHistory = currentBlockNumber - oldestInHistory
 	if requestedBlockNumber < oldestInHistory {
@@ -775,7 +775,7 @@ func opBlockhash(c *context) {
 		return
 	}
 
-	hash := c.context.GetBlockHash(int64(top.Uint64()))
+	hash := c.context.GetBlockHash(int64(requestedBlockNumber))
 	top.SetBytes(hash[:])
 }
 

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -12,9 +12,9 @@ package lfvm
 
 import (
 	"bytes"
+	"crypto/rand"
 	"fmt"
 	"math"
-	"slices"
 	"testing"
 
 	"github.com/Fantom-foundation/Tosca/go/tosca"
@@ -1754,7 +1754,8 @@ func TestInstructions_ComparisonAndShiftOperations(t *testing.T) {
 
 func TestOpBlockhash(t *testing.T) {
 
-	hash := tosca.Hash(uint256.MustFromHex("0xABCD").Bytes32())
+	hash := tosca.Hash{}
+	_, _ = rand.Read(hash[:])
 	zeroHash := tosca.Hash{}
 	u64overflow := new(uint256.Int).Add(uint256.NewInt(2), uint256.NewInt(math.MaxUint64))
 
@@ -1813,7 +1814,7 @@ func TestOpBlockhash(t *testing.T) {
 
 					opBlockhash(&ctxt)
 
-					if want, got := test.expectedValue, ctxt.stack.pop(); slices.Equal(want[:], got.Bytes()) {
+					if want, got := new(uint256.Int).SetBytes(test.expectedValue[:]), ctxt.stack.pop(); want.Cmp(got) != 0 {
 						t.Errorf("unexpected result, wanted %v, got %v", want, got)
 					}
 				})

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1794,7 +1794,7 @@ func TestOpBlockhash(t *testing.T) {
 			expectedValue: hash,
 			inputs: map[string]testInput{
 				"default": {currentBlockNumber: 5000, requestedBlockNumber: uint256.NewInt(4990)},
-				"and history has lees than 256 elements": {
+				"and history has less than 256 elements": {
 					currentBlockNumber: 128, requestedBlockNumber: uint256.NewInt(16),
 				},
 			},
@@ -1811,7 +1811,7 @@ func TestOpBlockhash(t *testing.T) {
 					ctxt.params.BlockNumber = input.currentBlockNumber
 
 					runContext := tosca.NewMockRunContext(gomock.NewController(t))
-					if bytes.Equal(hash[:], test.expectedValue[:]) {
+					if hash == test.expectedValue {
 						runContext.EXPECT().GetBlockHash(gomock.Any()).Return(hash).AnyTimes()
 					}
 					ctxt.context = runContext

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1768,16 +1768,20 @@ func TestOpBlockhash(t *testing.T) {
 		expectedValue tosca.Hash
 		inputs        map[string]testInput
 	}{
-		"produces zero if requested block number older than available history": {
+		"produces zero if requested block number is older than available history": {
 			expectedValue: zeroHash,
 			inputs: map[string]testInput{
-				"default": {currentBlockNumber: 1024, requestedBlockNumber: uint256.NewInt(36)},
+				"default": {
+					currentBlockNumber: 1024, requestedBlockNumber: uint256.NewInt(36),
+				},
 			},
 		},
-		"produces zero if requested block number newer than current": {
+		"produces zero if requested block number is newer than history": {
 			expectedValue: zeroHash,
 			inputs: map[string]testInput{
-				"default": {currentBlockNumber: 500, requestedBlockNumber: uint256.NewInt(501)},
+				"current is not included in history": {
+					currentBlockNumber: 500, requestedBlockNumber: uint256.NewInt(500),
+				},
 				"and history has less than 256 elements": {
 					currentBlockNumber: 35, requestedBlockNumber: uint256.NewInt(36),
 				},


### PR DESCRIPTION
Part of #751 

Simplify function and test branches.

The reason behind multiple inputs for each case is that when `requestedBlockNumber` overflows, is still an out of range case.  