### PR TITLE
Geth adapter: Fix error conversion

### DIFF
--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -352,8 +352,11 @@ func decodeReadOnlyFromGas(depth int, readOnly bool, gas uint64) (bool, uint64) 
 
 func gethToVMErrors(err error, gas tosca.Gas) (tosca.CallResult, error) {
 	switch err {
-	case geth.ErrInsufficientBalance:
-		// In this case, the caller get its gas back.
+	case
+		geth.ErrInsufficientBalance,
+		geth.ErrDepth,
+		geth.ErrNonceUintOverflow:
+		// In these cases, the caller get its gas back.
 		// TODO: this seems to be a geth implementation quirk that got
 		// transferred into the LFVM implementation; this should be fixed.
 		return tosca.CallResult{
@@ -363,9 +366,9 @@ func gethToVMErrors(err error, gas tosca.Gas) (tosca.CallResult, error) {
 	case
 		geth.ErrOutOfGas,
 		geth.ErrCodeStoreOutOfGas,
-		geth.ErrDepth,
 		geth.ErrContractAddressCollision,
 		geth.ErrExecutionReverted,
+		geth.ErrMaxInitCodeSizeExceeded,
 		geth.ErrMaxCodeSizeExceeded,
 		geth.ErrInvalidJump,
 		geth.ErrWriteProtection,

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -665,6 +665,16 @@ func TestRunContextAdapter_gethToVMErrors(t *testing.T) {
 			wantResult: tosca.CallResult{GasLeft: gas},
 			wantError:  nil,
 		},
+		"maxCallDepth": {
+			input:      geth.ErrDepth,
+			wantResult: tosca.CallResult{GasLeft: gas},
+			wantError:  nil,
+		},
+		"nonceOverflow": {
+			input:      geth.ErrNonceUintOverflow,
+			wantResult: tosca.CallResult{GasLeft: gas},
+			wantError:  nil,
+		},
 		"OutOfGas": {
 			input:      geth.ErrOutOfGas,
 			wantResult: tosca.CallResult{},
@@ -700,6 +710,37 @@ func TestRunContextAdapter_gethToVMErrors(t *testing.T) {
 			}
 			reflect.DeepEqual(gotResult, test.wantResult)
 		})
+	}
+}
+
+func TestRunContextAdapter_AllGethErrorsAreHandled(t *testing.T) {
+	// all errors defined in geth/core/vm/gethErrors.go
+	gethErrors := []error{
+		geth.ErrOutOfGas,
+		geth.ErrCodeStoreOutOfGas,
+		geth.ErrDepth,
+		geth.ErrInsufficientBalance,
+		geth.ErrContractAddressCollision,
+		geth.ErrExecutionReverted,
+		geth.ErrMaxCodeSizeExceeded,
+		geth.ErrMaxInitCodeSizeExceeded,
+		geth.ErrInvalidJump,
+		geth.ErrWriteProtection,
+		geth.ErrReturnDataOutOfBounds,
+		geth.ErrGasUintOverflow,
+		geth.ErrInvalidCode,
+		geth.ErrNonceUintOverflow,
+
+		&geth.ErrStackUnderflow{},
+		&geth.ErrStackOverflow{},
+		&geth.ErrInvalidOpCode{},
+	}
+
+	for _, inErr := range gethErrors {
+		_, outErr := gethToVMErrors(inErr, tosca.Gas(42))
+		if outErr != nil {
+			t.Errorf("Unexpected return error %v", outErr)
+		}
 	}
 }
 


### PR DESCRIPTION
The execution of the ethereum tests surfaced a bug in the error conversion between geth and tosca. If the maximum call depth is reached, the call was not successful but all its gas is returned. The same behavior is expected in an nonce overflow. 
Further, errors exceeding the max init code size were not handled in the conversion.