### PR TITLE
evmrs: bump deps & refactor

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "benchmarks"
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e31ea183f6ee62ac8b8a8cf7feddd766317adfb13ff469de57ce033efd6a790"
+checksum = "50202def95bf36cb7d1d7a7962cea1c36a3f8ad42425e5d2b71d7acb8041b5b8"
 
 [[package]]
 name = "bumpalo"
@@ -150,18 +150,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.18"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.18"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -175,9 +175,9 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -296,13 +296,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "evmc-sys"
 version = "12.0.0-alpha.0"
-source = "git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions#2e71997a46b28ce8898346f4ba924c7397e8cb86"
+source = "git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions#3c08c564350c3c7341e2dae0059562cf37f41fe4"
 dependencies = [
  "bindgen",
 ]
@@ -310,7 +310,7 @@ dependencies = [
 [[package]]
 name = "evmc-vm"
 version = "12.0.0-alpha.0"
-source = "git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions#2e71997a46b28ce8898346f4ba924c7397e8cb86"
+source = "git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions#3c08c564350c3c7341e2dae0059562cf37f41fe4"
 dependencies = [
  "evmc-sys",
 ]
@@ -371,7 +371,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -382,7 +382,7 @@ checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -411,9 +411,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -441,9 +441,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libloading"
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oorandom"
@@ -592,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -602,18 +602,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-hash"
@@ -675,15 +675,15 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -751,9 +751,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -784,9 +784,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "version_check"
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -817,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -832,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -842,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -855,15 +855,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -887,7 +887,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -895,6 +895,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,7 +17,7 @@ dump-cov = []
 performance = []
 
 [dependencies]
-bnum = "0.11.0"
+bnum = "0.12.0"
 evmc-vm = { git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
 mockall = { version = "0.13.0", optional = true }
 sha3 = "0.10.8"

--- a/rust/scripts/bench.sh
+++ b/rust/scripts/bench.sh
@@ -64,4 +64,6 @@ for FEATURES in "$@"; do
     sed -i "s/$INTERPRETER-//g" $OUTPUT_FILE
 done
 
-benchstat $OUTPUT_DIR/* | tee $OUTPUT_DIR/comparison
+cd $OUTPUT_DIR
+benchstat * | tee comparison
+cd -

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -295,7 +295,7 @@ where
                         self.stack.push(u256::ZERO)?;
                     } else {
                         let end = min(call_data.len(), offset + 32);
-                        let mut bytes = [0; 32];
+                        let mut bytes = u256::ZERO;
                         bytes[..end - offset].copy_from_slice(&call_data[offset..end]);
                         self.stack.push(bytes)?;
                     }
@@ -903,6 +903,7 @@ where
             salt.into(),
             u256::ZERO.into(), // ignored
             None,
+            None,
         );
         let result = self.context.call(&message);
 
@@ -993,6 +994,7 @@ where
                 u256::ZERO.into(), // ignored
                 addr,
                 None,
+                None,
             )
         } else {
             ExecutionMessage::new(
@@ -1006,6 +1008,7 @@ where
                 value.into(),
                 u256::ZERO.into(), // ignored
                 u256::ZERO.into(), // ignored
+                None,
                 None,
             )
         };
@@ -1083,6 +1086,7 @@ where
                 u256::ZERO.into(), // ignored
                 addr,
                 None,
+                None,
             )
         } else {
             ExecutionMessage::new(
@@ -1096,6 +1100,7 @@ where
                 u256::ZERO.into(), // ignored
                 u256::ZERO.into(), // ignored
                 u256::ZERO.into(), // ignored
+                None,
                 None,
             )
         };

--- a/rust/src/types/amount.rs
+++ b/rust/src/types/amount.rs
@@ -111,9 +111,9 @@ impl From<U512> for u256 {
         // U512 = BUint<8>
         // BUint<8> is transparent wrapper around [u64; 8]
         let bytes64: [u8; 64] = unsafe { mem::transmute(be_value) };
-        let mut bytes32 = [0; 32];
+        let mut bytes32 = Self::ZERO;
         bytes32.copy_from_slice(&bytes64[32..]);
-        bytes32.into()
+        bytes32
     }
 }
 
@@ -164,17 +164,17 @@ impl From<usize> for u256 {
 
 impl From<Address> for u256 {
     fn from(value: Address) -> Self {
-        let mut bytes = [0; 32];
+        let mut bytes = Self::ZERO;
         bytes[32 - 20..].copy_from_slice(&value.bytes);
-        bytes.into()
+        bytes
     }
 }
 
 impl From<&Address> for u256 {
     fn from(value: &Address) -> Self {
-        let mut bytes = [0; 32];
+        let mut bytes = Self::ZERO;
         bytes[32 - 20..].copy_from_slice(&value.bytes);
-        bytes.into()
+        bytes
     }
 }
 

--- a/rust/src/types/code_reader.rs
+++ b/rust/src/types/code_reader.rs
@@ -69,11 +69,11 @@ impl<'a> CodeReader<'a> {
         assert!(len <= 32);
 
         let len = min(len, self.code.len() - self.pc);
-        let mut bytes = [0; 32];
-        bytes[32 - len..].copy_from_slice(&self.code[self.pc..self.pc + len]);
+        let mut data = u256::ZERO;
+        data[32 - len..].copy_from_slice(&self.code[self.pc..self.pc + len]);
         self.pc += len;
 
-        bytes.into()
+        data
     }
 
     pub fn pc(&self) -> usize {

--- a/rust/src/types/memory.rs
+++ b/rust/src/types/memory.rs
@@ -76,9 +76,9 @@ impl Memory {
 
     pub fn get_word(&mut self, offset: u256, gas_left: &mut Gas) -> Result<u256, StatusCode> {
         let slice = self.get_mut_slice(offset, 32u8.into(), gas_left)?;
-        let mut bytes = [0; 32];
-        bytes.copy_from_slice(slice);
-        Ok(bytes.into())
+        let mut word = u256::ZERO;
+        word.copy_from_slice(slice);
+        Ok(word)
     }
 
     pub fn get_mut_byte(

--- a/rust/src/types/mock_execution_message.rs
+++ b/rust/src/types/mock_execution_message.rs
@@ -18,6 +18,7 @@ pub struct MockExecutionMessage<'a> {
     pub create2_salt: Uint256,
     pub code_address: Address,
     pub code: Option<&'a [u8]>,
+    pub code_hash: Option<u256>,
 }
 
 impl<'a> MockExecutionMessage<'a> {
@@ -57,6 +58,7 @@ impl<'a> Default for MockExecutionMessage<'a> {
             create2_salt: u256::ZERO.into(),
             code_address: u256::ZERO.into(),
             code: None,
+            code_hash: None,
         }
     }
 }
@@ -75,6 +77,7 @@ impl<'a> From<MockExecutionMessage<'a>> for ExecutionMessage {
             value.create2_salt,
             value.code_address,
             value.code,
+            value.code_hash.map(Into::into),
         )
     }
 }


### PR DESCRIPTION
- bump deps (in particular `evmc-vm` which now has a `code_hash` field in `ExecutionMessage`)
- when creating an `u256` from bytes do not create `[u8; 32]` first and then convert into u256 but create u256 directly and use DerefMut impl
- cd into output dir and invoke benchstat there. this avoids having the full path in the header of the table which benchstat generates which blows up the table width