### PR TITLE
LFVM: genericCall eip150 consume

### DIFF
--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -1022,11 +1022,7 @@ func genericCall(c *context, kind tosca.CallKind) error {
 	if provided_gas.IsUint64() && (nestedCallGas >= tosca.Gas(provided_gas.Uint64())) {
 		nestedCallGas = tosca.Gas(provided_gas.Uint64())
 	}
-	if err := c.useGas(nestedCallGas); err != nil {
-		// this usage can never fail because the endowment is at most
-		// 63/64 of the current gas level.
-		return err
-	}
+	c.gas -= nestedCallGas
 
 	// first use static and dynamic gas cost and then resize the memory
 	// when out of gas is happening, then mem should not be resized


### PR DESCRIPTION
EIP150 states that only 63/64 of the available gas can be passed on to the recursive calls. This creates a case of a gas consumption that can never fail, and this resulted in a branch of dead code that could never be triggered. To remove this, in this PR, I remove the call to `useGas` and replace it for a direct operation to the context's gas.

This solutions comes from this (https://github.com/Fantom-foundation/Tosca/pull/837#discussion_r1789716178) discussion. 

This solution passes:
- [x] unit tests
- [x] ct run