### PR TITLE
evmrs: add feature "thread-local-cache"

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,6 +29,7 @@ custom-evmc = ["dep:evmc-vm-tosca-refactor"]
 jumptable = []
 hash-cache = ["dep:lru"]
 jump-cache = ["dep:lru", "dep:nohash-hasher"]
+thread-local-cache = []
 
 [dependencies]
 bnum = "0.12.0"

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -11,6 +11,7 @@ custom-evmc = ["evmrs/custom-evmc"]
 jumptable = ["evmrs/jumptable"]
 hash-cache = ["evmrs/hash-cache"]
 jump-cache = ["evmrs/jump-cache"]
+thread-local-cache = ["evmrs/thread-local-cache"]
 
 [dependencies]
 evmrs = { path = ".." }

--- a/rust/src/types/cache.rs
+++ b/rust/src/types/cache.rs
@@ -1,14 +1,18 @@
+#[cfg(not(feature = "thread-local-cache"))]
+use std::sync::{LazyLock, Mutex};
+#[cfg(feature = "thread-local-cache")]
+use std::{cell::RefCell, thread::LocalKey};
 use std::{
     hash::{BuildHasher, Hash},
     num::NonZeroUsize,
-    sync::{LazyLock, Mutex},
 };
 
 use lru::{DefaultHasher, LruCache};
 
 pub struct Cache<const S: usize, K, V, H = DefaultHasher>(
     // Mutex<LruCache<...>> is faster that quick_cache::Cache<...>
-    LazyLock<Mutex<LruCache<K, V, H>>>,
+    #[cfg(not(feature = "thread-local-cache"))] LazyLock<Mutex<LruCache<K, V, H>>>,
+    #[cfg(feature = "thread-local-cache")] RefCell<LruCache<K, V, H>>,
 )
 where
     K: Hash + Eq;
@@ -18,6 +22,7 @@ where
     K: Hash + Eq,
     H: BuildHasher + Default,
 {
+    #[cfg(not(feature = "thread-local-cache"))]
     pub const fn new() -> Self {
         Self(LazyLock::new(|| {
             Mutex::new(LruCache::with_hasher(
@@ -26,13 +31,23 @@ where
             ))
         }))
     }
+    #[cfg(feature = "thread-local-cache")]
+    pub fn new() -> Self {
+        Self(RefCell::new(LruCache::with_hasher(
+            NonZeroUsize::new(S).unwrap(),
+            H::default(),
+        )))
+    }
 
     #[cfg(feature = "jump-cache")]
     pub fn get_or_insert(&self, key: K, f: impl FnOnce() -> V) -> V
     where
         V: Clone,
     {
-        self.0.lock().unwrap().get_or_insert(key, f).clone()
+        #[cfg(not(feature = "thread-local-cache"))]
+        return self.0.lock().unwrap().get_or_insert(key, f).clone();
+        #[cfg(feature = "thread-local-cache")]
+        return self.0.borrow_mut().get_or_insert(key, f).clone();
     }
 
     #[cfg(feature = "hash-cache")]
@@ -42,6 +57,49 @@ where
         Q: ToOwned<Owned = K> + Hash + Eq,
         V: Clone,
     {
-        self.0.lock().unwrap().get_or_insert_ref(key, f).clone()
+        #[cfg(not(feature = "thread-local-cache"))]
+        return self.0.lock().unwrap().get_or_insert_ref(key, f).clone();
+        #[cfg(feature = "thread-local-cache")]
+        return self.0.borrow_mut().get_or_insert_ref(key, f).clone();
+    }
+}
+
+#[cfg(feature = "thread-local-cache")]
+pub trait LocalKeyExt<const S: usize, K, V, H> {
+    #[cfg(feature = "jump-cache")]
+    fn get_or_insert(&'static self, key: K, f: impl FnOnce() -> V) -> V
+    where
+        V: Clone;
+
+    #[cfg(feature = "hash-cache")]
+    fn get_or_insert_ref<Q>(&'static self, key: &Q, f: impl FnOnce() -> V) -> V
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: ToOwned<Owned = K> + Hash + Eq,
+        V: Clone;
+}
+
+#[cfg(feature = "thread-local-cache")]
+impl<const S: usize, K, V, H> LocalKeyExt<S, K, V, H> for LocalKey<Cache<S, K, V, H>>
+where
+    K: Hash + Eq,
+    H: BuildHasher + Default,
+{
+    #[cfg(feature = "jump-cache")]
+    fn get_or_insert(&'static self, key: K, f: impl FnOnce() -> V) -> V
+    where
+        V: Clone,
+    {
+        self.with(|c| c.get_or_insert(key, f))
+    }
+
+    #[cfg(feature = "hash-cache")]
+    fn get_or_insert_ref<Q>(&'static self, key: &Q, f: impl FnOnce() -> V) -> V
+    where
+        K: std::borrow::Borrow<Q>,
+        Q: ToOwned<Owned = K> + Hash + Eq,
+        V: Clone,
+    {
+        self.with(|c| c.get_or_insert_ref(key, f))
     }
 }

--- a/rust/src/types/hash_cache.rs
+++ b/rust/src/types/hash_cache.rs
@@ -2,6 +2,8 @@ use sha3::{Digest, Keccak256};
 
 #[cfg(feature = "hash-cache")]
 use crate::types::Cache;
+#[cfg(all(feature = "hash-cache", feature = "thread-local-cache"))]
+use crate::types::LocalKeyExt;
 use crate::u256;
 
 #[cfg(feature = "hash-cache")]
@@ -12,10 +14,16 @@ pub type HashCache32 = Cache<CACHE_SIZE, [u8; 32], u256>;
 #[cfg(feature = "hash-cache")]
 pub type HashCache64 = Cache<CACHE_SIZE, [u8; 64], u256>;
 
-#[cfg(feature = "hash-cache")]
+#[cfg(all(feature = "hash-cache", not(feature = "thread-local-cache")))]
 static HASH_CACHE_32: HashCache32 = HashCache32::new();
-#[cfg(feature = "hash-cache")]
+#[cfg(all(feature = "hash-cache", not(feature = "thread-local-cache")))]
 static HASH_CACHE_64: HashCache64 = HashCache64::new();
+
+#[cfg(all(feature = "hash-cache", feature = "thread-local-cache"))]
+thread_local! {
+    static HASH_CACHE_32: HashCache32 = HashCache32::new();
+    static HASH_CACHE_64: HashCache64 = HashCache64::new();
+}
 
 fn sha3(data: &[u8]) -> u256 {
     let mut hasher = Keccak256::new();

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -15,6 +15,11 @@ mod tx_context;
 pub use amount::u256;
 #[cfg(any(feature = "hash-cache", feature = "jump-cache"))]
 pub use cache::Cache;
+#[cfg(all(
+    feature = "thread-local-cache",
+    any(feature = "hash-cache", feature = "jump-cache")
+))]
+pub use cache::LocalKeyExt;
 pub use code_reader::{CodeReader, GetOpcodeError};
 pub use execution_context::*;
 pub use jump_analysis::JumpAnalysis;


### PR DESCRIPTION
This PR add the feature "thread-local-cache". When enabled, all enabled caches (jump cache or hash cache or both) will use a thread local cache instead of a static cache.