### PR TITLE
evmrs: exclude mock,dump-cov,performance from feature matrix testing

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -58,7 +58,7 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo clippy
       working-directory: rust
-      run: cargo hack --workspace --feature-powerset clippy --examples --tests --benches -- --deny warnings
+      run: cargo hack --workspace --feature-powerset --exclude-features mock,dump-cov,performance clippy --examples --tests --benches -- --deny warnings
     
   doc:
     name: doc
@@ -79,7 +79,7 @@ jobs:
       env:
         RUSTDOCFLAGS: "-D warnings" 
       working-directory: rust
-      run: cargo hack --workspace --feature-powerset doc --no-deps
+      run: cargo hack --workspace --feature-powerset --exclude-features mock,dump-cov,performance doc --no-deps
 
   build:
     name: build
@@ -98,7 +98,7 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo build
       working-directory: rust
-      run: cargo hack --workspace --feature-powerset build
+      run: cargo hack --workspace --feature-powerset --exclude-features mock,dump-cov,performance build
 
   test:
     name: test
@@ -117,7 +117,7 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo test
       working-directory: rust
-      run: cargo hack --workspace --feature-powerset test
+      run: cargo hack --workspace --feature-powerset --exclude-features mock,dump-cov,performance test
 
   deps:
     name: unused deps


### PR DESCRIPTION
This PR removes the features mock, dump-cov and performance from feature matrix testing in CI.
With every feature the size of the feature matrix doubles so now that more and more features are added it is essential to only test those combinations that really matter.

Feature performance is just a combination of other features and is therefore already tested implicitly.
Feature mock is enabled for tests do it is also enabled implicitly.
Feature dump-cov is completely independent from all other features and also just contains two lines of code.