### PR TITLE
evmrs: refactor

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,14 +26,14 @@ performance = [
     "custom-evmc",
     "jumptable",
     "hash-cache",
-    "jump-cache",
+    "code-analysis-cache",
 ]
 mimalloc = ["dep:mimalloc"]
 stack-array = []
 custom-evmc = ["dep:evmc-vm-tosca-refactor"]
 jumptable = []
 hash-cache = ["dep:lru"]
-jump-cache = ["dep:lru", "dep:nohash-hasher"]
+code-analysis-cache = ["dep:lru", "dep:nohash-hasher"]
 thread-local-cache = []
 jumptable-tail-call = ["jumptable"]
 

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -10,7 +10,7 @@ stack-array = ["evmrs/stack-array"]
 custom-evmc = ["evmrs/custom-evmc"]
 jumptable = ["evmrs/jumptable"]
 hash-cache = ["evmrs/hash-cache"]
-jump-cache = ["evmrs/jump-cache"]
+code-analysis-cache = ["evmrs/code-analysis-cache"]
 thread-local-cache = ["evmrs/thread-local-cache"]
 jumptable-tail-call = ["evmrs/jumptable-tail-call"]
 

--- a/rust/benchmarks/src/lib.rs
+++ b/rust/benchmarks/src/lib.rs
@@ -23,7 +23,7 @@ impl RunArgs {
     /// pointers get passed via the FFI interface and then the data is copied into a fresh
     /// allocation on the other side.
     /// - `ExecutionMessage` contains non-empty input
-    /// - `code` is non-empty so that `CodeReader` must allocate memory to store the jump analysis
+    /// - `code` is non-empty so that `CodeReader` must allocate memory to store the code analysis
     ///   results
     /// - `code` contains `Opcode::MStore` so that `memory` is non-empty
     /// - `code` returns a single word so that `output` is non-empty

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -985,9 +985,9 @@ where
             self.gas_left.consume_copy_cost(len)?;
             let bytes_written = self.context.copy_code(&addr, offset as usize, dest);
             if offset_overflow {
-                dest.set_to_zero();
+                dest.fill(0);
             } else if (bytes_written as u64) < len {
-                dest[bytes_written..].set_to_zero();
+                dest[bytes_written..].fill(0);
             }
         }
         self.code_reader.next();

--- a/rust/src/types/cache.rs
+++ b/rust/src/types/cache.rs
@@ -39,7 +39,7 @@ where
         )))
     }
 
-    #[cfg(feature = "jump-cache")]
+    #[cfg(feature = "code-analysis-cache")]
     pub fn get_or_insert(&self, key: K, f: impl FnOnce() -> V) -> V
     where
         V: Clone,
@@ -66,7 +66,7 @@ where
 
 #[cfg(feature = "thread-local-cache")]
 pub trait LocalKeyExt<const S: usize, K, V, H> {
-    #[cfg(feature = "jump-cache")]
+    #[cfg(feature = "code-analysis-cache")]
     fn get_or_insert(&'static self, key: K, f: impl FnOnce() -> V) -> V
     where
         V: Clone;
@@ -85,7 +85,7 @@ where
     K: Hash + Eq,
     H: BuildHasher + Default,
 {
-    #[cfg(feature = "jump-cache")]
+    #[cfg(feature = "code-analysis-cache")]
     fn get_or_insert(&'static self, key: K, f: impl FnOnce() -> V) -> V
     where
         V: Clone,

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -1,10 +1,10 @@
 mod amount;
-#[cfg(any(feature = "hash-cache", feature = "jump-cache"))]
+#[cfg(any(feature = "hash-cache", feature = "code-analysis-cache"))]
 mod cache;
+mod code_analysis;
 mod code_reader;
 mod execution_context;
 pub mod hash_cache;
-mod jump_analysis;
 mod memory;
 mod mock_execution_message;
 mod opcode;
@@ -13,16 +13,16 @@ mod status_code;
 mod tx_context;
 
 pub use amount::u256;
-#[cfg(any(feature = "hash-cache", feature = "jump-cache"))]
+#[cfg(any(feature = "hash-cache", feature = "code-analysis-cache"))]
 pub use cache::Cache;
 #[cfg(all(
     feature = "thread-local-cache",
-    any(feature = "hash-cache", feature = "jump-cache")
+    any(feature = "hash-cache", feature = "code-analysis-cache")
 ))]
 pub use cache::LocalKeyExt;
+pub use code_analysis::CodeAnalysis;
 pub use code_reader::{CodeReader, GetOpcodeError};
 pub use execution_context::*;
-pub use jump_analysis::JumpAnalysis;
 pub use memory::Memory;
 pub use mock_execution_message::MockExecutionMessage;
 pub use opcode::*;

--- a/rust/src/utils/helpers.rs
+++ b/rust/src/utils/helpers.rs
@@ -11,8 +11,6 @@ use crate::{
 pub trait SliceExt {
     fn get_within_bounds(&self, offset: u256, len: u64) -> &[u8];
 
-    fn set_to_zero(&mut self);
-
     fn copy_padded(&mut self, src: &[u8], gas_left: &mut Gas) -> Result<(), FailStatus>;
 }
 
@@ -37,17 +35,10 @@ impl SliceExt for [u8] {
     }
 
     #[inline(always)]
-    fn set_to_zero(&mut self) {
-        for byte in self {
-            *byte = 0;
-        }
-    }
-
-    #[inline(always)]
     fn copy_padded(&mut self, src: &[u8], gas_left: &mut Gas) -> Result<(), FailStatus> {
         gas_left.consume_copy_cost(self.len() as u64)?;
         self[..src.len()].copy_from_slice(src);
-        self[src.len()..].set_to_zero();
+        self[src.len()..].fill(0);
         Ok(())
     }
 }
@@ -100,19 +91,6 @@ mod tests {
         assert_eq!([1].get_within_bounds(u256::ZERO, 2), &[1]);
         assert_eq!([1].get_within_bounds(u256::ONE, 1), &[]);
         assert_eq!([1].get_within_bounds(u256::MAX, 1), &[]);
-    }
-
-    #[test]
-    fn set_to_zero() {
-        let mut data = [];
-        data.set_to_zero();
-        assert_eq!(&data, &[]);
-        let mut data = [1];
-        data.set_to_zero();
-        assert_eq!(&data, &[0]);
-        let mut data = [1, 2];
-        data.set_to_zero();
-        assert_eq!(&data, &[0, 0]);
     }
 
     #[test]


### PR DESCRIPTION
replace set_to_zero() by fill(0)
rename jump analysis to code analysis
rename feature jump-cache to code-analysis-cache
use saturating_sub in CodeReader::get_push_data