### PR TITLE
Add interpreter stress tests

### DIFF
--- a/go/integration_test/interpreter/stress_test.go
+++ b/go/integration_test/interpreter/stress_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2024 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package interpreter_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Fantom-foundation/Tosca/go/interpreter/lfvm"
+	"github.com/Fantom-foundation/Tosca/go/tosca"
+	"github.com/Fantom-foundation/Tosca/go/tosca/vm"
+	"golang.org/x/sync/errgroup"
+)
+
+func BenchmarkParallelStressTests(b *testing.B) {
+	codes := map[string][]byte{
+		"smallTransaction": getStressBenchmark_SmallTransaction(),
+		"largeCodes":       getStressBenchmark_LargeCodes(),
+		"stressHashCache":  getStressBenchmark_StressHashCache(),
+		"noCodeReUsage":    getStressBenchmark_NoCodeReUsage(),
+	}
+
+	for _, interpreterName := range getAllInterpreterVariantsForTests() {
+		interpreter, err := tosca.NewInterpreter(interpreterName)
+		if err != nil {
+			b.Fatalf("failed to load %s with error: %v", interpreterName, err)
+		}
+		for _, numCalls := range []int{1, 10, 100, 1000, 10000} {
+			for codeName, code := range codes {
+				b.Run(fmt.Sprintf("%s-%s-numCalls=%d", interpreterName, codeName, numCalls), func(b *testing.B) {
+					hash := lfvm.Keccak256(code)
+					errs, _ := errgroup.WithContext(context.Background())
+					errs.SetLimit(-1) // set limit of max goroutines to unlimited
+
+					start := time.Now()
+					for i := 0; i < numCalls; i++ {
+						errs.Go(func() error {
+
+							if codeName == "noCodeReUsage" {
+								// code has to be different for each call
+								code = append(code, byte(vm.PUSH4))
+								code = append(code, uint32ToBytes(uint32(i))...)
+								code = append(code, byte(vm.STOP)) // stop
+								hash = lfvm.Keccak256(code)
+							}
+
+							params := tosca.Parameters{
+								Gas:      100000,
+								Input:    uint32ToBytes(uint32(i)),
+								CodeHash: &hash,
+								Code:     code,
+							}
+
+							result, err := interpreter.Run(params)
+							if err != nil || !result.Success {
+								return fmt.Errorf("interpreter run failed or was not successful, err: %v", err)
+							}
+							return nil
+						})
+					}
+					err = errs.Wait()
+					elapsed := time.Since(start)
+					if err != nil {
+						b.Fatalf("failed to run interpreter: %v", err)
+					}
+					b.Logf("Number calls %v, elapsed time: %v", numCalls, elapsed)
+				})
+			}
+		}
+	}
+}
+
+func getStressBenchmark_NoCodeReUsage() []byte {
+	code := make([]byte, 6*3*1000)
+	for i := 0; i < 6*3*1000; i += 6 {
+		code[i] = byte(vm.PUSH1)
+		code[i+1] = byte(i)
+		code[i+2] = byte(vm.PUSH1)
+		code[i+3] = byte(i)
+		code[i+4] = byte(vm.ADD)
+		code[i+5] = byte(vm.POP)
+	}
+	code = append(code, []byte{byte(vm.PUSH1), byte(0)}...)
+	return code
+}
+
+func getStressBenchmark_SmallTransaction() []byte {
+	code := []byte{
+		byte(vm.PUSH1), byte(21), // push 21
+		byte(vm.PUSH1), byte(21), // push 21
+		byte(vm.ADD),  // add
+		byte(vm.STOP), // stop
+	}
+	return code
+}
+
+func getStressBenchmark_LargeCodes() []byte {
+	code := []byte{
+		byte(vm.PUSH1), byte(0), // counter = 0
+		byte(vm.JUMPDEST),       // loop start
+		byte(vm.PUSH1), byte(1), // push 1
+		byte(vm.ADD),              // increment counter
+		byte(vm.DUP1),             // duplicate counter
+		byte(vm.PUSH1), byte(255), // push 255
+		byte(vm.GT),             // check if counter > 255
+		byte(vm.PUSH1), byte(2), // loop start
+		byte(vm.JUMPI), // loop until counter = 255
+		byte(vm.STOP),  // stop
+	}
+	return code
+}
+
+func getStressBenchmark_StressHashCache() []byte {
+	code := []byte{
+		byte(vm.PUSH1), byte(0), // call data offset
+		byte(vm.CALLDATALOAD),     // load index from calldata
+		byte(vm.PUSH1), byte(100), // push 100
+		byte(vm.MUL),              // multiply index by 100
+		byte(vm.DUP1),             // duplicate index (start)
+		byte(vm.PUSH1), byte(100), // push 100
+		byte(vm.ADD),   // add 100 to index (upper bound)
+		byte(vm.SWAP1), // swap start and end
+
+		byte(vm.JUMPDEST),       // loop start
+		byte(vm.PUSH1), byte(1), // push 1
+		byte(vm.ADD), // increment counter
+
+		byte(vm.DUP1),           // duplicate counter
+		byte(vm.PUSH1), byte(0), // offset in memory
+		byte(vm.MSTORE),          // store counter in memory
+		byte(vm.PUSH1), byte(32), // length of hash
+		byte(vm.PUSH1), byte(0), // offset in memory
+		byte(vm.SHA3), // hash counter
+		byte(vm.POP),  // pop hash
+
+		byte(vm.DUP1),            // duplicate counter
+		byte(vm.DUP3),            // duplicate upper bound
+		byte(vm.GT),              // check if counter > upper bound
+		byte(vm.PUSH1), byte(11), // loop start
+		byte(vm.JUMPI), // loop until counter = index*100 + 100
+		byte(vm.STOP),  // stop
+	}
+	return code
+}
+
+func uint32ToBytes(i uint32) []byte {
+	bytes := make([]byte, 4)
+	bytes[0] = byte(i)
+	bytes[1] = byte(i >> 8)
+	bytes[2] = byte(i >> 16)
+	bytes[3] = byte(i >> 24)
+	return bytes
+}


### PR DESCRIPTION
The lfvm is using multiple caches to improve performance. To ensure that these caches are not a bottleneck when a high number of concurrent calls are performed, stress tests are developed. 

Solves #694.