### PR TITLE
Geth adapter: Revision depending on geth rules

### DIFF
--- a/go/geth_adapter/adapter.go
+++ b/go/geth_adapter/adapter.go
@@ -88,7 +88,7 @@ func (a *gethInterpreterAdapter) Run(contract *geth.Contract, input []byte, read
 	rules := a.evm.ChainConfig().Rules(a.evm.Context.BlockNumber, a.evm.Context.Random != nil, a.evm.Context.Time)
 	revision, err := convertRevision(rules)
 	if err != nil {
-		return nil, fmt.Errorf("unsupported revision: %v", err)
+		return nil, fmt.Errorf("unsupported revision: %w", err)
 	}
 	if adapterDebug {
 		fmt.Printf("Running revision %v\n", revision)

--- a/go/geth_adapter/adapter_test.go
+++ b/go/geth_adapter/adapter_test.go
@@ -638,8 +638,9 @@ func TestRunContextAdapter_ConvertRevisionReturnsUnsupportedRevisionError(t *tes
 		IsHomestead: true,
 	}
 	_, err := convertRevision(rules)
-	if err == nil {
-		t.Errorf("Expected error, got nil")
+	targetError := &tosca.ErrUnsupportedRevision{}
+	if !errors.As(err, &targetError) {
+		t.Errorf("Expected unsupported revision error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
The ethereum substate started to fail starting with the first Paris revision block. This was caused by the MergeNetSplitBlock not being set. In order to not run into this problem in the future, the revision selection inside the geth adapter is now leveraged to the geth's ChainConfig rules. 

Check compatibility
- [x] Unit tests
- [x] Ethereum tests
- [ ] Ethereum substate