### PR TITLE
LFVM: Test use of deprecated functions, none allowed

### DIFF
--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -186,7 +186,6 @@ func TestInterpreter_CanDispatchExecutableInstructions(t *testing.T) {
 				// mock all to satisfy any instruction
 				mock.EXPECT().AccessAccount(gomock.Any()).Return(tosca.WarmAccess).AnyTimes()
 				mock.EXPECT().GetBalance(gomock.Any()).AnyTimes()
-				mock.EXPECT().IsAddressInAccessList(gomock.Any()).AnyTimes()
 				mock.EXPECT().GetCodeSize(gomock.Any()).AnyTimes()
 				mock.EXPECT().GetCode(gomock.Any()).AnyTimes()
 				mock.EXPECT().AccountExists(gomock.Any()).AnyTimes()


### PR DESCRIPTION
part of #751 

Remove all mocks of run-context deprecated functions, test fails if any is used. 