### PR TITLE
Fix selfdestruct empty vs. exists bug

### DIFF
--- a/go/integration_test/interpreter/dynamic_gas.go
+++ b/go/integration_test/interpreter/dynamic_gas.go
@@ -840,6 +840,13 @@ func gasDynamicSelfDestruct(revision Revision) []*DynGasTest {
 			})
 
 			mock.EXPECT().AccountExists(targetAddress).AnyTimes().Return(!empty)
+			mock.EXPECT().GetBalance(targetAddress).AnyTimes().Return(tosca.Value{})
+			mock.EXPECT().GetCode(targetAddress).AnyTimes().Return(nil)
+			if empty {
+				mock.EXPECT().GetNonce(targetAddress).AnyTimes().Return(uint64(0))
+			} else {
+				mock.EXPECT().GetNonce(targetAddress).AnyTimes().Return(uint64(1))
+			}
 			mock.EXPECT().IsAddressInAccessList(targetAddress).AnyTimes().Return(inAcl)
 			mock.EXPECT().AccessAccount(targetAddress).AnyTimes().Return(tosca.AccessStatus(inAcl))
 		}

--- a/go/integration_test/interpreter/verify_gas_test.go
+++ b/go/integration_test/interpreter/verify_gas_test.go
@@ -106,12 +106,13 @@ func TestDynamicGas(t *testing.T) {
 
 						// World state interactions triggered by the EVM.
 						mockStateDB.EXPECT().SetBalance(gomock.Any(), gomock.Any()).AnyTimes()
-						mockStateDB.EXPECT().GetNonce(gomock.Any()).AnyTimes()
 						mockStateDB.EXPECT().SetNonce(gomock.Any(), gomock.Any()).AnyTimes()
 						mockStateDB.EXPECT().SetCode(gomock.Any(), gomock.Any()).AnyTimes()
 
-						// SELFDESTRUCT gas computation is dependent on an account balance and sets its own expectations
+						// SELFDESTRUCT gas computation is dependent on an account balance and
+						// existence (handled by nonce in this test), it sets its own expectations
 						if op != vm.SELFDESTRUCT {
+							mockStateDB.EXPECT().GetNonce(gomock.Any()).AnyTimes()
 							mockStateDB.EXPECT().GetBalance(gomock.Any()).AnyTimes().Return(accountBalance)
 						}
 

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -656,10 +656,16 @@ func opSelfdestruct(c *context) (status, error) {
 			cost += getAccessCost(accessStatus)
 		}
 	}
-	empty := c.context.GetBalance(beneficiary).Cmp(tosca.Value{}) == 0 &&
+
+	empty := c.context.GetBalance(beneficiary) == (tosca.Value{}) &&
 		c.context.GetCode(beneficiary) == nil &&
 		c.context.GetNonce(beneficiary) == 0
-	cost += selfDestructNewAccountCost(empty, c.context.GetBalance(c.params.Recipient))
+	balance := c.context.GetBalance(c.params.Recipient)
+	if empty && balance != (tosca.Value{}) {
+		// cost of creating an account defined in eip-150 (see https://eips.ethereum.org/EIPS/eip-150)
+		cost += 25_000
+	}
+
 	// even death is not for free
 	if err := c.useGas(cost); err != nil {
 		return statusStopped, err
@@ -668,16 +674,6 @@ func opSelfdestruct(c *context) (status, error) {
 	destructed := c.context.SelfDestruct(c.params.Recipient, beneficiary)
 	c.refund += selfDestructRefund(destructed, c.params.Revision)
 	return statusSelfDestructed, nil
-}
-
-func selfDestructNewAccountCost(accountEmpty bool, balance tosca.Value) tosca.Gas {
-	if accountEmpty && balance != (tosca.Value{}) {
-		// cost of creating an account defined in eip-150 (see https://eips.ethereum.org/EIPS/eip-150)
-		// CreateBySelfdestructGas is used when the refunded account is one that does
-		// not exist. This logic is similar to call.
-		return 25_000
-	}
-	return 0
 }
 
 func selfDestructRefund(destructed bool, revision tosca.Revision) tosca.Gas {

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -188,6 +188,7 @@ func TestInterpreter_CanDispatchExecutableInstructions(t *testing.T) {
 				mock.EXPECT().GetBalance(gomock.Any()).AnyTimes()
 				mock.EXPECT().GetCodeSize(gomock.Any()).AnyTimes()
 				mock.EXPECT().GetCode(gomock.Any()).AnyTimes()
+				mock.EXPECT().GetNonce(gomock.Any()).AnyTimes()
 				mock.EXPECT().AccountExists(gomock.Any()).AnyTimes()
 				mock.EXPECT().AccessStorage(gomock.Any(), gomock.Any()).AnyTimes()
 				mock.EXPECT().GetStorage(gomock.Any(), gomock.Any()).AnyTimes()


### PR DESCRIPTION
The ethereum tests pointed out another problem regarding selfdestruct, the dynamic gas computation should not rely on whether the account exists but if its balance = 0, code = nil and nonce = 0.