### PR TITLE
LFVM: CT Adapter tests

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -59,7 +59,7 @@ override:
     path: go/interpreter/evmc/evmc_steppable_interpreter.go
   - threshold: 0
     path: go/interpreter/geth/ct.go
-  - threshold: 87
+  - threshold: 95
     path: go/interpreter/lfvm/ct.go
   - threshold: 100
     path: go/interpreter/lfvm/lfvm.go

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -59,7 +59,7 @@ override:
     path: go/interpreter/evmc/evmc_steppable_interpreter.go
   - threshold: 0
     path: go/interpreter/geth/ct.go
-  - threshold: 95
+  - threshold: 100
     path: go/interpreter/lfvm/ct.go
   - threshold: 100
     path: go/interpreter/lfvm/lfvm.go

--- a/go/interpreter/lfvm/ct.go
+++ b/go/interpreter/lfvm/ct.go
@@ -20,14 +20,13 @@ import (
 )
 
 func NewConformanceTestingTarget() ct.Evm {
-	sanctionedVm, err := NewInterpreter(Config{})
-	if err != nil {
-		// because configuration values are hardcoded, this panic can only
-		// happen if the interpreter is misconfigured during development
-		panic("failed to create converter: " + err.Error())
-	}
 
-	cache, _ := lru.New[[32]byte, *pcMap](4096) // can only fail for non-positive size
+	// Can only fail for invalid configuration. Configuration is hardcoded.
+	sanctionedVm, _ := NewInterpreter(Config{})
+
+	// can only fail for non-positive size
+	cache, _ := lru.New[[32]byte, *pcMap](4096)
+
 	return &ctAdapter{
 		vm:         sanctionedVm,
 		pcMapCache: cache,

--- a/go/interpreter/lfvm/ct_test.go
+++ b/go/interpreter/lfvm/ct_test.go
@@ -165,10 +165,7 @@ func TestConvertToLfvm_StatusCode(t *testing.T) {
 	}
 
 	for status, test := range tests {
-		got, err := convertLfvmStatusToCtStatus(status)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		got := convertLfvmStatusToCtStatus(status)
 		if want, got := test, got; want != got {
 			t.Errorf("unexpected conversion, wanted %v, got %v", want, got)
 		}
@@ -176,9 +173,9 @@ func TestConvertToLfvm_StatusCode(t *testing.T) {
 }
 
 func TestConvertToLfvm_StatusCodeFailsOnUnknownStatus(t *testing.T) {
-	_, err := convertLfvmStatusToCtStatus(statusFailed + 1)
-	if err == nil {
-		t.Fatalf("expected error, got nil")
+	status := convertLfvmStatusToCtStatus(statusFailed + 1)
+	if status != st.Failed {
+		t.Errorf("unexpected conversion, wanted %v, got %v", st.Failed, status)
 	}
 }
 

--- a/go/interpreter/lfvm/ct_test.go
+++ b/go/interpreter/lfvm/ct_test.go
@@ -64,19 +64,16 @@ func TestCTAdapter_DoesNotAddDuplicatedCodeToPCMap(t *testing.T) {
 	}))
 	c := NewConformanceTestingTarget()
 
-	executeStepAndChecks := func() {
+	for i := 0; i < 3; i++ {
 		s.Status = st.Running
 		_, err := c.StepN(s, 1)
 		if err != nil {
 			t.Fatalf("unexpected conversion error: %v", err)
 		}
-		if c.(*ctAdapter).pcMapCache.Len() != 1 {
-			t.Fatalf("unexpected pc map size, wanted 2, got %d", c.(*ctAdapter).pcMapCache.Len())
+		if want, got := 1, c.(*ctAdapter).pcMapCache.Len(); want != got {
+			t.Fatalf("unexpected pc map size, wanted %d, got %d", want, got)
 		}
 	}
-
-	executeStepAndChecks()
-	executeStepAndChecks()
 }
 
 func TestCtAdapter_ReturnsErrorForUnsupportedRevisions(t *testing.T) {

--- a/go/interpreter/lfvm/instruction_logger_test.go
+++ b/go/interpreter/lfvm/instruction_logger_test.go
@@ -55,7 +55,7 @@ func TestInterpreter_Logger_ExecutesCodeAndLogs(t *testing.T) {
 			code := test.code
 			buffer := bytes.NewBuffer([]byte{})
 			logger := newLogger(buffer)
-			config := interpreterConfig{
+			config := config{
 				runner: logger,
 			}
 			_, err := run(config, params, code)
@@ -88,7 +88,7 @@ func TestInterpreter_Logger_RunsWithoutOutput(t *testing.T) {
 	defer func() { os.Stderr = oldErr }()
 
 	logger := newLogger(nil)
-	config := interpreterConfig{
+	config := config{
 		runner: logger,
 	}
 
@@ -132,7 +132,7 @@ func (l loggerErrorMock) Write(p []byte) (n int, err error) {
 func TestInterpreter_logger_PropagatesWriterError(t *testing.T) {
 
 	logger := newLogger(loggerErrorMock{})
-	config := interpreterConfig{
+	config := config{
 		runner: logger,
 	}
 	// Get tosca.Parameters

--- a/go/interpreter/lfvm/instruction_statistcs_test.go
+++ b/go/interpreter/lfvm/instruction_statistcs_test.go
@@ -32,7 +32,7 @@ func TestStatisticsRunner_RunWithStatistics(t *testing.T) {
 	statsRunner := &statisticRunner{
 		stats: newStatistics(),
 	}
-	config := interpreterConfig{
+	config := config{
 		runner: statsRunner,
 	}
 	_, err := run(config, params, code)

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -83,13 +83,8 @@ type runner interface {
 	run(*context) (status, error)
 }
 
-type interpreterConfig struct {
-	withShaCache bool
-	runner       runner
-}
-
 func run(
-	config interpreterConfig,
+	config config,
 	params tosca.Parameters,
 	code Code,
 ) (tosca.Result, error) {
@@ -110,7 +105,7 @@ func run(
 		stack:        NewStack(),
 		memory:       NewMemory(),
 		code:         code,
-		withShaCache: config.withShaCache,
+		withShaCache: config.WithShaCache,
 	}
 	defer ReturnStack(ctxt.stack)
 

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -285,7 +285,7 @@ func TestInterpreter_Vanilla_RunsWithoutOutput(t *testing.T) {
 	os.Stdout = w
 
 	// Run testing code
-	_, err := run(interpreterConfig{}, params, code)
+	_, err := run(config{}, params, code)
 	// read the output
 	_ = w.Close() // ignore error in test
 	out, _ := io.ReadAll(r)
@@ -303,7 +303,7 @@ func TestInterpreter_Vanilla_RunsWithoutOutput(t *testing.T) {
 func TestInterpreter_EmptyCodeBypassesRunnerAndSucceeds(t *testing.T) {
 	code := []Instruction{}
 	params := tosca.Parameters{}
-	config := interpreterConfig{
+	config := config{
 		runner: NewMockrunner(gomock.NewController(t)),
 	}
 
@@ -322,7 +322,7 @@ func TestInterpreter_run_ReturnsErrorOnRuntimeError(t *testing.T) {
 	runner := NewMockrunner(gomock.NewController(t))
 	code := []Instruction{{JUMPDEST, 0}}
 	params := tosca.Parameters{Gas: 20}
-	config := interpreterConfig{runner: runner}
+	config := config{runner: runner}
 
 	expectedError := fmt.Errorf("runtime error")
 

--- a/go/interpreter/lfvm/lfvm.go
+++ b/go/interpreter/lfvm/lfvm.go
@@ -19,7 +19,6 @@ import (
 
 // Config provides a set of user-definable options for the LFVM interpreter.
 type Config struct {
-	// TODO: add options for code cache size and other configuration options
 }
 
 // NewInterpreter creates a new LFVM interpreter instance with the official
@@ -130,12 +129,7 @@ func (v *lfvm) Run(params tosca.Parameters) (tosca.Result, error) {
 		params.CodeHash,
 	)
 
-	config := interpreterConfig{
-		withShaCache: v.config.WithShaCache,
-		runner:       v.config.runner,
-	}
-
-	return run(config, params, converted)
+	return run(v.config, params, converted)
 }
 
 func (e *lfvm) DumpProfile() {


### PR DESCRIPTION
This PR is part of #751 
This PR adds tests for CT adapter.

Early tests shown that CT was running with sha3 cache disabled, this pr forces CT runs to use the sanctioned configuration for the release.
