### PR TITLE
LFVM: 100% coverage :pizza: 

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -59,16 +59,6 @@ override:
     path: go/interpreter/evmc/evmc_steppable_interpreter.go
   - threshold: 0
     path: go/interpreter/geth/ct.go
-  - threshold: 100
-    path: go/interpreter/lfvm/ct.go
-  - threshold: 100
-    path: go/interpreter/lfvm/lfvm.go
-  - threshold: 100
-    path: go/interpreter/lfvm/converter.go
-  - threshold: 100
-    path: go/interpreter/lfvm/memory.go
-  - threshold: 100
-    path: go/interpreter/lfvm/interpreter.go
   - threshold: 0
     path: go/processor/floria/processor.go
   - threshold: 0
@@ -97,7 +87,7 @@ override:
     path: go/integration_test/processor
   - threshold: 0
     path: go/interpreter/evmc
-  - threshold: 96
+  - threshold:  100
     path: go/interpreter/lfvm
   - threshold: 0
     path: go/processor/floria

--- a/Makefile
+++ b/Makefile
@@ -52,20 +52,23 @@ evmone:
 	cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_SHARED_LIBRARY_SUFFIX_CXX=.so ; \
 	cmake --build build --parallel -t evmone
 
-coverage-go: DATE=$(shell date +"%Y-%m-%d-%T")
-coverage-go: TOSCA_GO_COVERAGE_DIR=./go/build/coverage/${TOSCA_GO_COVERAGE_EVM}/${DATE}
-coverage-go:
-	go build -cover -o ${TOSCA_GO_COVERAGE_DIR}/driver -coverpkg=./go/...,${TOSCA_GO_COVERAGE_DEPENDENCY_PACKAGES} ./go/ct/driver/ ; \
-	GOCOVERDIR=${TOSCA_GO_COVERAGE_DIR} ${TOSCA_GO_COVERAGE_DIR}/driver run --max-errors 1 ${TOSCA_GO_COVERAGE_EVM} ; \
-	go tool covdata textfmt --i ${TOSCA_GO_COVERAGE_DIR} -o ${TOSCA_GO_COVERAGE_DIR}/driver_coverage_report.txt ; \
-	go tool cover -html ${TOSCA_GO_COVERAGE_DIR}/driver_coverage_report.txt -o ${TOSCA_GO_COVERAGE_DIR}/coverage_output.html
+ct-coverage-go: DATE=$(shell date +"%Y-%m-%d-%T")
+ct-coverage-go: PACKAGES=${EXTRA_PACKAGES},./go/ct/driver/
+ct-coverage-go: export GOCOVERDIR=./go/build/${DATE}
+ct-coverage-go:
+	@ mkdir -p ${GOCOVERDIR} ;\
+	go run -cover -coverpkg ${PACKAGES} ./go/ct/driver run --max-errors 1 ${TOSCA_GO_COVERAGE_EVM} ;\
+	go tool covdata textfmt --i ${GOCOVERDIR} -o ${GOCOVERDIR}/cover.out ;\
+	go tool cover -html ${GOCOVERDIR}/cover.out -o coverage.html ;\
+	echo "Coverage report generated in coverage.html"
 
 ct-coverage-lfvm: TOSCA_GO_COVERAGE_EVM=lfvm
-ct-coverage-lfvm: coverage-go
+ct-coverage-lfvm: EXTRA_PACKAGES=github.com/Fantom-foundation/Tosca/go/interpreter/lfvm
+ct-coverage-lfvm: ct-coverage-go
 
 ct-coverage-geth: TOSCA_GO_COVERAGE_EVM=geth
-ct-coverage-geth: TOSCA_GO_COVERAGE_DEPENDENCY_PACKAGES=github.com/ethereum/go-ethereum/core/vm/...
-ct-coverage-geth: coverage-go
+ct-coverage-geth: EXTRA_PACKAGES=github.com/ethereum/go-ethereum/core/vm/...
+ct-coverage-geth: ct-coverage-go
 
 ct-coverage-evmzero: tosca-cpp-coverage
 ct-coverage-evmzero: 


### PR DESCRIPTION
This PR sets the requirement for 100% coverage for the LFVM. 
Additionally, rewrites ct coverage tool to collect coverage of the LFVM code only, speeding up the process. 