### PR TITLE
Fuzzing VMs: Limit memory usage

### DIFF
--- a/go/ct/evm_fuzz_test.go
+++ b/go/ct/evm_fuzz_test.go
@@ -138,9 +138,9 @@ func fuzzVm(testee ct.Evm, f *testing.F) {
 }
 
 const (
-	fuzzIdealStackSize     int = 7             // < max pops in a single instruction
-	fuzzMaximumCodeSegment int = 33            // < 1 instruction with 32 data bytes
-	fuzzMaxGas             int = 5_000_000_000 // < gas limits memory usage
+	fuzzIdealStackSize     = 7             // < max pops in a single instruction
+	fuzzMaximumCodeSegment = 33            // < 1 instruction with 32 data bytes
+	fuzzMaxGas             = 5_000_000_000 // < gas limits memory usage
 )
 
 // prepareFuzzingSeeds is a helper function to be used by similar fuzzing tests
@@ -159,7 +159,7 @@ func prepareFuzzingSeeds(f *testing.F) {
 			// the fuzzer will generate more interesting values around these, the initial
 			// list just sketches a region of interest around which the fuzzer will generate
 			// more values. I found no measurable difference about being more accurate.
-			for _, gas := range []int64{0, 1, 6, 10, 1000, int64(fuzzMaxGas)} {
+			for _, gas := range []int64{0, 1, 6, 10, 1000, fuzzMaxGas} {
 
 				// generate a code segment with the operation followed by 6 random values
 				ops := make([]byte, fuzzMaximumCodeSegment)
@@ -216,7 +216,7 @@ func corpusEntryToCtState(opCodes []byte, gas int64, revision byte, stackBytes [
 		return nil, fmt.Errorf("negative gas %v", gas)
 	}
 
-	if gas > int64(fuzzMaxGas) {
+	if gas > fuzzMaxGas {
 		return nil, fmt.Errorf("gas too large %v", gas)
 	}
 

--- a/go/ct/evm_fuzz_test.go
+++ b/go/ct/evm_fuzz_test.go
@@ -138,8 +138,9 @@ func fuzzVm(testee ct.Evm, f *testing.F) {
 }
 
 const (
-	fuzzIdealStackSize     int = 7  // < max pops in a single instruction
-	fuzzMaximumCodeSegment int = 33 // < 1 instruction with 32 data bytes
+	fuzzIdealStackSize     int = 7             // < max pops in a single instruction
+	fuzzMaximumCodeSegment int = 33            // < 1 instruction with 32 data bytes
+	fuzzMaxGas             int = 5_000_000_000 // < gas limits memory usage
 )
 
 // prepareFuzzingSeeds is a helper function to be used by similar fuzzing tests
@@ -158,7 +159,7 @@ func prepareFuzzingSeeds(f *testing.F) {
 			// the fuzzer will generate more interesting values around these, the initial
 			// list just sketches a region of interest around which the fuzzer will generate
 			// more values. I found no measurable difference about being more accurate.
-			for _, gas := range []int64{0, 1, 6, 10, 1000, st.MaxGasUsedByCt} {
+			for _, gas := range []int64{0, 1, 6, 10, 1000, int64(fuzzMaxGas)} {
 
 				// generate a code segment with the operation followed by 6 random values
 				ops := make([]byte, fuzzMaximumCodeSegment)
@@ -215,7 +216,7 @@ func corpusEntryToCtState(opCodes []byte, gas int64, revision byte, stackBytes [
 		return nil, fmt.Errorf("negative gas %v", gas)
 	}
 
-	if gas > st.MaxGasUsedByCt {
+	if gas > int64(fuzzMaxGas) {
 		return nil, fmt.Errorf("gas too large %v", gas)
 	}
 
@@ -391,7 +392,6 @@ func TestCorpusEntryToCtState(t *testing.T) {
 			if state.Stack.Size() != stateStackSize {
 				t.Errorf("Unexpected stack size. Got: %v, Want: %v", state.Stack.Size(), stateStackSize)
 			}
-
 		})
 	}
 }

--- a/go/ct/st/state.go
+++ b/go/ct/st/state.go
@@ -35,7 +35,7 @@ import (
 // This, in turn, would allow operations with overflowing memory requirements
 // to trigger memory expansions for low gas costs that would exceed real
 // world memory capacities.
-// Such overflows happen whenever more than MaxMemoryExapnsionSize
+// Such overflows happen whenever more than MaxMemoryExpansionSize
 // words of memory are to be allocated. To be able to detect those in the CT,
 // there must be sufficient Gas provided to cover the 3*W term in the gas cost
 // equation, assuming that the W^2/512 will overflow to a near zero value.


### PR DESCRIPTION
This PR adds a limit to the memory expansions generated by fuzzing tests. Nightly fuzzing has crashed a few times and the problem is attributed to large memory allocations. 

The CT has a [limit](https://github.com/Fantom-foundation/Tosca/blob/7b33705a4675b39f52859e2aadcbb9b69d3e9805/go/ct/st/state.go#L44) to the available gas for the execution of an instruction, large enough for a 450MB allocation. This limit may be too high for `FuzzDifferentialLfvmVsGeth`. During fuzzing, two resulting states are created by executing both geth and lfvm. This doubles the memory expansion.

The offending corpus: 
```
go test fuzz v1
[]byte("\xa0") 
int64(499_999_999_947)   
byte('\x04')
[]byte("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1e\x00\xe90\x00")
```
Arguments are:
-  op: LOG0
- gas: almost maximum allowed
- revision
- stack values: Last value is parameter size: 503_376_128 (480 MB)

The new code will not allow this execution by limiting gas to a 1/10 of the current limit. 