### PR TITLE
evmrs: add feature "jumptable-tail-call"

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,6 +15,7 @@ inherits = "release"
 debug = true
 
 [features]
+default = []
 # Flag mock enables code generation for test mocking. This allows generating mocks for other build configuration but "test". 
 mock = ["dep:mockall"]
 dump-cov = []
@@ -34,6 +35,7 @@ jumptable = []
 hash-cache = ["dep:lru"]
 jump-cache = ["dep:lru", "dep:nohash-hasher"]
 thread-local-cache = []
+jumptable-tail-call = ["jumptable"]
 
 [dependencies]
 bnum = "0.12.0"

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -12,6 +12,7 @@ jumptable = ["evmrs/jumptable"]
 hash-cache = ["evmrs/hash-cache"]
 jump-cache = ["evmrs/jump-cache"]
 thread-local-cache = ["evmrs/thread-local-cache"]
+jumptable-tail-call = ["evmrs/jumptable-tail-call"]
 
 [dependencies]
 evmrs = { path = ".." }


### PR DESCRIPTION
This PR adds the feature "jumptable-tail-call". When enabled this enables the feature "jumptable" and additionally implements the function dispatch using tail calls.

The idea here is that instead of calling the function for an opcode, executing it, returning to the dispatch function and then calling the function of the next opcode we instead call the next opcode function from the first one.

In order to implement this each function has to advance the pc itself, because the (inlined) dispatcher function does no longer knows what the last opcode was.