### PR TITLE
CT/LFVM: call provided gas over int64

### DIFF
--- a/go/ct/rlz/parameters.go
+++ b/go/ct/rlz/parameters.go
@@ -152,11 +152,8 @@ type GasParameter struct{}
 var gasParameterSamples = []U256{
 	NewU256(0),
 	NewU256(1),
-	NewU256(1 << 10),
-	NewU256(st.MaxGasUsedByCt),
 	NewU256(math.MaxInt64),
 	NewU256(math.MaxInt64 + 1),
-	NewU256(math.MaxUint64),
 }
 
 func (GasParameter) Samples() []U256 {

--- a/go/ct/rlz/parameters.go
+++ b/go/ct/rlz/parameters.go
@@ -154,6 +154,9 @@ var gasParameterSamples = []U256{
 	NewU256(1),
 	NewU256(1 << 10),
 	NewU256(st.MaxGasUsedByCt),
+	NewU256(math.MaxInt64),
+	NewU256(math.MaxInt64 + 1),
+	NewU256(math.MaxUint64),
 }
 
 func (GasParameter) Samples() []U256 {

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -973,7 +973,7 @@ func genericCall(c *context, kind tosca.CallKind) error {
 	// defines that at all but one 64th of the available gas in one scope may be passed
 	// to a nested call.
 	nestedCallGas := tosca.Gas(c.gas - c.gas/64)
-	if provided_gas.IsUint64() && (nestedCallGas >= tosca.Gas(provided_gas.Uint64())) {
+	if provided_gas.IsUint64() && provided_gas.Uint64() <= math.MaxInt64 && (nestedCallGas >= tosca.Gas(provided_gas.Uint64())) {
 		nestedCallGas = tosca.Gas(provided_gas.Uint64())
 	}
 	c.gas -= nestedCallGas

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -1576,10 +1576,6 @@ func TestGenericCall_HandlesBigProvidedGasValues(t *testing.T) {
 	for name, providedGas := range tests {
 		t.Run(name, func(t *testing.T) {
 			nestedGas := tosca.Gas(gas - gas/64)
-			providedGasU64 := providedGas.Uint64()
-			if providedGas.IsUint64() && providedGasU64 <= math.MaxInt64 && (nestedGas >= tosca.Gas(providedGasU64)) {
-				nestedGas = tosca.Gas(providedGasU64)
-			}
 			runContext := tosca.NewMockRunContext(gomock.NewController(t))
 			runContext.EXPECT().Call(tosca.Call, tosca.CallParameters{Gas: nestedGas}).Return(tosca.CallResult{}, nil)
 			ctxt := context{gas: gas}


### PR DESCRIPTION
This bug was first found through the Ethereum json tests.
When a `CALL` command is executed and the top of the stack is a value bigger than `maxInt64` but smaller than `maxUint64` this value was still considered accepted and overflowed when converted to uint64. 
This PR:
- expands CT `gasParameter` to include values over max int64
- add fix in the lfvm interpreter
- adds a test that fails without the fix in lfvm