### PR TITLE
Fix go version settings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,9 @@
 
 module github.com/Fantom-foundation/Tosca
 
-go 1.22
+go 1.22.0
+
+toolchain go1.22.4
 
 require (
 	github.com/dsnet/golib/unitconv v1.0.2


### PR DESCRIPTION
This PR aligns the go version and toolchain configuration to those of other projects.

It also fixes a problem on some system where go version `1.22` is not a valid version specifier and something like `1.22.0` is required.