### PR TITLE
evmrs: test tail call elimination

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -118,6 +118,9 @@ jobs:
     - name: cargo test
       working-directory: rust
       run: cargo hack --workspace --each-feature test
+    - name: cargo test tail call elimination
+      working-directory: rust
+      run: cargo test --profile release --features tail-call
 
   deps:
     name: unused deps

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -1950,6 +1950,27 @@ mod tests {
         );
     }
 
+    #[cfg(not(debug_assertions))]
+    #[test]
+    // When feature tail-call is enabled, but the tail calls are not eliminated the stack will
+    // overflow if enough operations are executed. This test makes sure that does not happen.
+    // Because it will fail when compiled without optimizations, it is only enabled when
+    // debug_assertions are not enabled (the default in release mode).
+    fn tail_call_elimination() {
+        let mut context = MockExecutionContextTrait::new();
+        let message = MockExecutionMessage::default().into();
+        let mut interpreter = Interpreter::new(
+            Revision::EVMC_FRONTIER,
+            &message,
+            &mut context,
+            &[Opcode::JumpDest as u8; 10_000_000],
+        );
+        let result = interpreter.run();
+        println!("{result:?}");
+        assert!(result.is_ok());
+        assert_eq!(interpreter.exec_status, ExecStatus::Stopped);
+    }
+
     #[test]
     fn add_not_enough_gas() {
         let mut context = MockExecutionContextTrait::new();

--- a/rust/src/types/mock_execution_message.rs
+++ b/rust/src/types/mock_execution_message.rs
@@ -22,7 +22,7 @@ pub struct MockExecutionMessage<'a> {
 }
 
 impl<'a> MockExecutionMessage<'a> {
-    pub const DEFAULT_INIT_GAS: u64 = 1_000_000;
+    pub const DEFAULT_INIT_GAS: u64 = u64::MAX;
 
     pub fn to_evmc_message(&self) -> evmc_message {
         evmc_message {


### PR DESCRIPTION
This PR adds a test which makes sure tail calls are eliminated in release mode. This is necessary because otherwise, with sufficiently operations executed, the stack will overflow if feature tail-call is enabled.