### PR TITLE
LFVM: Add test for mcopy

### DIFF
--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1961,7 +1961,8 @@ func TestInstructions_MCopy_ReturnsErrorOnFailure(t *testing.T) {
 				*uint256.NewInt(test.size))
 
 			// ignore memory setup errors, to focus on the mcopy operation
-			// if cached here, too large size error cannot be tested
+			// expansion is done to accumulate memory cost and focus on the
+			// word count gas cost.
 			_ = ctxt.memory.expandMemory(test.destOffset, test.size, &context{gas: 1 << 32})
 			_ = ctxt.memory.expandMemory(test.srcOffset, test.size, &context{gas: 1 << 32})
 			ctxt.gas = tosca.Gas(3*tosca.SizeInWords(test.size) - test.gasRemoved)

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1934,9 +1934,9 @@ func TestInstructions_MCopy_DoesNothingWithSizeZero(t *testing.T) {
 	ctxt := getEmptyContext()
 	ctxt.params.Revision = tosca.R13_Cancun
 	ctxt.stack = fillStack(
-		*uint256.NewInt(2500),
-		*uint256.NewInt(137),
-		*uint256.NewInt(0))
+		*uint256.NewInt(2500), // destOffset
+		*uint256.NewInt(137),  // offset
+		*uint256.NewInt(0))    // size
 	ctxt.gas = 0
 
 	err := ctxt.memory.set(

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -2050,6 +2050,77 @@ func TestInstructions_opLog(t *testing.T) {
 	}
 }
 
+func TestInstructions_MCopy_ReturnsErrorOnFailure(t *testing.T) {
+
+	tests := map[string]struct {
+		srcOffset, destOffset, size uint64
+		expectedError               error
+		gasRemoved                  uint64
+		result                      []byte
+	}{
+		"returns error on failed write memory expansion": {
+			srcOffset: math.MaxUint64, destOffset: 0, size: 1,
+			expectedError: errOverflow,
+		},
+		"returns error on failed read memory expansion": {
+			srcOffset: 0, destOffset: math.MaxUint64, size: 1,
+			expectedError: errOverflow,
+		},
+		"returns error if gas is not enough for size": {
+			srcOffset: 0, destOffset: 0, size: 128,
+			expectedError: errOutOfGas,
+			gasRemoved:    1,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctxt := getEmptyContext()
+			ctxt.params.Revision = tosca.R13_Cancun
+			ctxt.stack = fillStack(
+				*uint256.NewInt(test.destOffset),
+				*uint256.NewInt(test.srcOffset),
+				*uint256.NewInt(test.size))
+
+			ctxt.memory.expandMemory(test.destOffset, test.size, &context{gas: 1 << 32})
+			ctxt.memory.expandMemory(test.srcOffset, test.size, &context{gas: 1 << 32})
+			ctxt.gas = tosca.Gas(3*tosca.SizeInWords(test.size) - test.gasRemoved)
+
+			err := opMcopy(&ctxt)
+			if err != test.expectedError {
+				t.Fatalf("unexpected error, wanted %v, got %v", test.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestInstructions_MCopy_CopiesOverlappingRanges(t *testing.T) {
+
+	ctxt := getEmptyContext()
+	ctxt.params.Revision = tosca.R13_Cancun
+	ctxt.stack = fillStack(
+		*uint256.NewInt(5),
+		*uint256.NewInt(0),
+		*uint256.NewInt(10))
+
+	ctxt.memory.set(
+		uint256.NewInt(0),
+		[]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		&context{gas: 1 << 32},
+	)
+	ctxt.gas = tosca.Gas(3 * tosca.SizeInWords(10))
+
+	err := opMcopy(&ctxt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []byte{0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	if want, got := expected, ctxt.memory.store[0:15]; !bytes.Equal(want, got) {
+		t.Errorf("unexpected memory, wanted %v, got %v", want, got)
+	}
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Helper functions
 


### PR DESCRIPTION
part of #751 

Old test is replaced with new ones:

- min version is tested for all ops in "TestInterpreter_InstructionsFailWhenExecutedInRevisionsEarlierThanIntroducedIn" 
- memory expansion is tested in memory tests.
- add overlapping range test
- test for errors happening both on read and write. 
- test gas cost for word count.