### PR TITLE
Adds a cleanup stage in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,5 +118,11 @@ pipeline {
                 sh 'LLVM_PROFILE_FILE="/tmp/go/rust-%p-%m.profraw" go test -v  -run ^TestDumpRustCoverageData$ ./go/lib/rust/ --expect-coverage'
             }
         }
+
+        stage('Clean up') {
+            steps {
+                sh 'make clean'
+            }
+        }
     }
 }


### PR DESCRIPTION
Tosca PR may run on a dedicated PR testing agent. Each PR is built as a separated job and has its own workspace on the agent, which quickly fills the storage space. This PR adds a cleanup stage to reduce required disk space.