### PR TITLE
evmrs: add feature "custom-evmc"

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -35,7 +35,6 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "driver",
- "evmc-vm",
  "evmrs",
 ]
 
@@ -288,7 +287,6 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 name = "driver"
 version = "0.1.0"
 dependencies = [
- "evmc-vm",
  "evmrs",
 ]
 
@@ -317,11 +315,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "evmc-sys"
+version = "12.0.0-alpha.0"
+source = "git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-execution-message-slice-output-box#814f804c60a313d00704da8fce3b7f8b07a92b37"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
 name = "evmc-vm"
 version = "12.0.0-alpha.0"
 source = "git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions#3c08c564350c3c7341e2dae0059562cf37f41fe4"
 dependencies = [
- "evmc-sys",
+ "evmc-sys 12.0.0-alpha.0 (git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions)",
+]
+
+[[package]]
+name = "evmc-vm"
+version = "12.0.0-alpha.0"
+source = "git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-execution-message-slice-output-box#814f804c60a313d00704da8fce3b7f8b07a92b37"
+dependencies = [
+ "evmc-sys 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-execution-message-slice-output-box)",
 ]
 
 [[package]]
@@ -330,7 +344,8 @@ version = "0.1.0"
 dependencies = [
  "bnum",
  "driver",
- "evmc-vm",
+ "evmc-vm 12.0.0-alpha.0 (git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions)",
+ "evmc-vm 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-execution-message-slice-output-box)",
  "evmrs",
  "mimalloc",
  "mockall",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,13 +15,15 @@ debug = true
 mock = ["dep:mockall"]
 dump-cov = []
 # optimizations:
-performance = ["mimalloc", "stack-array"]
+performance = ["mimalloc", "stack-array", "custom-evmc"]
 mimalloc = ["dep:mimalloc"]
 stack-array = []
+custom-evmc = ["dep:evmc-vm-tosca-refactor"]
 
 [dependencies]
 bnum = "0.12.0"
-evmc-vm = { git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
+evmc-vm-tosca = { package = "evmc-vm", git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
+evmc-vm-tosca-refactor = { package = "evmc-vm", git = "https://github.com/LorenzSchueler/evmc", branch = "tosca-extensions-execution-message-slice-output-box", optional = true }
 sha3 = "0.10.8"
 mockall = { version = "0.13.0", optional = true }
 mimalloc = { version = "0.1.43", optional = true }

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 performance = ["evmrs/performance"]
 mimalloc = ["evmrs/mimalloc"]
 stack-array = ["evmrs/stack-array"]
+custom-evmc = ["evmrs/custom-evmc"]
 
 [dependencies]
-evmc-vm = { git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
 evmrs = { path = ".." }
 driver = { path = "../driver" }
 

--- a/rust/benchmarks/src/lib.rs
+++ b/rust/benchmarks/src/lib.rs
@@ -1,13 +1,13 @@
-#![allow(unused_crate_dependencies)]
-
 use core::slice;
 
 use driver::{self, get_tx_context_zeroed, host_interface::null_ptr_host_interface, Instance};
-use evmc_vm::{
-    ffi::{evmc_host_interface, evmc_message},
-    Revision, StatusCode,
+use evmrs::{
+    evmc_vm::{
+        ffi::{evmc_host_interface, evmc_message},
+        Revision, StatusCode,
+    },
+    MockExecutionMessage, Opcode,
 };
-use evmrs::{MockExecutionMessage, Opcode};
 
 pub struct RunArgs {
     instance: Instance,

--- a/rust/driver/Cargo.toml
+++ b/rust/driver/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 mock = ["evmrs/mock"]
 
 [dependencies]
-evmc-vm = { git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
-evmrs = { path = "..", optional = true }
+evmrs = { path = ".." }

--- a/rust/driver/src/host_interface.rs
+++ b/rust/driver/src/host_interface.rs
@@ -1,14 +1,16 @@
-use evmc_vm::ffi::evmc_host_interface;
+use evmrs::evmc_vm::ffi::evmc_host_interface;
 
 #[cfg(feature = "mock")]
 mod mock_callbacks {
     use std::{ffi, slice};
 
-    use evmc_vm::{
-        ffi::{evmc_message, evmc_result, evmc_tx_context},
-        AccessStatus, Address, StorageStatus, Uint256,
+    use evmrs::{
+        evmc_vm::{
+            ffi::{evmc_message, evmc_result, evmc_tx_context},
+            AccessStatus, Address, StorageStatus, Uint256,
+        },
+        ExecutionContextTrait, MockExecutionContextTrait,
     };
-    use evmrs::{ExecutionContextTrait, MockExecutionContextTrait};
 
     pub extern "C" fn account_exists(context: *mut ffi::c_void, addr: *const Address) -> bool {
         let mock = unsafe { &mut *(context as *mut MockExecutionContextTrait) };

--- a/rust/driver/src/lib.rs
+++ b/rust/driver/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
     ptr,
 };
 
-use evmc_vm::{
+use evmrs::evmc_vm::{
     ffi::{
         evmc_host_interface, evmc_message, evmc_result, evmc_step_result, evmc_step_status_code,
         evmc_tx_context, evmc_vm as evmc_vm_t, evmc_vm_steppable,

--- a/rust/src/evmc.rs
+++ b/rust/src/evmc.rs
@@ -40,7 +40,7 @@ impl EvmcVm for EvmRs {
         if let Err(status_code) = interpreter.run() {
             return ExecutionResult::from(status_code);
         }
-        ExecutionResult::from(&interpreter)
+        ExecutionResult::from(&mut interpreter)
     }
 
     fn set_option(&mut self, _: &str, _: &str) -> Result<(), evmc_vm::SetOptionError> {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,6 +5,11 @@ mod interpreter;
 mod types;
 mod utils;
 
+#[cfg(not(feature = "custom-evmc"))]
+pub extern crate evmc_vm_tosca as evmc_vm;
+#[cfg(feature = "custom-evmc")]
+pub extern crate evmc_vm_tosca_refactor as evmc_vm;
+
 #[cfg(feature = "mock")]
 pub use types::MockExecutionContextTrait;
 pub use types::{u256, ExecutionContextTrait, MockExecutionMessage, Opcode};

--- a/rust/src/types/execution_context.rs
+++ b/rust/src/types/execution_context.rs
@@ -33,7 +33,11 @@ pub trait ExecutionContextTrait {
     fn selfdestruct(&mut self, address: &Address, beneficiary: &Address) -> bool;
 
     /// Call to another account.
+    #[cfg(not(feature = "custom-evmc"))]
     fn call(&mut self, message: &ExecutionMessage) -> ExecutionResult;
+    #[cfg(feature = "custom-evmc")]
+    #[allow(clippy::needless_lifetimes)] // this is a bug in clippy
+    fn call<'a>(&mut self, message: &ExecutionMessage<'a>) -> ExecutionResult;
 
     /// Get block hash of an account.
     fn get_block_hash(&self, num: i64) -> Uint256;

--- a/rust/src/types/mock_execution_message.rs
+++ b/rust/src/types/mock_execution_message.rs
@@ -63,8 +63,29 @@ impl<'a> Default for MockExecutionMessage<'a> {
     }
 }
 
+#[cfg(not(feature = "custom-evmc"))]
 impl<'a> From<MockExecutionMessage<'a>> for ExecutionMessage {
-    fn from(value: MockExecutionMessage) -> Self {
+    fn from(value: MockExecutionMessage<'a>) -> Self {
+        Self::new(
+            value.kind,
+            value.flags,
+            value.depth,
+            value.gas,
+            value.recipient,
+            value.sender,
+            value.input,
+            value.value,
+            value.create2_salt,
+            value.code_address,
+            value.code,
+            value.code_hash.map(Into::into),
+        )
+    }
+}
+
+#[cfg(feature = "custom-evmc")]
+impl<'a> From<MockExecutionMessage<'a>> for ExecutionMessage<'a> {
+    fn from(value: MockExecutionMessage<'a>) -> Self {
         Self::new(
             value.kind,
             value.flags,

--- a/rust/src/utils/helpers.rs
+++ b/rust/src/utils/helpers.rs
@@ -70,7 +70,7 @@ pub fn check_min_revision(min_revision: Revision, revision: Revision) -> Result<
 }
 
 #[inline(always)]
-pub fn check_not_read_only<E>(state: &Interpreter<E>) -> Result<(), FailStatus>
+pub fn check_not_read_only<E>(state: &Interpreter<'_, E>) -> Result<(), FailStatus>
 where
     E: ExecutionContextTrait,
 {

--- a/rust/tests/ffi.rs
+++ b/rust/tests/ffi.rs
@@ -1,11 +1,13 @@
-#![allow(clippy::undocumented_unsafe_blocks, unused_crate_dependencies)]
+#![allow(unused_crate_dependencies)]
 use driver::{
     get_tx_context_zeroed,
     host_interface::{self, null_ptr_host_interface},
     Instance, SteppableInstance, TX_CONTEXT_ZEROED, ZERO,
 };
-use evmc_vm::{Revision, StatusCode, StepStatusCode};
-use evmrs::{MockExecutionContextTrait, MockExecutionMessage, Opcode};
+use evmrs::{
+    evmc_vm::{Revision, StatusCode, StepStatusCode},
+    MockExecutionContextTrait, MockExecutionMessage, Opcode,
+};
 
 #[test]
 fn execute_can_be_called_with_mocked_context() {


### PR DESCRIPTION
This PR adds the feature "custom-evmc". When this feature is enabled a different version of evmc-vm is used, in which multiple allocations are avoided. 
To simplify the imports, evmrs (lib) reexports evmc_vm.

Important changes:
- evmrs reexports evmc_vm
- because ExecutionMessage now holds slices instead of Vec it has a lifetime
- output is now Option<Box<[u8]>> instead of Option<Vec<u8>>
- Interpreter -> ExecutionResult conversion now need a &mut because it moves the output field out of it leaving None behind
