### PR TITLE
LFVM: add test to bring converter coverage back to 100%

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -63,8 +63,12 @@ override:
     path: go/interpreter/lfvm/ct.go
   - threshold: 38
     path: go/interpreter/lfvm/lfvm.go
-  - threshold: 0
+  - threshold: 100
+    path: go/interpreter/lfvm/converter.go
+  - threshold: 100
     path: go/interpreter/lfvm/memory.go
+  - threshold: 100
+    path: go/interpreter/lfvm/interpreter.go
   - threshold: 0
     path: go/processor/floria/processor.go
   - threshold: 0

--- a/go/interpreter/lfvm/converter_test.go
+++ b/go/interpreter/lfvm/converter_test.go
@@ -412,6 +412,23 @@ func TestConvert_SI_WhenDisabledNoSuperInstructionsAreUsed(t *testing.T) {
 	}
 }
 
+func TestConverter_SI_FallsBackToLFVMInstructionsWhenNoSuperInstructionIsFit(t *testing.T) {
+
+	config := ConversionConfig{
+		WithSuperInstructions: true,
+	}
+	code := []byte{byte(PUSH2), 0x12, 0x34, byte(ADD), byte(PUSH1), 0x56, byte(SUB)}
+	convertedCode := convert(code, config)
+	if len(convertedCode) != 4 {
+		t.Fatalf("Expected 4 instructions, got %d", len(convertedCode))
+	}
+	for _, inst := range convertedCode {
+		if inst.opcode.isSuperInstruction() {
+			t.Errorf("Super instruction %v used", inst.opcode)
+		}
+	}
+}
+
 func benchmarkConvertCode(b *testing.B, code []byte, config ConversionConfig) {
 	converter, err := NewConverter(config)
 	if err != nil {


### PR DESCRIPTION
Part of #751 

Refactor introduced a new branch, this pr adds a test for the situation where converter does not find any SI fit for the input and it falls-back to use normal LFVM instructions. 