### PR TITLE
LFVM: Rest register experimental features into global registry

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -61,7 +61,7 @@ override:
     path: go/interpreter/geth/ct.go
   - threshold: 87
     path: go/interpreter/lfvm/ct.go
-  - threshold: 37
+  - threshold: 100
     path: go/interpreter/lfvm/lfvm.go
   - threshold: 100
     path: go/interpreter/lfvm/converter.go

--- a/go/interpreter/lfvm/lfvm_interface_test.go
+++ b/go/interpreter/lfvm/lfvm_interface_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package lfvm_test
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/Tosca/go/interpreter/lfvm"
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+)
+
+// TestLfvm_RegisterExperimentalConfigurations tests the registration of
+// experimental configurations.
+// This test is slightly different from other tests because of dealing with the
+// global registry:
+// - It is declared in it's own package to avoid leaking the registration to other tests.
+// - It tests different properties, in one single function. The reason is that the
+// order of different functions may change, invalidating the test.
+func TestLfvm_RegisterExperimentalConfigurations(t *testing.T) {
+
+	// Fist registration must succeed.
+	err := lfvm.RegisterExperimentalInterpreterConfigurations()
+	if err != nil {
+		t.Fatalf("failed to register experimental configurations: %v", err)
+	}
+
+	// Registering a second time must fail.
+	err = lfvm.RegisterExperimentalInterpreterConfigurations()
+	if err == nil {
+		t.Fatalf("expected error when registering experimental configurations twice")
+	}
+
+	// Check that lfvm is registered by default, in addition to experimental configurations
+	if _, ok := tosca.GetAllRegisteredInterpreters()["lfvm"]; !ok {
+		t.Fatalf("lfvm is not registered")
+	}
+
+	// Construct all registered interpreter configurations
+	for name, factory := range tosca.GetAllRegisteredInterpreters() {
+		t.Run(name, func(t *testing.T) {
+			vm, err := factory(lfvm.Config{})
+			if err != nil {
+				t.Fatalf("failed to create interpreter: %v", err)
+			}
+
+			// Vms are opaque, we can't check their configuration directly.
+			// We can only check that they do execute some basic code.
+			params := tosca.Parameters{}
+			params.Code = []byte{byte(lfvm.PUSH1), 0xff, byte(lfvm.POP), byte(lfvm.STOP)}
+			params.Gas = 5
+			res, err := vm.Run(params)
+			if err != nil {
+				t.Fatalf("failed to run interpreter: %v", err)
+			}
+
+			if want, got := true, res.Success; want != got {
+				t.Fatalf("unexpected success result: want %v, got %v", want, got)
+			}
+			if want, got := tosca.Gas(0), res.GasLeft; want != got {
+				t.Fatalf("unexpected gas used: want %v, got %v", want, got)
+			}
+		})
+	}
+}

--- a/go/interpreter/lfvm/lfvm_test.go
+++ b/go/interpreter/lfvm/lfvm_test.go
@@ -11,6 +11,7 @@
 package lfvm
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/Fantom-foundation/Tosca/go/tosca"
@@ -43,5 +44,30 @@ func TestLfvm_OfficialConfigurationHasSanctionedProperties(t *testing.T) {
 	}
 	if lfvm.config.ConversionConfig.WithSuperInstructions != false {
 		t.Fatalf("lfvm is configured with super instructions")
+	}
+}
+
+func TestLfvm_InterpreterReturnsErrorWhenExecutingUnsupportedRevision(t *testing.T) {
+	vm, err := tosca.NewInterpreter("lfvm")
+	if err != nil {
+		t.Fatalf("lfvm is not registered: %v", err)
+	}
+
+	params := tosca.Parameters{}
+	params.Revision = newestSupportedRevision + 1
+
+	_, err = vm.Run(params)
+	if want, got := fmt.Sprintf("unsupported revision %d", params.Revision), err.Error(); want != got {
+		t.Fatalf("unexpected error: want %q, got %q", want, got)
+	}
+}
+
+func TestLfvm_newVm_returnsErrorWithWrongConfiguration(t *testing.T) {
+	config := config{
+		ConversionConfig: ConversionConfig{CacheSize: maxCachedCodeLength / 2},
+	}
+	_, err := newVm(config)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
 	}
 }

--- a/go/tosca/interpreter.go
+++ b/go/tosca/interpreter.go
@@ -199,7 +199,7 @@ type ErrUnsupportedRevision struct {
 }
 
 func (e *ErrUnsupportedRevision) Error() string {
-	return fmt.Sprintf("Unsupported revision %d", e.Revision)
+	return fmt.Sprintf("unsupported revision %d", e.Revision)
 }
 
 // ProfilingInterpreter is an optional extension to the Interpreter interface


### PR DESCRIPTION
part of #684 

This PR adds testing for lfvm.go, in particular to registration of the experimental configurations of the vm and error handling during execution or construction of the vm.