### PR TITLE
LFVM: extCodeHash use isEmpty semantics instead of exists.

### DIFF
--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -729,7 +729,7 @@ func opCodeSize(c *context) {
 	c.stack.pushUndefined().SetUint64(uint64(size))
 }
 
-func opExtcodesize(c *context) error {
+func opExtCodeSize(c *context) error {
 	top := c.stack.peek()
 	address := tosca.Address(top.Bytes20())
 	if c.isAtLeast(tosca.R09_Berlin) {
@@ -741,7 +741,7 @@ func opExtcodesize(c *context) error {
 	return nil
 }
 
-func opExtcodehash(c *context) error {
+func opExtCodeHash(c *context) error {
 	slot := c.stack.peek()
 	address := tosca.Address(slot.Bytes20())
 	if c.isAtLeast(tosca.R09_Berlin) {

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1106,8 +1106,8 @@ func TestInstructions_EIP2929_dynamicGasCostReportsOutOfGas(t *testing.T) {
 	tests := map[OpCode]func(*context) error{
 		BALANCE:      opBalance,
 		EXTCODECOPY:  opExtCodeCopy,
-		EXTCODEHASH:  opExtcodehash,
-		EXTCODESIZE:  opExtcodesize,
+		EXTCODEHASH:  opExtCodeHash,
+		EXTCODESIZE:  opExtCodeSize,
 		CALL:         opCall,
 		CALLCODE:     opCallCode,
 		DELEGATECALL: opDelegateCall,
@@ -1721,7 +1721,7 @@ func TestInstructions_opExtcodesize_CallsContextAndWritesResultInStack(t *testin
 
 	ctxt.stack.push(new(uint256.Int).SetBytes(address[:]))
 
-	err := opExtcodesize(&ctxt)
+	err := opExtCodeSize(&ctxt)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1948,7 +1948,7 @@ func TestOpExtCodeHash_WritesHashOnStackIfAccountExists(t *testing.T) {
 			}
 			ctxt.context = runContext
 
-			err := opExtcodehash(&ctxt)
+			err := opExtCodeHash(&ctxt)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/go/interpreter/lfvm/interpreter.go
+++ b/go/interpreter/lfvm/interpreter.go
@@ -438,9 +438,9 @@ func steps(c *context, oneStepOnly bool) (status, error) {
 		case CODECOPY:
 			err = genericDataCopy(c, c.params.Code)
 		case EXTCODESIZE:
-			err = opExtcodesize(c)
+			err = opExtCodeSize(c)
 		case EXTCODEHASH:
-			err = opExtcodehash(c)
+			err = opExtCodeHash(c)
 		case EXTCODECOPY:
 			err = opExtCodeCopy(c)
 		case BALANCE:

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -186,6 +186,7 @@ func TestInterpreter_CanDispatchExecutableInstructions(t *testing.T) {
 				// mock all to satisfy any instruction
 				mock.EXPECT().AccessAccount(gomock.Any()).Return(tosca.WarmAccess).AnyTimes()
 				mock.EXPECT().GetBalance(gomock.Any()).AnyTimes()
+				mock.EXPECT().GetNonce(gomock.Any()).AnyTimes()
 				mock.EXPECT().GetCodeSize(gomock.Any()).AnyTimes()
 				mock.EXPECT().GetCode(gomock.Any()).AnyTimes()
 				mock.EXPECT().AccountExists(gomock.Any()).AnyTimes()


### PR DESCRIPTION
As @HerbertJordan pointed out, [python reference](https://github.com/ethereum/execution-specs/blob/3282ee5bb88bdd56aabf2461360277ab8eac4032/src/ethereum/cancun/vm/instructions/environment.py#L458-L487) does not call `exists`.

[evm.codes](https://www.evm.codes/) states: "0 if the account does not exist or has been destroyed." 
My interpretation of this sentence is: 
- If the account does not exist, any query to the state will yield the zero value (code, balance, and nonce). Exists would be False. 
- If the account has been destroyed, it may still have an entry in the state with zero values. Exists would be true, although contents are empty. 

