### PR TITLE
evmrs: make clean build when benchmarking

### DIFF
--- a/go/integration_test/interpreter/vm_test.go
+++ b/go/integration_test/interpreter/vm_test.go
@@ -118,7 +118,10 @@ func BenchmarkEmpty(b *testing.B) {
 }
 
 func BenchmarkStaticOverhead(b *testing.B) {
-	benchmark(b, examples.GetStaticOverheadExample(), 1)
+	// this is just to the benchmark name consists of 3 parts and can be matched by regex
+	b.Run("1", func(b *testing.B) {
+		benchmark(b, examples.GetStaticOverheadExample(), 1)
+	})
 }
 
 func BenchmarkInc(b *testing.B) {

--- a/rust/BUILD.md
+++ b/rust/BUILD.md
@@ -47,7 +47,7 @@ cargo doc --workspace --document-private-items --open
     go run ./go/ct/driver run --full-mode evmrs
     ```
 
-Also see [test.sh](./scripts/test.sh) which runs the Go tests and CT in full mode.
+Also see [run_ct.sh](./scripts/run_ct.sh) which runs the Go tests and CT.
 
 ## Coverage
 
@@ -76,7 +76,7 @@ cargo build --features mimalloc,stack-array
 1. Identify a possible optimization opportunity by
     - running the Go VM benchmarks and comparing them, in cases where `evmrs` is slower than the other interpreters
         ```sh
-        ./scripts/bench.sh performance
+        cargo run --package bencher
         ```
     - running a profiler of you choice and identifying a bottleneck
 1. Add a feature in [Cargo.toml](Cargo.toml)
@@ -88,7 +88,7 @@ cargo build --features mimalloc,stack-array
    This will run the Rust benchmarks and generate flamegraphs for all currently implemented features and for all currently implemented features and the new feature
 1. Run Go VM Benchmarks 
     ```sh
-    ./scripts/bench.sh performance performance,my-new-feature
+    cargo run --package bencher -- --evmrs-only performance,my-new-feature
     ```
 1. If all benchmarks indicate that the performance with the optimization is better that before, add the feature name to the features enabled by the `performance` feature in [Cargo.toml](Cargo.toml).
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,6 +27,7 @@ performance = [
     "jumptable",
     "hash-cache",
     "code-analysis-cache",
+    "jumptable-tail-call",
 ]
 mimalloc = ["dep:mimalloc"]
 stack-array = []

--- a/rust/bencher/src/main.rs
+++ b/rust/bencher/src/main.rs
@@ -145,6 +145,8 @@ fn make_build() -> Result<(), Box<dyn Error>> {
 }
 
 fn cargo_build(features: &str) -> Result<(), Box<dyn Error>> {
+    let output = Command::new("cargo").arg("clean").output()?;
+    check_success("cargo clean", &output)?;
     let output = Command::new("cargo")
         .args(["build", "--lib", "--release", "--features", features])
         .output()?;

--- a/rust/scripts/bench.sh
+++ b/rust/scripts/bench.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-cargo run --package bencher -- $@

--- a/rust/scripts/run_ct.sh
+++ b/rust/scripts/run_ct.sh
@@ -18,14 +18,20 @@ export RUST_BACKTRACE=full
 
 make -C .. 
 
+cargo clean
+go clean --cache
 cargo build --lib --release --no-default-features
 go test ../go/... | tee $OUTPUT_DIR/go-test-no-default
 go run ../go/ct/driver run evmrs | tee $OUTPUT_DIR/ct-full-no-default
 
+cargo clean
+go clean --cache
 cargo build --lib --release --features performance
 go test ../go/... | tee $OUTPUT_DIR/go-test-performance
 go run ../go/ct/driver run evmrs | tee $OUTPUT_DIR/ct-full-performance
 
-cargo build --lib --release --all-features
+cargo clean
+go clean --cache
+RUSTFLAGS="-C instrument-coverage" cargo build --lib --release --all-features
 go test ../go/... | tee $OUTPUT_DIR/go-test-all-features
 go run ../go/ct/driver run evmrs | tee $OUTPUT_DIR/ct-full-all-features


### PR DESCRIPTION
- make a clean build when benchmarking
- remove bench.sh
- clean go cache before running tests
- build with coverage when --all-features is set (otherwise linking fails)
- add jumptable-tail-call to performance feature
- update BUILD.md
- call b.Run in BenchmarkStaticOverhead to make regex matching possible (the run input is split along / with each split-string treated as a regex)