### PR TITLE
evmrs: make feature tail-call available for all dispatch methods

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,7 +27,7 @@ performance = [
     "jumptable",
     "hash-cache",
     "code-analysis-cache",
-    "jumptable-tail-call",
+    "tail-call",
 ]
 mimalloc = ["dep:mimalloc"]
 stack-array = []
@@ -36,7 +36,7 @@ jumptable = []
 hash-cache = ["dep:lru"]
 code-analysis-cache = ["dep:lru", "dep:nohash-hasher"]
 thread-local-cache = []
-jumptable-tail-call = ["jumptable"]
+tail-call = []
 
 [dependencies]
 bnum = "0.12.0"

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -12,7 +12,7 @@ jumptable = ["evmrs/jumptable"]
 hash-cache = ["evmrs/hash-cache"]
 code-analysis-cache = ["evmrs/code-analysis-cache"]
 thread-local-cache = ["evmrs/thread-local-cache"]
-jumptable-tail-call = ["evmrs/jumptable-tail-call"]
+tail-call = ["evmrs/tail-call"]
 
 [dependencies]
 evmrs = { path = ".." }

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -353,7 +353,7 @@ impl<'a> Interpreter<'a> {
         }
     }
 
-    #[cfg(not(feature = "jumptable-tail-call"))]
+    #[cfg(not(feature = "tail-call"))]
     pub fn run(&mut self) -> Result<(), FailStatus> {
         loop {
             if self.exec_status != ExecStatus::Running {
@@ -380,7 +380,7 @@ impl<'a> Interpreter<'a> {
 
         Ok(())
     }
-    #[cfg(feature = "jumptable-tail-call")]
+    #[cfg(feature = "tail-call")]
     #[inline(always)]
     pub fn run(&mut self) -> Result<(), FailStatus> {
         match &mut self.steps {
@@ -405,7 +405,6 @@ impl<'a> Interpreter<'a> {
     fn run_op(&mut self, op: Opcode) -> OpResult {
         Self::JUMPTABLE[op as u8 as usize](self)
     }
-
     #[cfg(not(feature = "jumptable"))]
     fn run_op(&mut self, op: Opcode) -> OpResult {
         match op {
@@ -563,9 +562,9 @@ impl<'a> Interpreter<'a> {
 
     #[allow(clippy::unused_self)]
     fn return_from_op(&mut self) -> OpResult {
-        #[cfg(not(feature = "jumptable-tail-call"))]
+        #[cfg(not(feature = "tail-call"))]
         return Ok(());
-        #[cfg(feature = "jumptable-tail-call")]
+        #[cfg(feature = "tail-call")]
         return self.run();
     }
 


### PR DESCRIPTION
- rename feature jumptable-tail-call -> tail-call
- do not enable feature jumptable when feature tail-call is enabled

This makes it possible to use the tail-call feature also for switch dispatch (and the upcoming feature opcode-fn-ptr-conversion)