### PR TITLE
evmrs: add feature "mimalloc"

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -96,6 +96,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +332,7 @@ dependencies = [
  "driver",
  "evmc-vm",
  "evmrs",
+ "mimalloc",
  "mockall",
  "sha3",
 ]
@@ -456,6 +466,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +492,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "minimal-lexical"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,13 +14,16 @@ debug = true
 # Flag mock enables code generation for test mocking. This allows generating mocks for other build configuration but "test". 
 mock = ["dep:mockall"]
 dump-cov = []
-performance = []
+# optimizations:
+performance = ["mimalloc"]
+mimalloc = ["dep:mimalloc"]
 
 [dependencies]
 bnum = "0.12.0"
 evmc-vm = { git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
-mockall = { version = "0.13.0", optional = true }
 sha3 = "0.10.8"
+mockall = { version = "0.13.0", optional = true }
+mimalloc = { version = "0.1.43", optional = true }
 
 [dev-dependencies]
 # workaround for enabling mock feature also in integration tests

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -3,6 +3,10 @@ name = "benchmarks"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+performance = ["evmrs/performance"]
+mimalloc = ["evmrs/mimalloc"]
+
 [dependencies]
 evmc-vm = { git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
 evmrs = { path = ".." }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -28,3 +28,10 @@ pub unsafe extern "C" fn evmrs_dump_coverage() {
 pub extern "C" fn evmrs_is_coverage_enabled() -> u8 {
     cfg!(feature = "dump-cov") as u8
 }
+
+#[cfg(feature = "mimalloc")]
+use mimalloc::MiMalloc;
+
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;


### PR DESCRIPTION
This PR adds the feature "mimalloc". When enabled the default memory allocator is replaced by mimalloc.