### PR TITLE
LFVM: Fix empty vs exists bug in Call

### DIFF
--- a/go/integration_test/interpreter/dynamic_gas.go
+++ b/go/integration_test/interpreter/dynamic_gas.go
@@ -607,8 +607,16 @@ func gasDynamicCallCommon(revision Revision, useCallValue bool, addressCreationG
 		}
 		mockCalls := func(mock *MockStateDB) {
 			mock.EXPECT().GetCodeHash(address).AnyTimes().Return(hash)
-			mock.EXPECT().GetCode(address).AnyTimes().Return(calledCode)
 			mock.EXPECT().AccountExists(address).AnyTimes().Return(exist)
+			if exist {
+				mock.EXPECT().GetBalance(address).AnyTimes().Return(tosca.Value{1})
+				mock.EXPECT().GetCode(address).AnyTimes().Return(calledCode)
+			} else {
+				mock.EXPECT().GetBalance(address).AnyTimes().Return(tosca.Value{})
+				mock.EXPECT().GetCode(address).AnyTimes().Return(nil)
+				mock.EXPECT().GetNonce(address).AnyTimes().Return(uint64(0))
+			}
+			mock.EXPECT().GetBalance(tosca.Address{}).AnyTimes().Return(tosca.Value{100})
 			mock.EXPECT().IsAddressInAccessList(address).AnyTimes().Return(inAccessList)
 			mock.EXPECT().AccessAccount(address).AnyTimes().Return(accountState)
 		}

--- a/go/integration_test/interpreter/verify_gas_test.go
+++ b/go/integration_test/interpreter/verify_gas_test.go
@@ -111,7 +111,7 @@ func TestDynamicGas(t *testing.T) {
 
 						// SELFDESTRUCT gas computation is dependent on an account balance and
 						// existence (handled by nonce in this test), it sets its own expectations
-						if op != vm.SELFDESTRUCT {
+						if op != vm.SELFDESTRUCT && op != vm.CALL {
 							mockStateDB.EXPECT().GetNonce(gomock.Any()).AnyTimes()
 							mockStateDB.EXPECT().GetBalance(gomock.Any()).AnyTimes().Return(accountBalance)
 						}

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -997,7 +997,10 @@ func genericCall(c *context, kind tosca.CallKind) error {
 
 	// EIP158 states that non-zero value calls that create a new account should
 	// be charged an additional gas fee.
-	if kind == tosca.Call && !value.IsZero() && !c.context.AccountExists(toAddr) {
+	empty := c.context.GetBalance(toAddr) == (tosca.Value{}) &&
+		c.context.GetCode(toAddr) == nil &&
+		c.context.GetNonce(toAddr) == 0
+	if kind == tosca.Call && !value.IsZero() && empty {
 		if err := c.useGas(CallNewAccountGas); err != nil {
 			return err
 		}


### PR DESCRIPTION
Just like in SELFDESTRUCT, a transfer of a value to an empty account is charged extra. 