### PR TITLE
CT: refactor domain for offsets.

### DIFF
--- a/go/ct/evm_test.go
+++ b/go/ct/evm_test.go
@@ -22,13 +22,14 @@ import (
 	"github.com/Fantom-foundation/Tosca/go/ct/spc"
 	"github.com/Fantom-foundation/Tosca/go/ct/st"
 	"github.com/Fantom-foundation/Tosca/go/interpreter/evmzero"
+	"github.com/Fantom-foundation/Tosca/go/interpreter/geth"
 	"github.com/Fantom-foundation/Tosca/go/interpreter/lfvm"
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 	"github.com/Fantom-foundation/Tosca/go/tosca/vm"
 )
 
 var evms = map[string]ct.Evm{
-	// "geth":    tosca.NewConformanceTestingTarget(), // < TODO: fix and reenable
+	"geth":    geth.NewConformanceTestingTarget(),
 	"lfvm":    lfvm.NewConformanceTestingTarget(),
 	"evmzero": evmzero.NewConformanceTestingTarget(),
 }

--- a/go/ct/rlz/parameters.go
+++ b/go/ct/rlz/parameters.go
@@ -62,6 +62,7 @@ func (JumpTargetParameter) Samples() []U256 {
 
 type StorageAccessKeyParameter = NumericParameter
 
+// MemoryOffsetParameter is a parameter for offsets used when accessing memory.
 type MemoryOffsetParameter struct{}
 
 var memoryOffsetParameterSamples = []U256{
@@ -77,13 +78,33 @@ func (MemoryOffsetParameter) Samples() []U256 {
 	return memoryOffsetParameterSamples
 }
 
-type MemorySizeParameter struct{}
+// DataOffsetParameter is a parameter for offsets used when accessing other
+// buffers but Memory (input, code, return).
+// Because these buffers are not expanding memory, much larger offsets are valid.
+type DataOffsetParameter struct{}
 
-var memorySizeParameterSamples = []U256{
+var dataOffsetParameterSamples = []U256{
+	NewU256(0),
+	NewU256(1),
+	NewU256(32),
+	NewU256(math.MaxUint64),
+	MaxU256(),
+}
+
+func (DataOffsetParameter) Samples() []U256 {
+	return dataOffsetParameterSamples
+}
+
+// SizeParameter is a parameter for sizes used when accessing buffers,
+// Ops involving both memory and a second buffer use one single size parameter.
+type SizeParameter struct{}
+
+var sizeParameterSamples = []U256{
 	NewU256(0),
 	NewU256(1),
 	NewU256(32),
 	NewU256(1, 0),
+
 	// Samples stressing the max init code size introduced with Shanghai
 	NewU256(2*24576 - 1),
 	NewU256(2 * 24576),
@@ -93,8 +114,8 @@ var memorySizeParameterSamples = []U256{
 	NewU256(st.MaxMemoryExpansionSize + 1),
 }
 
-func (MemorySizeParameter) Samples() []U256 {
-	return memorySizeParameterSamples
+func (SizeParameter) Samples() []U256 {
+	return sizeParameterSamples
 }
 
 type TopicParameter struct{}
@@ -125,9 +146,6 @@ var addressParameterSamples = []U256{
 func (AddressParameter) Samples() []U256 {
 	return addressParameterSamples
 }
-
-type DataOffsetParameter = MemoryOffsetParameter
-type DataSizeParameter = MemorySizeParameter
 
 type GasParameter struct{}
 

--- a/go/ct/rlz/parameters.go
+++ b/go/ct/rlz/parameters.go
@@ -77,21 +77,6 @@ func (MemoryOffsetParameter) Samples() []U256 {
 	return memoryOffsetParameterSamples
 }
 
-type MemoryOffsetForCopyParameter struct{}
-
-var memoryOffsetForCopyParameter = []U256{
-	NewU256(0),
-	NewU256(1),
-	NewU256(32),
-	NewU256(st.MaxMemoryExpansionSize),
-	NewU256(st.MaxMemoryExpansionSize + 1),
-	NewU256(1, 0),
-}
-
-func (MemoryOffsetForCopyParameter) Samples() []U256 {
-	return memoryOffsetForCopyParameter
-}
-
 type MemorySizeParameter struct{}
 
 var memorySizeParameterSamples = []U256{

--- a/go/ct/rlz/parameters_test.go
+++ b/go/ct/rlz/parameters_test.go
@@ -35,9 +35,9 @@ func TestNumericParameter_Samples(t *testing.T) {
 			got:  MemoryOffsetParameter{}.Samples(),
 			want: memoryOffsetParameterSamples,
 		},
-		"MemorySizeParameter": {
-			got:  MemorySizeParameter{}.Samples(),
-			want: memorySizeParameterSamples,
+		"SizeParameter": {
+			got:  SizeParameter{}.Samples(),
+			want: sizeParameterSamples,
 		},
 		"TopicParameter": {
 			got:  TopicParameter{}.Samples(),
@@ -54,6 +54,10 @@ func TestNumericParameter_Samples(t *testing.T) {
 		"ValueParameter": {
 			got:  ValueParameter{}.Samples(),
 			want: valueParameterSamples,
+		},
+		"DataOffsetParameter": {
+			got:  DataOffsetParameter{}.Samples(),
+			want: dataOffsetParameterSamples,
 		},
 	}
 

--- a/go/ct/rlz/parameters_test.go
+++ b/go/ct/rlz/parameters_test.go
@@ -35,10 +35,6 @@ func TestNumericParameter_Samples(t *testing.T) {
 			got:  MemoryOffsetParameter{}.Samples(),
 			want: memoryOffsetParameterSamples,
 		},
-		"MemoryOffsetForCopyParameter": {
-			got:  MemoryOffsetForCopyParameter{}.Samples(),
-			want: memoryOffsetForCopyParameter,
-		},
 		"MemorySizeParameter": {
 			got:  MemorySizeParameter{}.Samples(),
 			want: memorySizeParameterSamples,

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -349,7 +349,7 @@ func getAllRules() []Rule {
 		pops:      1,
 		pushes:    1,
 		parameters: []Parameter{
-			MemoryOffsetForCopyParameter{},
+			MemoryOffsetParameter{},
 		},
 		effect: func(s *st.State) {
 			offsetU256 := s.Stack.Pop()
@@ -374,7 +374,7 @@ func getAllRules() []Rule {
 		pops:      2,
 		pushes:    0,
 		parameters: []Parameter{
-			MemoryOffsetForCopyParameter{},
+			MemoryOffsetParameter{},
 			NumericParameter{},
 		},
 		effect: func(s *st.State) {
@@ -384,7 +384,6 @@ func getAllRules() []Rule {
 			cost, offset, _ := s.Memory.ExpansionCosts(offsetU256, NewU256(32))
 			if s.Gas < cost {
 				s.Status = st.Failed
-				s.Gas = 0
 				return
 			}
 			s.Gas -= cost
@@ -402,7 +401,7 @@ func getAllRules() []Rule {
 		pops:      2,
 		pushes:    0,
 		parameters: []Parameter{
-			MemoryOffsetForCopyParameter{},
+			MemoryOffsetParameter{},
 			NumericParameter{},
 		},
 		effect: func(s *st.State) {
@@ -412,7 +411,6 @@ func getAllRules() []Rule {
 			cost, offset, _ := s.Memory.ExpansionCosts(offsetU256, NewU256(1))
 			if s.Gas < cost {
 				s.Status = st.Failed
-				s.Gas = 0
 				return
 			}
 			s.Gas -= cost
@@ -881,8 +879,8 @@ func getAllRules() []Rule {
 		pops:      3,
 		pushes:    0,
 		parameters: []Parameter{
-			MemoryOffsetForCopyParameter{},
-			MemoryOffsetForCopyParameter{},
+			MemoryOffsetParameter{},
+			MemoryOffsetParameter{},
 			MemorySizeParameter{},
 		},
 		conditions: []Condition{
@@ -1180,7 +1178,7 @@ func getAllRules() []Rule {
 		},
 		parameters: []Parameter{
 			AddressParameter{},
-			MemoryOffsetForCopyParameter{},
+			MemoryOffsetParameter{},
 			DataOffsetParameter{},
 			DataSizeParameter{}},
 		effect: func(s *st.State) {
@@ -1201,7 +1199,7 @@ func getAllRules() []Rule {
 		},
 		parameters: []Parameter{
 			AddressParameter{},
-			MemoryOffsetForCopyParameter{},
+			MemoryOffsetParameter{},
 			DataOffsetParameter{},
 			DataSizeParameter{}},
 		effect: func(s *st.State) {
@@ -1221,7 +1219,7 @@ func getAllRules() []Rule {
 		},
 		parameters: []Parameter{
 			AddressParameter{},
-			MemoryOffsetForCopyParameter{},
+			MemoryOffsetParameter{},
 			DataOffsetParameter{},
 			DataSizeParameter{}},
 		effect: func(s *st.State) {
@@ -1436,7 +1434,7 @@ func getAllRules() []Rule {
 		pops:      3,
 		pushes:    0,
 		parameters: []Parameter{
-			MemoryOffsetForCopyParameter{},
+			MemoryOffsetParameter{},
 			DataOffsetParameter{},
 			DataSizeParameter{}},
 		effect: func(s *st.State) {
@@ -1484,7 +1482,7 @@ func getAllRules() []Rule {
 		staticGas:  3,
 		pops:       1,
 		pushes:     1,
-		parameters: []Parameter{MemoryOffsetForCopyParameter{}},
+		parameters: []Parameter{MemoryOffsetParameter{}},
 		effect: func(s *st.State) {
 			offsetU256 := s.Stack.Pop()
 			pushData := NewU256(0)

--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -263,7 +263,6 @@ func getAllRules() []Rule {
 			memExpCost, offset, size := s.Memory.ExpansionCosts(offsetU256, sizeU256)
 			if s.Gas < memExpCost {
 				s.Status = st.Failed
-				s.Gas = 0
 				return
 			}
 			s.Gas -= memExpCost
@@ -271,7 +270,6 @@ func getAllRules() []Rule {
 			wordCost := tosca.Gas(6 * tosca.SizeInWords(size))
 			if s.Gas < wordCost {
 				s.Status = st.Failed
-				s.Gas = 0
 				return
 			}
 			s.Gas -= wordCost
@@ -359,7 +357,6 @@ func getAllRules() []Rule {
 			cost, offset, _ := s.Memory.ExpansionCosts(offsetU256, NewU256(32))
 			if s.Gas < cost {
 				s.Status = st.Failed
-				s.Gas = 0
 				return
 			}
 			s.Gas -= cost
@@ -904,7 +901,6 @@ func getAllRules() []Rule {
 			dynamicGas, overflow := sumWithOverflow(expansionCost, wordCountCost)
 			if s.Gas < dynamicGas || overflow {
 				s.Status = st.Failed
-				s.Gas = 0
 				return
 			}
 			s.Gas -= dynamicGas
@@ -1452,7 +1448,6 @@ func getAllRules() []Rule {
 			cost, overflow := sumWithOverflow(cost, tosca.Gas(3*tosca.SizeInWords(size)))
 			if s.Gas < cost || overflow {
 				s.Status = st.Failed
-				s.Gas = 0
 				return
 			}
 			s.Gas -= cost
@@ -1529,7 +1524,6 @@ func getAllRules() []Rule {
 			expansionCost, overflow := sumWithOverflow(expansionCost, tosca.Gas(3*tosca.SizeInWords(size)))
 			if s.Gas < expansionCost || overflow {
 				s.Status = st.Failed
-				s.Gas = 0
 				return
 			}
 			s.Gas -= expansionCost
@@ -1593,7 +1587,6 @@ func getAllRules() []Rule {
 			if !offsetU256.IsUint64() || !sizeU256.IsUint64() || overflow ||
 				readUntil > uint64(s.LastCallReturnData.Length()) {
 				s.Status = st.Failed
-				s.Gas = 0
 				return
 			}
 
@@ -1601,7 +1594,6 @@ func getAllRules() []Rule {
 			expansionCost, overflow = sumWithOverflow(expansionCost, tosca.Gas(3*tosca.SizeInWords(size)))
 			if s.Gas < expansionCost || overflow {
 				s.Status = st.Failed
-				s.Gas = 0
 				return
 			}
 			s.Gas -= expansionCost
@@ -1627,7 +1619,6 @@ func getAllRules() []Rule {
 			expansionCost, offset, size := s.Memory.ExpansionCosts(offsetU256, sizeU256)
 			if s.Gas < expansionCost {
 				s.Status = st.Failed
-				s.Gas = 0
 				return
 			}
 			s.Gas -= expansionCost
@@ -1654,7 +1645,6 @@ func getAllRules() []Rule {
 			expansionCost, offset, size := s.Memory.ExpansionCosts(offsetU256, sizeU256)
 			if s.Gas < expansionCost {
 				s.Status = st.Failed
-				s.Gas = 0
 				return
 			}
 			s.Gas -= expansionCost
@@ -1797,13 +1787,11 @@ func createEffect(s *st.State, callKind tosca.CallKind) {
 			InitCodeWordGas = 2 // Once per word of the init code when creating a contract.
 		)
 		if !sizeU256.IsUint64() || size > MaxInitCodeSize {
-			s.Gas = 0
 			s.Status = st.Failed
 			return
 		}
 		dynamicGas, overflow = sumWithOverflow(dynamicGas, tosca.Gas(InitCodeWordGas*tosca.SizeInWords(size)))
 		if overflow {
-			s.Gas = 0
 			s.Status = st.Failed
 			return
 		}
@@ -1814,7 +1802,6 @@ func createEffect(s *st.State, callKind tosca.CallKind) {
 		saltU256 = s.Stack.Pop()
 		dynamicGas, overflow = sumWithOverflow(dynamicGas, tosca.Gas(6*tosca.SizeInWords(size)))
 		if overflow {
-			s.Gas = 0
 			s.Status = st.Failed
 			return
 		}
@@ -1822,7 +1809,6 @@ func createEffect(s *st.State, callKind tosca.CallKind) {
 
 	if s.Gas < dynamicGas {
 		s.Status = st.Failed
-		s.Gas = 0
 		return
 	}
 	s.Gas -= dynamicGas
@@ -1881,7 +1867,6 @@ func binaryOpWithDynamicCost(
 			// TODO: Improve handling of dynamic gas through dedicated constraint.
 			if s.Gas < dynamicCost {
 				s.Status = st.Failed
-				s.Gas = 0
 				return
 			}
 			s.Gas -= dynamicCost
@@ -2009,7 +1994,6 @@ func extCodeCopyEffect(s *st.State, markWarm bool) {
 	cost, overflow := sumWithOverflow(cost, tosca.Gas(3*tosca.SizeInWords(size)))
 	if s.Gas < cost || overflow {
 		s.Status = st.Failed
-		s.Gas = 0
 		return
 	}
 	s.Gas -= cost
@@ -2183,14 +2167,12 @@ func logOp(n int) []Rule {
 			memExpCost, offset, size := s.Memory.ExpansionCosts(offsetU256, sizeU256)
 			if s.Gas < memExpCost {
 				s.Status = st.Failed
-				s.Gas = 0
 				return
 			}
 			s.Gas -= memExpCost
 
 			if s.Gas < tosca.Gas(8*size) {
 				s.Status = st.Failed
-				s.Gas = 0
 				return
 			}
 			s.Gas -= tosca.Gas(8 * size)


### PR DESCRIPTION
This PR changes the definition for offsets, adding the difference between Data and Memory:
- Memory is artificially capped, because the VM will always allocate the memory if there is enough gas and this has a hardware limit. 
- Data Offsets are not capped, this is because input, code, and return data are not resizable. They handle overflows via other mechanisms (zero padding for reads, errors for writes) and therefore the offset values can be much larger. 
- Additionally, Size has been unified because it is used indistinctly. Sometimes combined. 

Some other refactors for the CT:
- remove gas=0 on error, this is not something we need to check.
- reactivate Geth in TestCt_ExplicitCases (playground test).


- [ ]  rerun ct coverage