### PR TITLE
evmrs: build with lto and one code gen unit

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,6 +6,10 @@ name = "evmrs"
 version = "0.1.0"
 edition = "2021"
 
+[profile.release]
+lto = true
+codegen-units = 1
+
 [profile.profiling]
 inherits = "release"
 debug = true

--- a/rust/scripts/bench.sh
+++ b/rust/scripts/bench.sh
@@ -38,7 +38,7 @@ mkdir -p $OUTPUT_DIR
 
 make -C ..
 
-if [ ! $EVMRS_ONLY ]; then
+if [ $EVMRS_ONLY -eq 0 ]; then
     INTERPRETERS=("evmzero" "lfvm" "geth")
     for INTERPRETER in "${INTERPRETERS[@]}"; do
         echo running $INTERPRETER


### PR DESCRIPTION
- change release profile to build with full lto and only one code gen unit to produce more performant binaries
- fix bench.sh