### PR TITLE
LFVM: Refactor data copy routines.

### DIFF
--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -306,7 +306,7 @@ func opCallDataload(c *context) {
 	top.SetBytes(value)
 }
 
-func opCallDataCopy(c *context) error {
+func genericDataCopy(c *context, source []byte) error {
 	var (
 		memOffset  = c.stack.pop()
 		dataOffset = c.stack.pop()
@@ -315,8 +315,7 @@ func opCallDataCopy(c *context) error {
 
 	// Charge for the copy costs
 	words := tosca.SizeInWords(length.Uint64())
-	price := tosca.Gas(3 * words)
-	if err := c.useGas(price); err != nil {
+	if err := c.useGas(tosca.Gas(3 * words)); err != nil {
 		return err
 	}
 
@@ -324,9 +323,10 @@ func opCallDataCopy(c *context) error {
 	if err != nil {
 		return err
 	}
+
 	// length overflow has been checked by getSlice
-	codeCopy := getData(c.params.Input, dataOffset, length.Uint64())
-	copy(data, codeCopy)
+	dataCopy := getData(source, dataOffset, length.Uint64())
+	copy(data, dataCopy)
 	return nil
 }
 
@@ -727,29 +727,6 @@ func opCodeSize(c *context) {
 	c.stack.pushUndefined().SetUint64(uint64(size))
 }
 
-func opCodeCopy(c *context) error {
-	var (
-		memOffset  = c.stack.pop()
-		codeOffset = c.stack.pop()
-		length     = c.stack.pop()
-	)
-
-	// Charge for length of copied code
-	words := tosca.SizeInWords(length.Uint64())
-	if err := c.useGas(tosca.Gas(3 * words)); err != nil {
-		return err
-	}
-
-	data, err := c.memory.getSlice(memOffset, length, c)
-	if err != nil {
-		return err
-	}
-	// length overflow has been checked by getSlice
-	codeCopy := getData(c.params.Code, codeOffset, length.Uint64())
-	copy(data, codeCopy)
-	return nil
-}
-
 func opExtcodesize(c *context) error {
 	top := c.stack.peek()
 	address := tosca.Address(top.Bytes20())
@@ -914,34 +891,16 @@ func getData(data []byte, offset *uint256.Int, size uint64) []byte {
 }
 
 func opExtCodeCopy(c *context) error {
-	var (
-		a          = c.stack.pop()
-		memOffset  = c.stack.pop()
-		codeOffset = c.stack.pop()
-		length     = c.stack.pop()
-	)
 
-	// Charge for length of copied code
-	words := tosca.SizeInWords(length.Uint64())
-	if err := c.useGas(tosca.Gas(3 * words)); err != nil {
-		return err
-	}
+	address := c.stack.pop().Bytes20()
 
-	address := tosca.Address(a.Bytes20())
 	if c.isAtLeast(tosca.R09_Berlin) {
 		if err := c.useGas(getAccessCost(c.context.AccessAccount(address))); err != nil {
 			return err
 		}
 	}
 
-	data, err := c.memory.getSlice(memOffset, length, c)
-	if err != nil {
-		return err
-	}
-	// length overflow has been checked by getSlice
-	codeCopy := getData(c.context.GetCode(address), codeOffset, length.Uint64())
-	copy(data, codeCopy)
-	return nil
+	return genericDataCopy(c, c.context.GetCode(address))
 }
 
 func getAccessCost(accessStatus tosca.AccessStatus) tosca.Gas {

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -666,83 +666,46 @@ func TestTransientStorageOperations(t *testing.T) {
 	}
 }
 
-func TestExpansionCostOverflow(t *testing.T) {
-	memTestValues := []uint64{
-		maxMemoryExpansionSize,
-		maxMemoryExpansionSize + 1,
-		math.MaxUint64,
-	}
+func TestGenericDataCopy_ReturnsErrorOn(t *testing.T) {
+	testBuffer := make([]byte, 1024)
 
 	tests := map[string]struct {
-		op         func(*context) error
-		stackSize  int
-		memIndexes []int
-		setup      func(*tosca.MockRunContext)
+		offset        uint256.Int
+		size          uint256.Int
+		gas           tosca.Gas
+		expectedError error
 	}{
-		"mcopy": {
-			op:         opMcopy,
-			stackSize:  3,
-			memIndexes: []int{0, 1, 2},
-			setup:      func(runContext *tosca.MockRunContext) {},
+		"not enough gas": {
+			offset:        *uint256.NewInt(10),
+			size:          *uint256.NewInt(10),
+			gas:           1,
+			expectedError: errOutOfGas,
 		},
-		"calldatacopy": {
-			op:         opCallDataCopy,
-			stackSize:  3,
-			memIndexes: []int{0, 2},
-			setup:      func(runContext *tosca.MockRunContext) {},
-		},
-		"codecopy": {
-			op:         opCodeCopy,
-			stackSize:  3,
-			memIndexes: []int{0, 2},
-			setup:      func(runContext *tosca.MockRunContext) {},
-		},
-		"extcodecopy": {
-			op:         opExtCodeCopy,
-			stackSize:  4,
-			memIndexes: []int{0, 2},
-			setup: func(runContext *tosca.MockRunContext) {
-				runContext.EXPECT().AccessAccount(gomock.Any()).AnyTimes().Return(tosca.WarmAccess)
-				runContext.EXPECT().GetCode(gomock.Any()).AnyTimes().Return([]byte{0x01, 0x02, 0x03, 0x04})
-			},
+
+		"expansionFailure": {
+			offset:        *uint256.NewInt(math.MaxUint64),
+			size:          *uint256.NewInt(10),
+			gas:           1 << 32,
+			expectedError: errOverflow,
 		},
 	}
 
 	for name, test := range tests {
-		for _, memIndex := range test.memIndexes {
-			for _, memValue := range memTestValues {
-				t.Run(fmt.Sprintf("%v_i:%v_v:%v", name, memIndex, memValue), func(t *testing.T) {
-					ctrl := gomock.NewController(t)
-					runContext := tosca.NewMockRunContext(ctrl)
-					test.setup(runContext)
+		t.Run(name, func(t *testing.T) {
 
-					ctxt := context{
-						params: tosca.Parameters{
-							BlockParameters: tosca.BlockParameters{
-								Revision: tosca.R13_Cancun,
-							},
-						},
-						stack:   NewStack(),
-						memory:  NewMemory(),
-						context: runContext,
-						gas:     12884901899,
-					}
-					ctxt.stack.stackPointer = test.stackSize
-					ctxt.stack.data[memIndex].Set(uint256.NewInt(memValue))
-					for i := range test.memIndexes {
-						if i != memIndex {
-							ctxt.stack.data[i].Set(uint256.NewInt(1))
-						}
-					}
+			ctxt := getEmptyContext()
+			ctxt.gas = test.gas
+			ctxt.stack = fillStack(
+				test.offset,
+				*uint256.NewInt(0), // source offset
+				test.size,
+			)
 
-					err := test.op(&ctxt)
-					// FIXME: can we narrow the error? test says overflow, it manifests an out of gas error
-					if err == nil {
-						t.Fatalf("expected error, got nil")
-					}
-				})
+			err := genericDataCopy(&ctxt, testBuffer)
+			if want, got := test.expectedError, err; want != got {
+				t.Fatalf("unexpected return, wanted %v, got %v", want, got)
 			}
-		}
+		})
 	}
 }
 

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -288,7 +288,7 @@ func steps(c *context, oneStepOnly bool) (status, error) {
 		case CALLDATASIZE:
 			opCallDatasize(c)
 		case CALLDATACOPY:
-			err = opCallDataCopy(c)
+			err = genericDataCopy(c, c.params.Input)
 		case MLOAD:
 			err = opMload(c)
 		case MSTORE:
@@ -436,7 +436,7 @@ func steps(c *context, oneStepOnly bool) (status, error) {
 		case CODESIZE:
 			opCodeSize(c)
 		case CODECOPY:
-			err = opCodeCopy(c)
+			err = genericDataCopy(c, c.params.Code)
 		case EXTCODESIZE:
 			err = opExtcodesize(c)
 		case EXTCODEHASH:


### PR DESCRIPTION
This PR started tracking a Fixme inside the instructions_test, related to memory expansion errors during operations manipulating memory. 
Deleting the test exposed the untested code, and the repeating pattern was obvious. 

There are Read Only buffers (RO-buffer) data can be copied from and into vm memory:
- input
- code
- external account code 

They follow the same rules: 
- Every RO-buffer read charges 3*word count of the copy, plus an expansion of the destination memory, then copy is done.
- If the expansion succeeds, the read operation from the RO-buffer cannot fail (excess is padded). 

Note: Return buffer is slightly different because write must fit in, and therefore it can overflow. 