### PR TITLE
evmrs: add feature "hash-cache"

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +303,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,10 +359,17 @@ dependencies = [
  "evmc-vm 12.0.0-alpha.0 (git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions)",
  "evmc-vm 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-execution-message-slice-output-box)",
  "evmrs",
+ "lru",
  "mimalloc",
  "mockall",
  "sha3",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "fragile"
@@ -382,6 +401,17 @@ checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -501,6 +531,15 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "memchr"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,11 +15,18 @@ debug = true
 mock = ["dep:mockall"]
 dump-cov = []
 # optimizations:
-performance = ["mimalloc", "stack-array", "custom-evmc", "jumptable"]
+performance = [
+    "mimalloc",
+    "stack-array",
+    "custom-evmc",
+    "jumptable",
+    "hash-cache",
+]
 mimalloc = ["dep:mimalloc"]
 stack-array = []
 custom-evmc = ["dep:evmc-vm-tosca-refactor"]
 jumptable = []
+hash-cache = ["dep:lru"]
 
 [dependencies]
 bnum = "0.12.0"
@@ -28,6 +35,7 @@ evmc-vm-tosca-refactor = { package = "evmc-vm", git = "https://github.com/Lorenz
 sha3 = "0.10.8"
 mockall = { version = "0.13.0", optional = true }
 mimalloc = { version = "0.1.43", optional = true }
+lru = { version = "0.12.5", optional = true }
 
 [dev-dependencies]
 # workaround for enabling mock feature also in integration tests

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -9,6 +9,7 @@ mimalloc = ["evmrs/mimalloc"]
 stack-array = ["evmrs/stack-array"]
 custom-evmc = ["evmrs/custom-evmc"]
 jumptable = ["evmrs/jumptable"]
+hash-cache = ["evmrs/hash-cache"]
 
 [dependencies]
 evmrs = { path = ".." }

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -4,12 +4,11 @@ use evmc_vm::{
     AccessStatus, ExecutionMessage, ExecutionResult, MessageFlags, MessageKind, Revision,
     StatusCode as EvmcStatusCode, StepResult, StorageStatus, Uint256,
 };
-use sha3::{Digest, Keccak256};
 
 use crate::{
     types::{
-        u256, CodeReader, ExecStatus, ExecutionContextTrait, ExecutionTxContext, FailStatus,
-        GetOpcodeError, Memory, Opcode, Stack,
+        hash_cache, u256, CodeReader, ExecStatus, ExecutionContextTrait, ExecutionTxContext,
+        FailStatus, GetOpcodeError, Memory, Opcode, Stack,
     },
     utils::{check_min_revision, check_not_read_only, word_size, Gas, SliceExt},
 };
@@ -748,11 +747,7 @@ where
         self.gas_left.consume(6 * word_size(len)?)?; // * does not overflow
 
         let data = self.memory.get_mut_slice(offset, len, &mut self.gas_left)?;
-        let mut hasher = Keccak256::new();
-        hasher.update(data);
-        let mut bytes = [0; 32];
-        hasher.finalize_into((&mut bytes).into());
-        self.stack.push(bytes)?;
+        self.stack.push(hash_cache::hash(data))?;
         Ok(())
     }
 

--- a/rust/src/types/hash_cache.rs
+++ b/rust/src/types/hash_cache.rs
@@ -1,0 +1,56 @@
+#[cfg(feature = "hash-cache")]
+use std::{
+    num::NonZeroUsize,
+    sync::{LazyLock, Mutex},
+};
+
+#[cfg(feature = "hash-cache")]
+use lru::LruCache;
+use sha3::{Digest, Keccak256};
+
+use crate::u256;
+
+#[cfg(feature = "hash-cache")]
+const CACHE_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(1024) };
+
+// Mutex<LruCache<...>> is faster that quick_cache::Cache<...>
+#[cfg(feature = "hash-cache")]
+static HASH_CACHE_32: LazyLock<Mutex<LruCache<[u8; 32], u256>>> =
+    LazyLock::new(|| Mutex::new(LruCache::new(CACHE_SIZE)));
+#[cfg(feature = "hash-cache")]
+static HASH_CACHE_64: LazyLock<Mutex<LruCache<[u8; 64], u256>>> =
+    LazyLock::new(|| Mutex::new(LruCache::new(CACHE_SIZE)));
+
+fn sha3(data: &[u8]) -> u256 {
+    let mut hasher = Keccak256::new();
+    hasher.update(data);
+    let mut bytes = [0; 32];
+    hasher.finalize_into((&mut bytes).into());
+
+    bytes.into()
+}
+
+pub fn hash(data: &[u8]) -> u256 {
+    #[cfg(feature = "hash-cache")]
+    if data.len() == 32 {
+        // SAFETY:
+        // data has length 32 so it is safe to cast it to &[u8; 32].
+        let data = unsafe { &*(data.as_ptr() as *const [u8; 32]) };
+        *HASH_CACHE_32
+            .lock()
+            .unwrap()
+            .get_or_insert_ref(data, || sha3(data))
+    } else if data.len() == 64 {
+        // SAFETY:
+        // data has length 64 so it is safe to cast it to &[u8; 64].
+        let data = unsafe { &*(data.as_ptr() as *const [u8; 64]) };
+        *HASH_CACHE_64
+            .lock()
+            .unwrap()
+            .get_or_insert_ref(data, || sha3(data))
+    } else {
+        sha3(data)
+    }
+    #[cfg(not(feature = "hash-cache"))]
+    sha3(data)
+}

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -1,6 +1,7 @@
 mod amount;
 mod code_reader;
 mod execution_context;
+pub mod hash_cache;
 mod memory;
 mod mock_execution_message;
 mod opcode;


### PR DESCRIPTION
This PR adds the feature "hash-cache". When enabled, the sha3 hashes of 32 and 64 byte slices are stored in an last-recently-used cache.