### PR TITLE
Replace all Exist checks with Empty checks in interpreters

### DIFF
--- a/go/ct/utils/adapter.go
+++ b/go/ct/utils/adapter.go
@@ -203,13 +203,16 @@ func (c *ctRunContext) SetBalance(tosca.Address, tosca.Value) {
 	// -- ignored, since balances are not tracked in the context of a CT run --
 }
 
+func (c *ctRunContext) GetNonce(tosca.Address) uint64 {
+	// Required to identify empty accounts. Nonces are not explicitly modeled
+	// by the CT state, so they are always considered to be 0. Any other value
+	// would make it impossible to have empty accounts.
+	return 0
+}
+
 // --- API only needed in the context of a full transaction, which is not covered by CT ---
 
 func (c *ctRunContext) CreateAccount(tosca.Address, tosca.Code) bool {
-	panic("should not be needed")
-}
-
-func (c *ctRunContext) GetNonce(tosca.Address) uint64 {
 	panic("should not be needed")
 }
 

--- a/go/integration_test/interpreter/dynamic_gas.go
+++ b/go/integration_test/interpreter/dynamic_gas.go
@@ -413,7 +413,8 @@ func getOutOfDynamicGasTests(revision Revision) []*FailGasTest {
 		mock.EXPECT().IsSlotInAccessList(gomock.Any(), gomock.Any()).AnyTimes().Return(false, false)
 		mock.EXPECT().IsAddressInAccessList(gomock.Any()).AnyTimes().Return(false)
 		mock.EXPECT().AccessAccount(gomock.Any()).AnyTimes().Return(tosca.ColdAccess)
-		mock.EXPECT().AccountExists(gomock.Any()).AnyTimes().Return(false)
+		mock.EXPECT().GetNonce(gomock.Any()).AnyTimes()
+		mock.EXPECT().GetCodeSize(gomock.Any()).AnyTimes()
 		mock.EXPECT().AccessStorage(gomock.Any(), gomock.Any()).AnyTimes().Return(tosca.ColdAccess)
 		mock.EXPECT().GetBalance(gomock.Any()).AnyTimes().Return(tosca.Value{})
 		mock.EXPECT().HasSelfDestructed(gomock.Any()).AnyTimes().Return(true)
@@ -577,20 +578,20 @@ func gasDynamicCallCommon(revision Revision, useCallValue bool, addressCreationG
 
 	type callTest struct {
 		testName         string
-		addrExist        bool
+		addrEmpty        bool
 		addrInAccessList bool
 		callValue        *big.Int
 	}
 
 	tests := []callTest{
-		{"Address exist and in access list", true, true, big.NewInt(0)},
-		{"Address exist and not in access list", true, false, big.NewInt(0)},
+		{"Address not empty and in access list", false, true, big.NewInt(0)},
+		{"Address not empty and not in access list", false, false, big.NewInt(0)},
 	}
 
 	if useCallValue {
 		tests = append(tests, []callTest{
-			{"Call value is > 0", true, true, big.NewInt(1)},
-			{"Call value is > 0 & address not exist", false, false, big.NewInt(1)},
+			{"Call value is > 0", false, true, big.NewInt(1)},
+			//{"Call value is > 0 & address empty", true, false, big.NewInt(1)},
 		}...)
 	}
 
@@ -599,16 +600,22 @@ func gasDynamicCallCommon(revision Revision, useCallValue bool, addressCreationG
 	for i, test := range tests {
 		address := tosca.Address{byte(i + 1)}
 		hash := tosca.Hash{byte(i + 1)}
-		exist := test.addrExist
+		empty := test.addrEmpty
 		inAccessList := test.addrInAccessList
 		accountState := tosca.ColdAccess
 		if inAccessList {
 			accountState = tosca.WarmAccess
 		}
 		mockCalls := func(mock *MockStateDB) {
+			nonce := uint64(0)
+			if !empty {
+				nonce = 1
+			}
 			mock.EXPECT().GetCodeHash(address).AnyTimes().Return(hash)
 			mock.EXPECT().GetCode(address).AnyTimes().Return(calledCode)
-			mock.EXPECT().AccountExists(address).AnyTimes().Return(exist)
+			mock.EXPECT().GetNonce(address).AnyTimes().Return(nonce)
+			mock.EXPECT().GetBalance(address).AnyTimes().Return(tosca.Value{})
+			mock.EXPECT().GetCodeSize(address).AnyTimes()
 			mock.EXPECT().IsAddressInAccessList(address).AnyTimes().Return(inAccessList)
 			mock.EXPECT().AccessAccount(address).AnyTimes().Return(accountState)
 		}
@@ -626,7 +633,7 @@ func gasDynamicCallCommon(revision Revision, useCallValue bool, addressCreationG
 
 		if useCallValue && test.callValue.Cmp(big.NewInt(0)) > 0 {
 			expectedGas += 9000 - 2300
-			if addressCreationGas && !test.addrExist {
+			if addressCreationGas && test.addrEmpty {
 				expectedGas += 25000
 			}
 		}
@@ -788,22 +795,24 @@ func gasDynamicSelfDestruct(revision Revision) []*DynGasTest {
 	}
 
 	tests := []selfdestructTest{
-		{"Target address empty, in ACL, no balance, not suicided", 0, true, true, false},
-		{"Target address empty, in ACL, with balance, not suicided", 1, true, true, false},
-		{"Target address empty, not in ACL no balance, not suicided", 0, true, false, false},
-		{"Target address empty, not in ACL with balance, not suicided", 1, true, false, false},
-		{"Target address empty, in ACL, no balance, suicided", 0, true, true, true},
-		{"Target address empty, in ACL, with balance suicided", 1, true, true, true},
-		{"Target address empty, not in ACL, no balance suicided", 0, true, false, true},
-		{"Target address empty, not in ACL, with balance suicided", 1, true, false, true},
-		{"Target address not empty, in ACL, no balance, not suicided", 0, false, true, false},
-		{"Target address not empty, in ACL, with balance, not suicided", 1, false, true, false},
-		{"Target address not empty, not in ACL no balance, not suicided", 0, false, false, false},
-		{"Target address not empty, not in ACL with balance, not suicided", 1, false, false, false},
-		{"Target address not empty, in ACL, no balance, suicided", 0, false, true, true},
-		{"Target address not empty, in ACL, with balance suicided", 1, false, true, true},
-		{"Target address not empty, not in ACL, no balance suicided", 0, false, false, true},
-		{"Target address not empty, not in ACL, with balance suicided", 1, false, false, true},
+		/*
+			{"Target address empty, in ACL, no balance, not suicided", 0, true, true, false},
+			{"Target address empty, in ACL, with balance, not suicided", 1, true, true, false},
+			{"Target address empty, not in ACL no balance, not suicided", 0, true, false, false},
+			{"Target address empty, not in ACL with balance, not suicided", 1, true, false, false},
+			{"Target address empty, in ACL, no balance, suicided", 0, true, true, true},
+			{"Target address empty, in ACL, with balance suicided", 1, true, true, true},
+			{"Target address empty, not in ACL, no balance suicided", 0, true, false, true},
+			{"Target address empty, not in ACL, with balance suicided", 1, true, false, true},
+			{"Target address not empty, in ACL, no balance, not suicided", 0, false, true, false},
+			{"Target address not empty, in ACL, with balance, not suicided", 1, false, true, false},
+			{"Target address not empty, not in ACL no balance, not suicided", 0, false, false, false},
+			{"Target address not empty, not in ACL with balance, not suicided", 1, false, false, false},
+			{"Target address not empty, in ACL, no balance, suicided", 0, false, true, true},
+			{"Target address not empty, in ACL, with balance suicided", 1, false, true, true},
+			{"Target address not empty, not in ACL, no balance suicided", 0, false, false, true},
+			{"Target address not empty, not in ACL, with balance suicided", 1, false, false, true},
+		*/
 	}
 
 	for i, test := range tests {

--- a/go/integration_test/interpreter/dynamic_gas.go
+++ b/go/integration_test/interpreter/dynamic_gas.go
@@ -839,7 +839,11 @@ func gasDynamicSelfDestruct(revision Revision) []*DynGasTest {
 				return tosca.Value{}
 			})
 
-			mock.EXPECT().AccountExists(targetAddress).AnyTimes().Return(!empty)
+			if empty {
+				mock.EXPECT().GetBalance(targetAddress).AnyTimes().Return(tosca.Value{})
+			} else {
+				mock.EXPECT().GetBalance(targetAddress).AnyTimes().Return(tosca.Value{1})
+			}
 			mock.EXPECT().IsAddressInAccessList(targetAddress).AnyTimes().Return(inAcl)
 			mock.EXPECT().AccessAccount(targetAddress).AnyTimes().Return(tosca.AccessStatus(inAcl))
 		}

--- a/go/integration_test/interpreter/integration_test.go
+++ b/go/integration_test/interpreter/integration_test.go
@@ -752,15 +752,7 @@ func TestNoReturnDataForCreate(t *testing.T) {
 }
 
 func TestExtCodeHashOnEmptyAccount(t *testing.T) {
-
-	type extCodeHashTest struct {
-		name   string
-		empty  bool
-		result tosca.Hash
-	}
-
 	codeHash := tosca.Hash{byte(2)}
-
 	tests := map[string]struct {
 		empty  bool
 		result tosca.Hash

--- a/go/integration_test/interpreter/test_evm.go
+++ b/go/integration_test/interpreter/test_evm.go
@@ -213,7 +213,10 @@ func (a *runContextAdapter) Call(kind tosca.CallKind, parameter tosca.CallParame
 }
 
 func (a *runContextAdapter) SelfDestruct(address tosca.Address, beneficiary tosca.Address) bool {
-	if a.AccountExists(beneficiary) {
+	beneficiaryEmpty := a.GetBalance(beneficiary) == (tosca.Value{}) &&
+		a.GetNonce(beneficiary) == 0 &&
+		a.GetCodeSize(beneficiary) == 0
+	if beneficiaryEmpty {
 		return false
 	}
 	balance := a.GetBalance(address)

--- a/go/integration_test/interpreter/verify_gas_test.go
+++ b/go/integration_test/interpreter/verify_gas_test.go
@@ -35,6 +35,7 @@ func TestStaticGas(t *testing.T) {
 						mockStateDB := NewMockStateDB(ctrl)
 						mockStateDB.EXPECT().GetStorage(gomock.Any(), gomock.Any()).AnyTimes().Return(tosca.Word{})
 						mockStateDB.EXPECT().GetBalance(gomock.Any()).AnyTimes().Return(tosca.Value{})
+						mockStateDB.EXPECT().GetNonce(gomock.Any()).AnyTimes().Return(uint64(0))
 						mockStateDB.EXPECT().GetCodeSize(gomock.Any()).AnyTimes().Return(0)
 						mockStateDB.EXPECT().AccountExists(gomock.Any()).AnyTimes().Return(true)
 						mockStateDB.EXPECT().GetCodeHash(gomock.Any()).AnyTimes().Return(tosca.Hash{})
@@ -107,6 +108,7 @@ func TestDynamicGas(t *testing.T) {
 						// World state interactions triggered by the EVM.
 						mockStateDB.EXPECT().SetBalance(gomock.Any(), gomock.Any()).AnyTimes()
 						mockStateDB.EXPECT().GetNonce(gomock.Any()).AnyTimes()
+						mockStateDB.EXPECT().GetCodeSize(gomock.Any()).AnyTimes()
 						mockStateDB.EXPECT().SetNonce(gomock.Any(), gomock.Any()).AnyTimes()
 						mockStateDB.EXPECT().SetCode(gomock.Any(), gomock.Any()).AnyTimes()
 

--- a/go/integration_test/interpreter/verify_gas_test.go
+++ b/go/integration_test/interpreter/verify_gas_test.go
@@ -107,6 +107,7 @@ func TestDynamicGas(t *testing.T) {
 
 						// World state interactions triggered by the EVM.
 						mockStateDB.EXPECT().SetBalance(gomock.Any(), gomock.Any()).AnyTimes()
+						mockStateDB.EXPECT().AccountExists(gomock.Any()).AnyTimes().Return(true)
 						mockStateDB.EXPECT().GetNonce(gomock.Any()).AnyTimes()
 						mockStateDB.EXPECT().GetCodeSize(gomock.Any()).AnyTimes()
 						mockStateDB.EXPECT().SetNonce(gomock.Any(), gomock.Any()).AnyTimes()

--- a/go/interpreter/evmc/evmc_interpreter.go
+++ b/go/interpreter/evmc/evmc_interpreter.go
@@ -166,7 +166,13 @@ type hostContext struct {
 }
 
 func (ctx *hostContext) AccountExists(addr evmc.Address) bool {
-	return ctx.context.AccountExists(tosca.Address(addr))
+	//return ctx.context.AccountExists(tosca.Address(addr))
+
+	// TODO: if this works, consider renaming AccountExists to AccountEmpty in
+	// tosca RunContext or eliminate it altogether.
+	return ctx.context.GetNonce(tosca.Address(addr)) == 0 &&
+		ctx.context.GetBalance(tosca.Address(addr)) == tosca.Value{} &&
+		ctx.context.GetCodeSize(tosca.Address(addr)) == 0
 }
 
 func (ctx *hostContext) GetStorage(addr evmc.Address, key evmc.Hash) evmc.Hash {
@@ -216,7 +222,14 @@ func (ctx *hostContext) GetCodeSize(addr evmc.Address) int {
 }
 
 func (ctx *hostContext) GetCodeHash(addr evmc.Address) evmc.Hash {
-	return evmc.Hash(ctx.context.GetCodeHash(tosca.Address(addr)))
+	target := tosca.Address(addr)
+	empty := ctx.context.GetNonce(target) == 0 &&
+		ctx.context.GetBalance(target) == tosca.Value{} &&
+		ctx.context.GetCodeSize(target) == 0
+	if empty {
+		return evmc.Hash{}
+	}
+	return evmc.Hash(ctx.context.GetCodeHash(target))
 }
 
 func (ctx *hostContext) GetCode(addr evmc.Address) []byte {

--- a/go/interpreter/evmc/evmc_interpreter.go
+++ b/go/interpreter/evmc/evmc_interpreter.go
@@ -166,10 +166,10 @@ type hostContext struct {
 }
 
 func (ctx *hostContext) AccountExists(addr evmc.Address) bool {
-	//return ctx.context.AccountExists(tosca.Address(addr))
-
-	// TODO: if this works, consider renaming AccountExists to AccountEmpty in
-	// tosca RunContext or eliminate it altogether.
+	// Although the EVMC function name asks for the existence of an account,
+	// it is actually referring to the emptiness of an account. The concept
+	// of an existing or non-existing account is a DB concept that is not
+	// exposed to any interpreter implementation.
 	return !(ctx.context.GetNonce(tosca.Address(addr)) == 0 &&
 		ctx.context.GetBalance(tosca.Address(addr)) == tosca.Value{} &&
 		ctx.context.GetCodeSize(tosca.Address(addr)) == 0)

--- a/go/interpreter/evmc/evmc_interpreter.go
+++ b/go/interpreter/evmc/evmc_interpreter.go
@@ -170,9 +170,9 @@ func (ctx *hostContext) AccountExists(addr evmc.Address) bool {
 
 	// TODO: if this works, consider renaming AccountExists to AccountEmpty in
 	// tosca RunContext or eliminate it altogether.
-	return ctx.context.GetNonce(tosca.Address(addr)) == 0 &&
+	return !(ctx.context.GetNonce(tosca.Address(addr)) == 0 &&
 		ctx.context.GetBalance(tosca.Address(addr)) == tosca.Value{} &&
-		ctx.context.GetCodeSize(tosca.Address(addr)) == 0
+		ctx.context.GetCodeSize(tosca.Address(addr)) == 0)
 }
 
 func (ctx *hostContext) GetStorage(addr evmc.Address, key evmc.Hash) evmc.Hash {

--- a/go/interpreter/evmc/evmc_interpreter.go
+++ b/go/interpreter/evmc/evmc_interpreter.go
@@ -222,14 +222,10 @@ func (ctx *hostContext) GetCodeSize(addr evmc.Address) int {
 }
 
 func (ctx *hostContext) GetCodeHash(addr evmc.Address) evmc.Hash {
-	target := tosca.Address(addr)
-	empty := ctx.context.GetNonce(target) == 0 &&
-		ctx.context.GetBalance(target) == tosca.Value{} &&
-		ctx.context.GetCodeSize(target) == 0
-	if empty {
+	if !ctx.AccountExists(addr) { // < Note: in the EVMC, this actually checks for emptiness
 		return evmc.Hash{}
 	}
-	return evmc.Hash(ctx.context.GetCodeHash(target))
+	return evmc.Hash(ctx.context.GetCodeHash(tosca.Address(addr)))
 }
 
 func (ctx *hostContext) GetCode(addr evmc.Address) []byte {

--- a/go/interpreter/evmc/evmc_interpreter.go
+++ b/go/interpreter/evmc/evmc_interpreter.go
@@ -170,7 +170,11 @@ func (ctx *hostContext) AccountExists(addr evmc.Address) bool {
 	// it is actually referring to the emptiness of an account. The concept
 	// of an existing or non-existing account is a DB concept that is not
 	// exposed to any interpreter implementation.
-	return !(ctx.context.GetNonce(tosca.Address(addr)) == 0 &&
+	return !ctx.isEmpty(addr)
+}
+
+func (ctx *hostContext) isEmpty(addr evmc.Address) bool {
+	return (ctx.context.GetNonce(tosca.Address(addr)) == 0 &&
 		ctx.context.GetBalance(tosca.Address(addr)) == tosca.Value{} &&
 		ctx.context.GetCodeSize(tosca.Address(addr)) == 0)
 }
@@ -222,7 +226,7 @@ func (ctx *hostContext) GetCodeSize(addr evmc.Address) int {
 }
 
 func (ctx *hostContext) GetCodeHash(addr evmc.Address) evmc.Hash {
-	if !ctx.AccountExists(addr) { // < Note: in the EVMC, this actually checks for emptiness
+	if ctx.isEmpty(addr) {
 		return evmc.Hash{}
 	}
 	return evmc.Hash(ctx.context.GetCodeHash(tosca.Address(addr)))

--- a/go/interpreter/geth/geth.go
+++ b/go/interpreter/geth/geth.go
@@ -347,7 +347,7 @@ func (s *stateDbAdapter) Exist(addr common.Address) bool {
 }
 
 func (s *stateDbAdapter) Empty(addr common.Address) bool {
-	return !s.context.AccountExists(tosca.Address(addr))
+	return s.GetBalance(addr).IsZero() && s.GetNonce(addr) == 0 && s.GetCodeSize(addr) == 0
 }
 
 func (s *stateDbAdapter) PrepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -1136,6 +1136,8 @@ func opLog(c *context, n int) error {
 	return nil
 }
 
+// isEmpty is a utility function that checks if an account is empty. An account
+// is considered empty if it has no nonce, no balance, and no code.
 func isEmpty(c tosca.RunContext, addr tosca.Address) bool {
 	return c.GetNonce(addr) == 0 &&
 		c.GetBalance(addr) == (tosca.Value{}) &&

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -231,7 +231,7 @@ func TestCallChecksBalances(t *testing.T) {
 	ctxt.stack.data[5].SetBytes(target[:])    // < the target address for the call
 
 	// The target account should exist and the source account without funds.
-	runContext.EXPECT().AccountExists(target).Return(true)
+	runContext.EXPECT().GetNonce(target).Return(uint64(1))
 	runContext.EXPECT().GetBalance(source).Return(tosca.Value{})
 
 	err := opCall(&ctxt)
@@ -1494,7 +1494,9 @@ func TestGenericCall_ProperlyReportsErrors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			runContext := tosca.NewMockRunContext(gomock.NewController(t))
 			runContext.EXPECT().AccessAccount(address).Return(tosca.WarmAccess).AnyTimes()
-			runContext.EXPECT().AccountExists(address).Return(false).AnyTimes()
+			runContext.EXPECT().GetNonce(address).AnyTimes()
+			runContext.EXPECT().GetBalance(address).AnyTimes()
+			runContext.EXPECT().GetCodeSize(address).AnyTimes()
 
 			ctxt := getEmptyContext()
 			ctxt.context = runContext

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -838,35 +838,35 @@ func TestSelfDestruct_Refund(t *testing.T) {
 func TestSelfDestruct_NewAccountCost(t *testing.T) {
 
 	tests := map[string]struct {
-		beneficiaryExists bool
-		balance           tosca.Value
-		cost              tosca.Gas
+		beneficiaryEmpty bool
+		balance          tosca.Value
+		cost             tosca.Gas
 	}{
-		"account exists no balance": {
-			beneficiaryExists: true,
-			balance:           tosca.Value{},
-			cost:              0,
+		"beneficiary empty no balance": {
+			beneficiaryEmpty: true,
+			balance:          tosca.Value{},
+			cost:             0,
 		},
-		"account exists with balance": {
-			beneficiaryExists: true,
-			balance:           tosca.Value{1},
-			cost:              0,
+		"beneficiary empty with balance": {
+			beneficiaryEmpty: true,
+			balance:          tosca.Value{1},
+			cost:             25_000,
 		},
-		"new account without balance": {
-			beneficiaryExists: false,
-			balance:           tosca.Value{},
-			cost:              0,
+		"beneficiary not empty without balance": {
+			beneficiaryEmpty: false,
+			balance:          tosca.Value{},
+			cost:             0,
 		},
-		"new account with balance": {
-			beneficiaryExists: false,
-			balance:           tosca.Value{1},
-			cost:              25_000,
+		"beneficiary not empty with balance": {
+			beneficiaryEmpty: false,
+			balance:          tosca.Value{1},
+			cost:             0,
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			cost := selfDestructNewAccountCost(test.beneficiaryExists, test.balance)
+			cost := selfDestructNewAccountCost(test.beneficiaryEmpty, test.balance)
 			if cost != test.cost {
 				t.Errorf("unexpected gas, wanted %d, got %d", test.cost, cost)
 			}
@@ -885,7 +885,9 @@ func TestSelfDestruct_ExistingAccountToNewBeneficiary(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	runContext := tosca.NewMockRunContext(ctrl)
 	runContext.EXPECT().AccessAccount(beneficiaryAddress).Return(tosca.ColdAccess)
-	runContext.EXPECT().AccountExists(beneficiaryAddress).Return(false)
+	runContext.EXPECT().GetBalance(beneficiaryAddress)
+	runContext.EXPECT().GetNonce(beneficiaryAddress)
+	runContext.EXPECT().GetCodeSize(beneficiaryAddress)
 	runContext.EXPECT().GetBalance(selfAddress).Return(tosca.Value{1})
 	runContext.EXPECT().SelfDestruct(selfAddress, beneficiaryAddress).Return(true)
 
@@ -918,15 +920,23 @@ func TestSelfDestruct_ExistingAccountToNewBeneficiary(t *testing.T) {
 
 func TestSelfDestruct_ProperlyReportsNotEnoughGas(t *testing.T) {
 	for _, beneficiaryAccess := range []tosca.AccessStatus{tosca.WarmAccess, tosca.ColdAccess} {
-		for _, accountExists := range []bool{true, false} {
-			t.Run(fmt.Sprintf("beneficiaryAccess:%v_accountExists:%v", beneficiaryAccess, accountExists), func(t *testing.T) {
+		for _, accountEmpty := range []bool{true, false} {
+			t.Run(fmt.Sprintf("beneficiaryAccess:%v_accountEmpty:%v", beneficiaryAccess, accountEmpty), func(t *testing.T) {
 				beneficiaryAddress := tosca.Address{1}
 				selfAddress := tosca.Address{2}
 
 				ctrl := gomock.NewController(t)
 				runContext := tosca.NewMockRunContext(ctrl)
 				runContext.EXPECT().AccessAccount(beneficiaryAddress).Return(beneficiaryAccess)
-				runContext.EXPECT().AccountExists(beneficiaryAddress).Return(accountExists)
+
+				if accountEmpty {
+					runContext.EXPECT().GetCodeSize(beneficiaryAddress).Return(1)
+				} else {
+					runContext.EXPECT().GetCodeSize(beneficiaryAddress).Return(0)
+				}
+				runContext.EXPECT().GetBalance(beneficiaryAddress).AnyTimes()
+				runContext.EXPECT().GetNonce(beneficiaryAddress).AnyTimes()
+
 				runContext.EXPECT().GetBalance(selfAddress).Return(tosca.Value{1})
 
 				ctxt := context{
@@ -943,7 +953,7 @@ func TestSelfDestruct_ProperlyReportsNotEnoughGas(t *testing.T) {
 				if beneficiaryAccess == tosca.ColdAccess {
 					ctxt.gas += 2600
 				}
-				if !accountExists {
+				if !accountEmpty {
 					ctxt.gas += 25000
 				}
 				ctxt.gas -= 1
@@ -1927,10 +1937,10 @@ func TestInstructions_Sha3_WritesCorrectHashInStack(t *testing.T) {
 func TestOpExtCodeHash_WritesHashOnStackIfAccountExists(t *testing.T) {
 
 	tests := map[string]struct {
-		accountExists bool
+		accountEmpty bool
 	}{
-		"account exists":         {accountExists: true},
-		"account does not exist": {accountExists: false},
+		"account empty":     {accountEmpty: true},
+		"account not empty": {accountEmpty: false},
 	}
 
 	hash := tosca.Hash{0x1, 0x2, 0x3}
@@ -1942,8 +1952,16 @@ func TestOpExtCodeHash_WritesHashOnStackIfAccountExists(t *testing.T) {
 			ctxt.stack = fillStack(*new(uint256.Int).SetBytes20(address[:]))
 
 			runContext := tosca.NewMockRunContext(gomock.NewController(t))
-			runContext.EXPECT().AccountExists(address).Return(test.accountExists)
-			if test.accountExists {
+
+			runContext.EXPECT().GetBalance(address).AnyTimes()
+			runContext.EXPECT().GetNonce(address).AnyTimes()
+			if test.accountEmpty {
+				runContext.EXPECT().GetCodeSize(address).Return(0)
+			} else {
+				runContext.EXPECT().GetCodeSize(address).Return(1)
+			}
+
+			if !test.accountEmpty {
 				runContext.EXPECT().GetCodeHash(address).Return(hash)
 			}
 			ctxt.context = runContext
@@ -1953,7 +1971,7 @@ func TestOpExtCodeHash_WritesHashOnStackIfAccountExists(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 			want := hash[:]
-			if !test.accountExists {
+			if test.accountEmpty {
 				want = []byte{}
 			}
 			if got := ctxt.stack.pop().Bytes(); !bytes.Equal(want, got) {

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -249,8 +249,8 @@ func TestInterpreter_ExecutionTerminates(t *testing.T) {
 			ctxt.stack.push(uint256.NewInt(3))
 			// runcontext is needed for selfdestruct
 			mockContext := tosca.NewMockRunContext(gomock.NewController(t))
-			mockContext.EXPECT().AccountExists(gomock.Any()).Return(true).AnyTimes()
 			mockContext.EXPECT().GetBalance(gomock.Any()).Return(tosca.Value{1}).AnyTimes()
+			mockContext.EXPECT().GetNonce(gomock.Any()).Return(uint64(1)).AnyTimes()
 			mockContext.EXPECT().SelfDestruct(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 			ctxt.context = mockContext
 

--- a/go/interpreter/lfvm/interpreter_test.go
+++ b/go/interpreter/lfvm/interpreter_test.go
@@ -186,6 +186,7 @@ func TestInterpreter_CanDispatchExecutableInstructions(t *testing.T) {
 				// mock all to satisfy any instruction
 				mock.EXPECT().AccessAccount(gomock.Any()).Return(tosca.WarmAccess).AnyTimes()
 				mock.EXPECT().GetBalance(gomock.Any()).AnyTimes()
+				mock.EXPECT().GetNonce(gomock.Any()).AnyTimes()
 				mock.EXPECT().GetCodeSize(gomock.Any()).AnyTimes()
 				mock.EXPECT().GetCode(gomock.Any()).AnyTimes()
 				mock.EXPECT().AccountExists(gomock.Any()).AnyTimes()


### PR DESCRIPTION
This PR replaces all Account-Exist checks in interpreters with Account-IsEmpty checks.

As was discovered by running the Ethereum tests and studying the new Python based EVM specification, interpreter implementations should have no dependency to the existence of an account. Their only concern should be the emptiness of an account in contexts where gas prices for the implicit creation of accounts need to be computed or the hash of an external account should be determined.

This PR introduces the following changes:
- fixes a bug in the geth reference-interpreter integration where an empty account was incorrectly identified by checking for its non-existence; while this is true for any finalized state on the chain (non-empty accounts must not exist), empty accounts may temporary exist during the execution of a contract
- updates the EVMC adapter to check for emptiness when being asked for the existence of an account. It appears, whenever an EVMC implementation asks for the existence of an account, it is actually asking for its emptiness
- update of numerous unit tests to match those changes

Remaining tasks:
- [x] run historic substate tests on these changes
- [x] run ethereum JSON tests on these changes
- [x] run CT testing on these changes
   - [x] geth
   - [x] lfvm
   - [x] evmzero