### PR TITLE
Fix selfdestruct in geth adapter

### DIFF
--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -508,8 +508,9 @@ func (a *runContextAdapter) SelfDestruct(addr tosca.Address, beneficiary tosca.A
 	}
 
 	stateDb := a.evm.StateDB
+	selfdestructed := true
 	if stateDb.HasSelfDestructed(gc.Address(addr)) {
-		return false
+		selfdestructed = false
 	}
 	balance := stateDb.GetBalance(a.contract.Address())
 	stateDb.AddBalance(gc.Address(beneficiary), balance, tracing.BalanceDecreaseSelfdestruct)
@@ -521,7 +522,7 @@ func (a *runContextAdapter) SelfDestruct(addr tosca.Address, beneficiary tosca.A
 		stateDb.SelfDestruct(gc.Address(addr))
 	}
 
-	return true
+	return selfdestructed
 }
 
 func (a *runContextAdapter) CreateSnapshot() tosca.Snapshot {


### PR DESCRIPTION
Running the ethereum tests, multiple tests stressing the SELFDESTRUCT were failing. The account should always be selfdestructed but only return true for the first time.