### PR TITLE
LFVM: comments to #869

### DIFF
--- a/go/interpreter/lfvm/ct_test.go
+++ b/go/interpreter/lfvm/ct_test.go
@@ -165,10 +165,7 @@ func TestConvertToLfvm_StatusCode(t *testing.T) {
 	}
 
 	for status, test := range tests {
-		got, err := convertLfvmStatusToCtStatus(status)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		got := convertLfvmStatusToCtStatus(status)
 		if want, got := test, got; want != got {
 			t.Errorf("unexpected conversion, wanted %v, got %v", want, got)
 		}
@@ -176,9 +173,9 @@ func TestConvertToLfvm_StatusCode(t *testing.T) {
 }
 
 func TestConvertToLfvm_StatusCodeFailsOnUnknownStatus(t *testing.T) {
-	_, err := convertLfvmStatusToCtStatus(statusFailed + 1)
-	if err == nil {
-		t.Fatalf("expected error, got nil")
+	status := convertLfvmStatusToCtStatus(statusFailed + 1)
+	if status != st.Failed {
+		t.Errorf("unexpected conversion, wanted %v, got %v", st.Failed, status)
 	}
 }
 


### PR DESCRIPTION
This pr refines CT to reduce need for testing. 

- First, use the sanctioned constructor for the LFVM to get the converter from. This removes the risk of testing a different configuration in CT than the production code
- Manually increase memory size and cost of expansion, since this expansion cannot produce errors
- remove error in status convert, statusFailed is sufficient for the CT to figure out that something did not work out. 
