### PR TITLE
LFVM: Add tests for code related context calls

### DIFF
--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1630,10 +1630,12 @@ func TestInstructions_OpExtCodeCopy_CallsContextAndCopiesCodeSlice(t *testing.T)
 	ctxt.context = runContext
 	ctxt.gas = 1 << 32
 
-	ctxt.stack.push(uint256.NewInt(size))   // length
-	ctxt.stack.push(uint256.NewInt(offset)) // codeOffset
-	ctxt.stack.push(uint256.NewInt(0))      // memOffset
-	ctxt.stack.push(new(uint256.Int).SetBytes(address[:]))
+	ctxt.stack = fillStack(
+		*new(uint256.Int).SetBytes(address[:]),
+		*uint256.NewInt(0),      // memOffset
+		*uint256.NewInt(offset), // codeOffset
+		*uint256.NewInt(size),   // length
+	)
 
 	err := opExtCodeCopy(&ctxt)
 	if err != nil {

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1628,7 +1628,6 @@ func TestInstructions_OpExtCodeCopy_CallsContextAndCopiesCodeSlice(t *testing.T)
 
 	ctxt := getEmptyContext()
 	ctxt.context = runContext
-	ctxt.gas = 1 << 32
 
 	ctxt.stack = fillStack(
 		*new(uint256.Int).SetBytes(address[:]),
@@ -1656,7 +1655,6 @@ func TestInstructions_opExtcodesize_CallsContextAndWritesResultInStack(t *testin
 
 	ctxt := getEmptyContext()
 	ctxt.context = runContext
-	ctxt.gas = 1 << 32
 
 	ctxt.stack.push(new(uint256.Int).SetBytes(address[:]))
 


### PR DESCRIPTION
part of #751 

This pr adds tests to check parameters passed to context calls for `GetCode`  and  `GetCodeSize` 