### PR TITLE
LFVM: calldataload tests

### DIFF
--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1827,6 +1827,49 @@ func TestOpBlockhash(t *testing.T) {
 	}
 }
 
+func TestCallDataload_WritesZeroOnStackWhen(t *testing.T) {
+
+	tests := map[string]struct {
+		offset *uint256.Int
+	}{
+		"offset larger than uint64": {
+			offset: new(uint256.Int).Add(uint256.NewInt(2), uint256.NewInt(math.MaxUint64)),
+		},
+		"offset+31 overflows uint64": {
+			offset: uint256.NewInt(math.MaxUint64 - 31),
+		},
+		"offset bigger than input code size": {
+			offset: uint256.NewInt(16),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctxt := getEmptyContext()
+			ctxt.params.Input = make([]byte, 16)
+			_, _ = rand.Read(ctxt.params.Input)
+			ctxt.stack.push(test.offset)
+			opCallDataload(&ctxt)
+			if got := ctxt.stack.pop(); got.Cmp(uint256.NewInt(0)) != 0 {
+				t.Errorf("unexpected result, wanted 0, got %d", got)
+			}
+		})
+	}
+}
+
+func TestCallDataload(t *testing.T) {
+	input := make([]byte, 32)
+	_, _ = rand.Read(input)
+	offset := uint256.NewInt(0)
+	ctxt := getEmptyContext()
+	ctxt.params.Input = input
+	ctxt.stack.push(offset)
+	opCallDataload(&ctxt)
+	if want, got := new(uint256.Int).SetBytes(input), ctxt.stack.pop(); want.Cmp(got) != 0 {
+		t.Errorf("unexpected result, wanted %v, got %v", want, got)
+	}
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Helper functions
 

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1838,15 +1838,15 @@ func TestCallDataload(t *testing.T) {
 		offset *uint256.Int
 		want   *uint256.Int
 	}{
-		"offset larger than uint64": {
+		"writes zero on the stack when offset larger than uint64 ": {
 			offset: new(uint256.Int).Add(uint256.NewInt(2), uint256.NewInt(math.MaxUint64)),
 			want:   zero,
 		},
-		"offset+31 overflows uint64": {
+		"writes zero on the stack when offset+31 overflows uint64": {
 			offset: uint256.NewInt(math.MaxUint64 - 31),
 			want:   zero,
 		},
-		"offset bigger than input code size": {
+		"pads with zeros when offset bigger than input code size": {
 			offset: uint256.NewInt(31),
 			want:   uint256.NewInt(0).SetBytes32([]byte{firstByte, 31: 0x0}),
 		},

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1832,7 +1832,6 @@ func TestCallDataload(t *testing.T) {
 	zero := uint256.NewInt(0)
 	someData := make([]byte, 32)
 	_, _ = rand.Read(someData)
-	firstByte := someData[31]
 
 	tests := map[string]struct {
 		offset *uint256.Int
@@ -1848,7 +1847,7 @@ func TestCallDataload(t *testing.T) {
 		},
 		"pads with zeros when offset bigger than input code size": {
 			offset: uint256.NewInt(31),
-			want:   uint256.NewInt(0).SetBytes32([]byte{firstByte, 31: 0x0}),
+			want:   uint256.NewInt(0).SetBytes32([]byte{someData[31], 31: 0x0}),
 		},
 		"writes data to stack": {
 			offset: zero,


### PR DESCRIPTION
part of #751 

This PR adds a test for `opCallDataload`. 

One 3 test cases where the input parameter, the offset read from the top of the stack, is bigger than u64, or produces an u64 overflow or is bigger than code length. Another test case checks for the regular behavior of the function.

