### PR TITLE
LFVM: genericCall precompiled contract recipient

### DIFF
--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -316,7 +316,7 @@ func (a *runContextAdapter) Call(kind tosca.CallKind, parameter tosca.CallParame
 // which is not a desired trait for Tosca interpreter implementations.
 // With this trick, this requirement is circumvented.
 func encodeReadOnlyInGas(gas uint64, recipient tosca.Address, readOnly bool) uint64 {
-	if !isPrecompiledContract(recipient) {
+	if !tosca.IsPrecompiledContract(recipient) {
 		if readOnly {
 			gas += (1 << 63)
 		}
@@ -593,14 +593,4 @@ func bigIntToHash(value *big.Int) (tosca.Hash, error) {
 func bigIntToWord(value *big.Int) (tosca.Word, error) {
 	res, err := bigIntToValue(value)
 	return tosca.Word(res), err
-}
-
-func isPrecompiledContract(recipient tosca.Address) bool {
-	// the addresses 1-9 are precompiled contracts
-	for i := 0; i < 18; i++ {
-		if recipient[i] != 0 {
-			return false
-		}
-	}
-	return 1 <= recipient[19] && recipient[19] <= 9
 }

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -1048,19 +1048,21 @@ func genericCall(c *context, kind tosca.CallKind) error {
 		Value: tosca.Value(value.Bytes32()),
 	}
 
+	if (kind == tosca.CallCode || kind == tosca.DelegateCall) && tosca.IsPrecompiledContract(toAddr) {
+		callParams.Recipient = toAddr
+	} else {
+		callParams.Recipient = c.params.Recipient
+	}
+
 	switch kind {
 	case tosca.Call, tosca.StaticCall:
 		callParams.Sender = c.params.Recipient
 		callParams.Recipient = toAddr
-
 	case tosca.CallCode:
 		callParams.Sender = c.params.Recipient
-		callParams.Recipient = c.params.Recipient
 		callParams.CodeAddress = toAddr
-
 	case tosca.DelegateCall:
 		callParams.Sender = c.params.Sender
-		callParams.Recipient = c.params.Recipient
 		callParams.CodeAddress = toAddr
 		callParams.Value = c.params.Value
 	}

--- a/go/tosca/utils.go
+++ b/go/tosca/utils.go
@@ -75,3 +75,13 @@ func SizeInWords(size uint64) uint64 {
 	}
 	return (size + 31) / 32
 }
+
+func IsPrecompiledContract(recipient Address) bool {
+	// the addresses 1-9 are precompiled contracts
+	for i := 0; i < 18; i++ {
+		if recipient[i] != 0 {
+			return false
+		}
+	}
+	return 1 <= recipient[19] && recipient[19] <= 9
+}


### PR DESCRIPTION
While executing the geth tests, lfvm failed to process a precompiled contract. There we realized this special case for delegate call and call code were not handled properly. 
This PR:
- moves `isPrecompiledContract` to tosca pkg to avoid unnecesary dependeencies.
- adds check for precompiled contract in generciCall, and handled nested call recipient properly. 
- [ ] add a unit test for these cases. 