### PR TITLE
Calls* forward code address

### DIFF
--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -2597,20 +2597,18 @@ func callEffect(s *st.State, addrAccessCost tosca.Gas, op vm.OpCode) {
 
 	sender := s.CallContext.AccountAddress
 	recipient := target.Bytes20be()
-	codeAddress := tosca.Address{}
+	codeAddress := target.Bytes20be()
 	// In a static context all calls are static calls.
 	kind := tosca.Call
 	if op == vm.DELEGATECALL {
 		kind = tosca.DelegateCall
 		sender = s.CallContext.CallerAddress
 		recipient = s.CallContext.AccountAddress
-		codeAddress = target.Bytes20be()
 		value = s.CallContext.Value
 	} else if op == vm.CALLCODE {
 		kind = tosca.CallCode
 		sender = s.CallContext.AccountAddress
 		recipient = s.CallContext.AccountAddress
-		codeAddress = target.Bytes20be()
 	}
 
 	if (s.ReadOnly && op == vm.CALL) || op == vm.STATICCALL {

--- a/go/ct/st/call_journal.go
+++ b/go/ct/st/call_journal.go
@@ -34,12 +34,13 @@ func NewCallJournal() *CallJournal {
 func (j *CallJournal) Call(kind tosca.CallKind, parameter tosca.CallParameters) tosca.CallResult {
 	// log the call as a past call.
 	j.Past = append(j.Past, PastCall{
-		Kind:      kind,
-		Recipient: parameter.Recipient,
-		Sender:    parameter.Sender,
-		Input:     NewBytes(parameter.Input),
-		Value:     parameter.Value,
-		Gas:       parameter.Gas,
+		Kind:        kind,
+		Recipient:   parameter.Recipient,
+		Sender:      parameter.Sender,
+		Input:       NewBytes(parameter.Input),
+		Value:       parameter.Value,
+		Gas:         parameter.Gas,
+		CodeAddress: parameter.CodeAddress,
 	})
 
 	// consume the next future result
@@ -118,12 +119,13 @@ func (j *CallJournal) Clone() *CallJournal {
 // PastCall represents an already processed call. It is part of the state
 // model for two reasons to enable the verification of call parameters.
 type PastCall struct {
-	Kind      tosca.CallKind
-	Recipient tosca.Address
-	Sender    tosca.Address
-	Input     Bytes
-	Value     tosca.Value
-	Gas       tosca.Gas
+	Kind        tosca.CallKind
+	Recipient   tosca.Address
+	Sender      tosca.Address
+	Input       Bytes
+	Value       tosca.Value
+	Gas         tosca.Gas
+	CodeAddress tosca.Address
 }
 
 func (c *PastCall) Equal(other *PastCall) bool {
@@ -149,6 +151,9 @@ func (c *PastCall) Diff(other *PastCall) []string {
 	}
 	if have, got := c.Gas, other.Gas; have != got {
 		res = append(res, fmt.Sprintf("different gas: %v vs %v (diff: %d)", have, got, got-have))
+	}
+	if have, got := c.CodeAddress, other.CodeAddress; have != got {
+		res = append(res, fmt.Sprintf("different code address: %v vs %v", have, got))
 	}
 	return res
 }

--- a/go/ct/st/call_journal_test.go
+++ b/go/ct/st/call_journal_test.go
@@ -59,12 +59,13 @@ func TestCallJournal_CallMovesFutureToPastCall(t *testing.T) {
 		t.Fatalf("no past call was recorded")
 	}
 	want := PastCall{
-		Kind:      tosca.StaticCall,
-		Recipient: tosca.Address{2},
-		Sender:    tosca.Address{1},
-		Input:     common.NewBytes([]byte{4, 5}),
-		Value:     tosca.Value{3},
-		Gas:       tosca.Gas(6),
+		Kind:        tosca.StaticCall,
+		Recipient:   tosca.Address{2},
+		Sender:      tosca.Address{1},
+		Input:       common.NewBytes([]byte{4, 5}),
+		Value:       tosca.Value{3},
+		Gas:         tosca.Gas(6),
+		CodeAddress: tosca.Address{8},
 	}
 
 	if got := journal.Past[0]; !want.Equal(&got) {
@@ -157,12 +158,13 @@ func TestPastCall_EqualDetectsDifferences(t *testing.T) {
 	tests := map[string]struct {
 		modify func(c *PastCall)
 	}{
-		"kind":      {func(c *PastCall) { c.Kind = tosca.DelegateCall }},
-		"recipient": {func(c *PastCall) { c.Recipient[0]++ }},
-		"sender":    {func(c *PastCall) { c.Sender[0]++ }},
-		"input":     {func(c *PastCall) { c.Input = common.NewBytes([]byte{1, 2, 3}) }},
-		"value":     {func(c *PastCall) { c.Value[0]++ }},
-		"gas":       {func(c *PastCall) { c.Gas++ }},
+		"kind":         {func(c *PastCall) { c.Kind = tosca.DelegateCall }},
+		"recipient":    {func(c *PastCall) { c.Recipient[0]++ }},
+		"sender":       {func(c *PastCall) { c.Sender[0]++ }},
+		"input":        {func(c *PastCall) { c.Input = common.NewBytes([]byte{1, 2, 3}) }},
+		"value":        {func(c *PastCall) { c.Value[0]++ }},
+		"gas":          {func(c *PastCall) { c.Gas++ }},
+		"code address": {func(c *PastCall) { c.CodeAddress[0]++ }},
 	}
 
 	for name, test := range tests {
@@ -181,12 +183,13 @@ func TestPastCall_DiffDetectsDifferences(t *testing.T) {
 	tests := map[string]struct {
 		modify func(c *PastCall)
 	}{
-		"kind":      {func(c *PastCall) { c.Kind = tosca.DelegateCall }},
-		"recipient": {func(c *PastCall) { c.Recipient[0]++ }},
-		"sender":    {func(c *PastCall) { c.Sender[0]++ }},
-		"input":     {func(c *PastCall) { c.Input = common.NewBytes([]byte{1, 2, 3}) }},
-		"value":     {func(c *PastCall) { c.Value[0]++ }},
-		"gas":       {func(c *PastCall) { c.Gas++ }},
+		"kind":         {func(c *PastCall) { c.Kind = tosca.DelegateCall }},
+		"recipient":    {func(c *PastCall) { c.Recipient[0]++ }},
+		"sender":       {func(c *PastCall) { c.Sender[0]++ }},
+		"input":        {func(c *PastCall) { c.Input = common.NewBytes([]byte{1, 2, 3}) }},
+		"value":        {func(c *PastCall) { c.Value[0]++ }},
+		"gas":          {func(c *PastCall) { c.Gas++ }},
+		"code address": {func(c *PastCall) { c.CodeAddress[0]++ }},
 	}
 
 	for name, test := range tests {

--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -270,7 +270,7 @@ func (a *runContextAdapter) Call(kind tosca.CallKind, parameter tosca.CallParame
 		defer func() { debugCallEnd(result, reserr) }()
 	}
 
-	gas := encodeReadOnlyInGas(uint64(parameter.Gas), parameter.Recipient, a.readOnly)
+	gas := encodeReadOnlyInGas(uint64(parameter.Gas), parameter.CodeAddress, a.readOnly)
 
 	// Documentation of the parameters can be found here: t.ly/yhxC
 	toAddr := gc.Address(parameter.Recipient)

--- a/go/interpreter/geth/ct.go
+++ b/go/interpreter/geth/ct.go
@@ -168,11 +168,12 @@ func (i *callInterceptor) Call(env *geth_vm.EVM, me geth_vm.ContractRef, addr ge
 	}
 
 	res, err := i.makeCall(kind, tosca.CallParameters{
-		Sender:    tosca.Address(me.Address()),
-		Recipient: tosca.Address(addr),
-		Value:     tosca.ValueFromUint256(value),
-		Input:     data,
-		Gas:       tosca.Gas(gas),
+		Sender:      tosca.Address(me.Address()),
+		Recipient:   tosca.Address(addr),
+		Value:       tosca.ValueFromUint256(value),
+		Input:       data,
+		Gas:         tosca.Gas(gas),
+		CodeAddress: tosca.Address(addr),
 	})
 	return res.Output, uint64(res.GasLeft), err
 }
@@ -199,21 +200,23 @@ func (i *callInterceptor) CallCode(env *geth_vm.EVM, me geth_vm.ContractRef, add
 
 func (i *callInterceptor) DelegateCall(env *geth_vm.EVM, me geth_vm.ContractRef, addr geth_common.Address, data []byte, gas uint64) ([]byte, uint64, error) {
 	res, err := i.makeCall(tosca.DelegateCall, tosca.CallParameters{
-		Sender:    i.parameters.Sender,
-		Recipient: i.parameters.Recipient,
-		Value:     i.parameters.Value,
-		Input:     data,
-		Gas:       tosca.Gas(gas),
+		Sender:      i.parameters.Sender,
+		Recipient:   i.parameters.Recipient,
+		Value:       i.parameters.Value,
+		Input:       data,
+		Gas:         tosca.Gas(gas),
+		CodeAddress: tosca.Address(addr),
 	})
 	return res.Output, uint64(res.GasLeft), err
 }
 
 func (i *callInterceptor) StaticCall(env *geth_vm.EVM, me geth_vm.ContractRef, addr geth_common.Address, input []byte, gas uint64) ([]byte, uint64, error) {
 	res, err := i.makeCall(tosca.StaticCall, tosca.CallParameters{
-		Sender:    tosca.Address(me.Address()),
-		Recipient: tosca.Address(addr),
-		Input:     input,
-		Gas:       tosca.Gas(gas),
+		Sender:      tosca.Address(me.Address()),
+		Recipient:   tosca.Address(addr),
+		Input:       input,
+		Gas:         tosca.Gas(gas),
+		CodeAddress: tosca.Address(addr),
 	})
 	return res.Output, uint64(res.GasLeft), err
 }

--- a/go/interpreter/geth/geth.go
+++ b/go/interpreter/geth/geth.go
@@ -192,7 +192,6 @@ func createGethInterpreterContext(parameters tosca.Parameters) (*geth.EVM, *geth
 	addr := geth.AccountRef(parameters.Recipient)
 	contract := geth.NewContract(addr, addr, value, uint64(parameters.Gas))
 	contract.CallerAddress = common.Address(parameters.Sender)
-	// contract.CodeAddr = addr.Address()
 	contract.Code = parameters.Code
 	contract.CodeHash = crypto.Keccak256Hash(parameters.Code)
 	contract.Input = parameters.Input

--- a/go/interpreter/geth/geth.go
+++ b/go/interpreter/geth/geth.go
@@ -192,7 +192,7 @@ func createGethInterpreterContext(parameters tosca.Parameters) (*geth.EVM, *geth
 	addr := geth.AccountRef(parameters.Recipient)
 	contract := geth.NewContract(addr, addr, value, uint64(parameters.Gas))
 	contract.CallerAddress = common.Address(parameters.Sender)
-	contract.CodeAddr = &common.Address{}
+	// contract.CodeAddr = addr.Address()
 	contract.Code = parameters.Code
 	contract.CodeHash = crypto.Keccak256Hash(parameters.Code)
 	contract.Input = parameters.Input

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -1006,9 +1006,10 @@ func genericCall(c *context, kind tosca.CallKind) error {
 
 	// Prepare arguments, depending on call kind
 	callParams := tosca.CallParameters{
-		Input: args,
-		Gas:   nestedCallGas,
-		Value: tosca.Value(value.Bytes32()),
+		Input:       args,
+		Gas:         nestedCallGas,
+		Value:       tosca.Value(value.Bytes32()),
+		CodeAddress: toAddr,
 	}
 
 	switch kind {

--- a/go/interpreter/lfvm/instructions.go
+++ b/go/interpreter/lfvm/instructions.go
@@ -1020,12 +1020,10 @@ func genericCall(c *context, kind tosca.CallKind) error {
 	case tosca.CallCode:
 		callParams.Sender = c.params.Recipient
 		callParams.Recipient = c.params.Recipient
-		callParams.CodeAddress = toAddr
 
 	case tosca.DelegateCall:
 		callParams.Sender = c.params.Sender
 		callParams.Recipient = c.params.Recipient
-		callParams.CodeAddress = toAddr
 		callParams.Value = c.params.Value
 	}
 

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -744,7 +744,7 @@ func TestCall_ChargesNothingForColdAccessBeforeBerlin(t *testing.T) {
 	one := *uint256.NewInt(1)
 	ctrl := gomock.NewController(t)
 	runContext := tosca.NewMockRunContext(ctrl)
-	runContext.EXPECT().Call(tosca.Call, tosca.CallParameters{Recipient: one.Bytes20()}).Return(tosca.CallResult{}, nil)
+	runContext.EXPECT().Call(tosca.Call, tosca.CallParameters{Recipient: one.Bytes20(), CodeAddress: one.Bytes20()}).Return(tosca.CallResult{}, nil)
 	ctxt := context{
 		params: tosca.Parameters{
 			BlockParameters: tosca.BlockParameters{
@@ -776,7 +776,7 @@ func TestCall_ChargesForAccessAfterBerlin(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		runContext := tosca.NewMockRunContext(ctrl)
 		runContext.EXPECT().AccessAccount(one.Bytes20()).Return(accessStatus)
-		runContext.EXPECT().Call(tosca.Call, tosca.CallParameters{Recipient: one.Bytes20()}).Return(tosca.CallResult{}, nil)
+		runContext.EXPECT().Call(tosca.Call, tosca.CallParameters{Recipient: one.Bytes20(), CodeAddress: one.Bytes20()}).Return(tosca.CallResult{}, nil)
 		delta := tosca.Gas(1)
 		ctxt := context{
 			params: tosca.Parameters{
@@ -1531,7 +1531,7 @@ func TestGenericCall_CallKindPropagatesStaticMode(t *testing.T) {
 	zero := *uint256.NewInt(0)
 	one := *uint256.NewInt(1)
 	runContext := tosca.NewMockRunContext(gomock.NewController(t))
-	runContext.EXPECT().Call(tosca.StaticCall, tosca.CallParameters{Recipient: one.Bytes20()}).Return(tosca.CallResult{}, nil)
+	runContext.EXPECT().Call(tosca.StaticCall, tosca.CallParameters{Recipient: one.Bytes20(), CodeAddress: one.Bytes20()}).Return(tosca.CallResult{}, nil)
 	ctxt := getEmptyContext()
 	ctxt.context = runContext
 	ctxt.params.Static = true
@@ -1548,7 +1548,7 @@ func TestGenericCall_ResultIsWrittenToStack(t *testing.T) {
 	one := *uint256.NewInt(1)
 	for _, success := range []bool{true, false} {
 		runContext := tosca.NewMockRunContext(gomock.NewController(t))
-		runContext.EXPECT().Call(tosca.Call, tosca.CallParameters{Recipient: one.Bytes20()}).Return(tosca.CallResult{Success: success}, nil)
+		runContext.EXPECT().Call(tosca.Call, tosca.CallParameters{Recipient: one.Bytes20(), CodeAddress: one.Bytes20()}).Return(tosca.CallResult{Success: success}, nil)
 		ctxt := getEmptyContext()
 		ctxt.context = runContext
 		ctxt.stack = fillStack(zero, one, zero, zero, zero, zero, zero)

--- a/go/interpreter/lfvm/instructions_test.go
+++ b/go/interpreter/lfvm/instructions_test.go
@@ -744,7 +744,7 @@ func TestCall_ChargesNothingForColdAccessBeforeBerlin(t *testing.T) {
 	one := *uint256.NewInt(1)
 	ctrl := gomock.NewController(t)
 	runContext := tosca.NewMockRunContext(ctrl)
-	runContext.EXPECT().Call(tosca.Call, tosca.CallParameters{Recipient: one.Bytes20(), CodeAddress: one.Bytes20()}).Return(tosca.CallResult{}, nil)
+	runContext.EXPECT().Call(tosca.Call, gomock.Any()).Return(tosca.CallResult{}, nil)
 	ctxt := context{
 		params: tosca.Parameters{
 			BlockParameters: tosca.BlockParameters{
@@ -776,7 +776,7 @@ func TestCall_ChargesForAccessAfterBerlin(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		runContext := tosca.NewMockRunContext(ctrl)
 		runContext.EXPECT().AccessAccount(one.Bytes20()).Return(accessStatus)
-		runContext.EXPECT().Call(tosca.Call, tosca.CallParameters{Recipient: one.Bytes20(), CodeAddress: one.Bytes20()}).Return(tosca.CallResult{}, nil)
+		runContext.EXPECT().Call(tosca.Call, gomock.Any()).Return(tosca.CallResult{}, nil)
 		delta := tosca.Gas(1)
 		ctxt := context{
 			params: tosca.Parameters{
@@ -1531,7 +1531,7 @@ func TestGenericCall_CallKindPropagatesStaticMode(t *testing.T) {
 	zero := *uint256.NewInt(0)
 	one := *uint256.NewInt(1)
 	runContext := tosca.NewMockRunContext(gomock.NewController(t))
-	runContext.EXPECT().Call(tosca.StaticCall, tosca.CallParameters{Recipient: one.Bytes20(), CodeAddress: one.Bytes20()}).Return(tosca.CallResult{}, nil)
+	runContext.EXPECT().Call(tosca.StaticCall, gomock.Any()).Return(tosca.CallResult{}, nil)
 	ctxt := getEmptyContext()
 	ctxt.context = runContext
 	ctxt.params.Static = true
@@ -1548,7 +1548,7 @@ func TestGenericCall_ResultIsWrittenToStack(t *testing.T) {
 	one := *uint256.NewInt(1)
 	for _, success := range []bool{true, false} {
 		runContext := tosca.NewMockRunContext(gomock.NewController(t))
-		runContext.EXPECT().Call(tosca.Call, tosca.CallParameters{Recipient: one.Bytes20(), CodeAddress: one.Bytes20()}).Return(tosca.CallResult{Success: success}, nil)
+		runContext.EXPECT().Call(tosca.Call, gomock.Any()).Return(tosca.CallResult{Success: success}, nil)
 		ctxt := getEmptyContext()
 		ctxt.context = runContext
 		ctxt.stack = fillStack(zero, one, zero, zero, zero, zero, zero)
@@ -1588,7 +1588,65 @@ func TestGenericCall_HandlesBigProvidedGasValues(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestGenericCall_ForwardsCallParamsDependingOnCallKind(t *testing.T) {
+
+	zero := *uint256.NewInt(0)
+	sender := tosca.Address{1}
+	recipient := tosca.Address{2}
+	value := tosca.Value{3}
+	targetAddress := tosca.Address{4}
+	targetAddressU256 := *new(uint256.Int).SetBytes20(targetAddress[:])
+
+	tests := map[tosca.CallKind]struct {
+		sender, recipient tosca.Address
+		value             tosca.Value
+	}{
+		tosca.Call: {
+			sender:    recipient,
+			recipient: targetAddress,
+		},
+		tosca.StaticCall: {
+			sender:    recipient,
+			recipient: targetAddress,
+		},
+		tosca.DelegateCall: {
+			sender:    sender,
+			recipient: recipient,
+			value:     value,
+		},
+		tosca.CallCode: {
+			sender:    recipient,
+			recipient: recipient,
+		},
+	}
+
+	for kind, test := range tests {
+		t.Run(kind.String(), func(t *testing.T) {
+
+			runContext := tosca.NewMockRunContext(gomock.NewController(t))
+			wantParams := tosca.CallParameters{
+				Sender:      test.sender,
+				Recipient:   test.recipient,
+				Value:       test.value,
+				CodeAddress: targetAddress,
+			}
+			runContext.EXPECT().Call(kind, wantParams).Return(tosca.CallResult{}, nil)
+			ctxt := getEmptyContext()
+			ctxt.context = runContext
+			ctxt.params.Sender = sender
+			ctxt.params.Recipient = recipient
+			ctxt.params.Value = value
+
+			ctxt.stack = fillStack(zero, targetAddressU256, zero, zero, zero, zero, zero)
+
+			err := genericCall(&ctxt, kind)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
 }
 
 func TestInstructions_ComparisonAndShiftOperations(t *testing.T) {

--- a/go/tosca/interpreter.go
+++ b/go/tosca/interpreter.go
@@ -167,8 +167,8 @@ type CallParameters struct {
 	Value       Value   // < ignored by static calls, considered to be 0
 	Input       Data
 	Gas         Gas
-	Salt        Hash    // < only relevant for CREATE2 calls
-	CodeAddress Address // < only relevant for DELEGATECALL and CALLCODE calls
+	Salt        Hash // < only relevant for CREATE2 calls
+	CodeAddress Address
 }
 
 type CallResult struct {


### PR DESCRIPTION
Thanks to the Ethereum json tests we found that all call kinds are expected to forward `CodeAddress`, We did not interpret this in CT nor the LFVM, so they are both fixed to reflect this new understanding. 
- To reflect this in the CT representation of the state, `CodeAddress` is added to `PastCalls` of the `CallJournal`.
- For the specification, in the `callEffect` used for the different call kinds, `CodeAddress` is initialized to the second parameter for all call kinds. 
- For geth, in `createGethInterpreterContext` there is yet no concept of the stack value, so it has to be modified forwarded in `geth/ct.go` where each call forwards the corresponding parameters into the corresponding call. 
- A test is added in LFVM to ensure correct call parameter usage depending on call kind.