### PR TITLE
CT: Add CodeHash for CT runs

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -61,7 +61,7 @@ override:
     path: go/interpreter/geth/ct.go
   - threshold: 87
     path: go/interpreter/lfvm/ct.go
-  - threshold: 38
+  - threshold: 37
     path: go/interpreter/lfvm/lfvm.go
   - threshold: 100
     path: go/interpreter/lfvm/converter.go

--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -26,8 +26,10 @@ import (
 func ToVmParameters(state *st.State) tosca.Parameters {
 
 	var code []byte
+	var codeHash tosca.Hash
 	if state.Code != nil {
 		code = state.Code.Copy()
+		codeHash = state.Code.Hash()
 	}
 
 	transactionContext := state.TransactionContext
@@ -61,8 +63,8 @@ func ToVmParameters(state *st.State) tosca.Parameters {
 		Sender:    tosca.Address(state.CallContext.CallerAddress),
 		Input:     state.CallData.ToBytes(),
 		Value:     tosca.Value(state.CallContext.Value.Bytes32be()),
-		CodeHash:  nil,
 		Code:      code,
+		CodeHash:  &codeHash,
 	}
 }
 


### PR DESCRIPTION
This was discovered by running coverage of lfvm Ct runs. CodeHash was never filled. 