### PR TITLE
evmrs: limit ci feature combinations to no, each and all features

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -58,7 +58,7 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo clippy
       working-directory: rust
-      run: cargo hack --workspace --feature-powerset --exclude-features mock,dump-cov,performance clippy --examples --tests --benches -- --deny warnings
+      run: cargo hack --workspace --each-feature clippy --examples --tests --benches -- --deny warnings
     
   doc:
     name: doc
@@ -79,7 +79,7 @@ jobs:
       env:
         RUSTDOCFLAGS: "-D warnings" 
       working-directory: rust
-      run: cargo hack --workspace --feature-powerset --exclude-features mock,dump-cov,performance doc --no-deps
+      run: cargo hack --workspace --each-feature doc --no-deps
 
   build:
     name: build
@@ -98,7 +98,7 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo build
       working-directory: rust
-      run: cargo hack --workspace --feature-powerset --exclude-features mock,dump-cov,performance build
+      run: cargo hack --workspace --each-feature build
 
   test:
     name: test
@@ -117,7 +117,7 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo test
       working-directory: rust
-      run: cargo hack --workspace --feature-powerset --exclude-features mock,dump-cov,performance test
+      run: cargo hack --workspace --each-feature test
 
   deps:
     name: unused deps


### PR DESCRIPTION
With feature powerset testing, CO takes way to long. Currently clippy needs ~30min. Add a couple more features and it is in the hours. This PR changes how cargo hack is called. With the `--each-feature` flag each feature is tested individually, but no longer all feature combinations. Additionally it tests with no and all features.