### PR TITLE
LFVM: extcodehash test

### DIFF
--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1997,7 +1997,7 @@ func TestInstructions_Sha3_WritesCorrectHashInStack(t *testing.T) {
 	}
 }
 
-func TestOpExtCodeHash_WritesHashInStackIf(t *testing.T) {
+func TestOpExtCodeHash_WritesHashOnStackIfAccountExists(t *testing.T) {
 
 	tests := map[string]struct {
 		accountExists bool

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1997,25 +1997,42 @@ func TestInstructions_Sha3_WritesCorrectHashInStack(t *testing.T) {
 	}
 }
 
-func TestOpExtCodeHash_WritesHashInStack(t *testing.T) {
+func TestOpExtCodeHash_WritesHashInStackIf(t *testing.T) {
+
+	tests := map[string]struct {
+		accountExists bool
+	}{
+		"account exists":         {accountExists: true},
+		"account does not exist": {accountExists: false},
+	}
 
 	hash := tosca.Hash{0x1, 0x2, 0x3}
 	address := tosca.Address{0x1}
 
-	ctxt := getEmptyContext()
-	ctxt.stack = fillStack(*new(uint256.Int).SetBytes20(address[:]))
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctxt := getEmptyContext()
+			ctxt.stack = fillStack(*new(uint256.Int).SetBytes20(address[:]))
 
-	runContext := tosca.NewMockRunContext(gomock.NewController(t))
-	runContext.EXPECT().AccountExists(address).Return(true)
-	runContext.EXPECT().GetCodeHash(address).Return(hash)
-	ctxt.context = runContext
+			runContext := tosca.NewMockRunContext(gomock.NewController(t))
+			runContext.EXPECT().AccountExists(address).Return(test.accountExists)
+			if test.accountExists {
+				runContext.EXPECT().GetCodeHash(address).Return(hash)
+			}
+			ctxt.context = runContext
 
-	err := opExtcodehash(&ctxt)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if want, got := hash[:], ctxt.stack.pop().Bytes(); !bytes.Equal(want, got) {
-		t.Errorf("unexpected result, wanted %v, got %v", want, got)
+			err := opExtcodehash(&ctxt)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			want := hash[:]
+			if !test.accountExists {
+				want = []byte{}
+			}
+			if got := ctxt.stack.pop().Bytes(); !bytes.Equal(want, got) {
+				t.Errorf("unexpected result, wanted %v, got %v", want, got)
+			}
+		})
 	}
 }
 

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1997,6 +1997,27 @@ func TestInstructions_Sha3_WritesCorrectHashInStack(t *testing.T) {
 	}
 }
 
+func TestOpExtCodeHash_WritesCorrectHashInStack(t *testing.T) {
+
+	hash := tosca.Hash{0x1, 0x2, 0x3}
+
+	ctxt := getEmptyContext()
+	ctxt.stack = fillStack(*uint256.NewInt(1))
+
+	runContext := tosca.NewMockRunContext(gomock.NewController(t))
+	runContext.EXPECT().AccountExists(gomock.Any()).Return(true)
+	runContext.EXPECT().GetCodeHash(gomock.Any()).Return(hash)
+	ctxt.context = runContext
+
+	err := opExtcodehash(&ctxt)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if want, got := hash[:], ctxt.stack.pop().Bytes(); !bytes.Equal(want, got) {
+		t.Errorf("unexpected result, wanted %v, got %v", want, got)
+	}
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Helper functions
 

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1997,16 +1997,17 @@ func TestInstructions_Sha3_WritesCorrectHashInStack(t *testing.T) {
 	}
 }
 
-func TestOpExtCodeHash_WritesCorrectHashInStack(t *testing.T) {
+func TestOpExtCodeHash_WritesHashInStack(t *testing.T) {
 
 	hash := tosca.Hash{0x1, 0x2, 0x3}
+	address := tosca.Address{0x1}
 
 	ctxt := getEmptyContext()
-	ctxt.stack = fillStack(*uint256.NewInt(1))
+	ctxt.stack = fillStack(*new(uint256.Int).SetBytes20(address[:]))
 
 	runContext := tosca.NewMockRunContext(gomock.NewController(t))
-	runContext.EXPECT().AccountExists(gomock.Any()).Return(true)
-	runContext.EXPECT().GetCodeHash(gomock.Any()).Return(hash)
+	runContext.EXPECT().AccountExists(address).Return(true)
+	runContext.EXPECT().GetCodeHash(address).Return(hash)
 	ctxt.context = runContext
 
 	err := opExtcodehash(&ctxt)


### PR DESCRIPTION
This PR is part of #751 
add test for successful case of `extCodeHash` and check that the correct hash is written in the stack.
