### PR TITLE
CT: clear NewStack from pool

### DIFF
--- a/go/ct/st/stack.go
+++ b/go/ct/st/stack.go
@@ -37,10 +37,7 @@ var stackPool = sync.Pool{
 
 // NewStack returns a stack from the stack pool, all stacks are allocated with the maximal capacity
 func NewStack(values ...U256) *Stack {
-	stack := stackPool.Get().(*Stack)
-	if MaxStackSize < len(values) {
-		panic("Warning: maximal stack size exceeded")
-	}
+	stack := NewStackWithSize(len(values))
 	stack.stack = stack.stack[:copy(stack.stack, values)]
 	return stack
 }


### PR DESCRIPTION
Adding stack releases in lfvm/ct tests, produced some tests to fail.
This was because stacks returned to the stack pool were not cleaned when returned neither when requested.

this small fix adds stack releases to tests and ensured ct's `NewStack` calls have the correct size and values. 