### PR TITLE
evmrs: add feature "opcode-fn-ptr-conversion-inline"

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,8 +37,10 @@ hash-cache = ["dep:lru"]
 code-analysis-cache = ["dep:lru", "dep:nohash-hasher"]
 thread-local-cache = []
 tail-call = []
-# opcode-fn-ptr-conversion takes precedence over jumptable
+# opcode-fn-ptr-conversion takes precedence over jumptable, switch (default) and opcode-fn-ptr-conversion-inline
 opcode-fn-ptr-conversion = []
+# opcode-fn-ptr-conversion-inline takes precedence over jumptable and switch (default)
+opcode-fn-ptr-conversion-inline = []
 
 [dependencies]
 bnum = "0.12.0"

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -7,10 +7,16 @@ mod execution_context;
 pub mod hash_cache;
 mod memory;
 mod mock_execution_message;
-#[cfg(feature = "opcode-fn-ptr-conversion")]
+#[cfg(any(
+    feature = "opcode-fn-ptr-conversion",
+    feature = "opcode-fn-ptr-conversion-inline"
+))]
 mod op_fn_data;
 mod opcode;
-#[cfg(feature = "opcode-fn-ptr-conversion")]
+#[cfg(any(
+    feature = "opcode-fn-ptr-conversion",
+    feature = "opcode-fn-ptr-conversion-inline"
+))]
 mod pc_map;
 mod stack;
 mod status_code;
@@ -29,10 +35,16 @@ pub use code_reader::{CodeReader, GetOpcodeError};
 pub use execution_context::*;
 pub use memory::Memory;
 pub use mock_execution_message::MockExecutionMessage;
-#[cfg(feature = "opcode-fn-ptr-conversion")]
+#[cfg(any(
+    feature = "opcode-fn-ptr-conversion",
+    feature = "opcode-fn-ptr-conversion-inline"
+))]
 pub use op_fn_data::OpFnData;
 pub use opcode::*;
-#[cfg(feature = "opcode-fn-ptr-conversion")]
+#[cfg(any(
+    feature = "opcode-fn-ptr-conversion",
+    feature = "opcode-fn-ptr-conversion-inline"
+))]
 pub use pc_map::PcMap;
 pub use stack::Stack;
 pub use status_code::{ExecStatus, FailStatus};

--- a/rust/src/types/op_fn_data.rs
+++ b/rust/src/types/op_fn_data.rs
@@ -1,17 +1,130 @@
 use std::fmt::Debug;
 
+#[cfg(feature = "opcode-fn-ptr-conversion")]
+use crate::u256;
 use crate::{
     interpreter::{Interpreter, OpFn},
     types::CodeByteType,
-    u256,
 };
 
+#[cfg(all(
+    not(feature = "opcode-fn-ptr-conversion"),
+    feature = "opcode-fn-ptr-conversion-inline"
+))]
+pub const OP_FN_DATA_SIZE: usize = 4;
+
+#[cfg(all(
+    not(feature = "opcode-fn-ptr-conversion"),
+    feature = "opcode-fn-ptr-conversion-inline"
+))]
+#[derive(Debug, PartialEq, Eq)]
+#[repr(u8)]
+enum OpFnDataType {
+    Opcode = 0,
+    JumpDest = 1,
+    DataOrInvalid = 2,
+}
+
+#[cfg(all(
+    not(feature = "opcode-fn-ptr-conversion"),
+    feature = "opcode-fn-ptr-conversion-inline"
+))]
+#[derive(Clone, PartialEq, Eq)]
+#[repr(align(8))]
+pub struct OpFnData {
+    raw: [u8; 8],
+}
+
+#[cfg(all(
+    not(feature = "opcode-fn-ptr-conversion"),
+    feature = "opcode-fn-ptr-conversion-inline"
+))]
+impl OpFnData {
+    pub fn data(data: [u8; OP_FN_DATA_SIZE]) -> Self {
+        // assumes native endian = little endian
+        let mut raw = [0; 8];
+        raw[..OP_FN_DATA_SIZE].copy_from_slice(&data);
+        raw[7] = OpFnDataType::DataOrInvalid as u8;
+
+        OpFnData { raw }
+    }
+
+    pub fn skip_no_ops_iter(count: usize) -> impl Iterator<Item = Self> {
+        std::iter::once(OpFnData {
+            raw: (Interpreter::SKIP_NO_OPS_FN as usize).to_ne_bytes(),
+        })
+        .chain(Some(OpFnData::data((count as u32).to_ne_bytes())))
+        .chain(
+            std::iter::repeat_with(move || OpFnData {
+                raw: (Interpreter::NO_OP_FN as usize).to_ne_bytes(),
+            })
+            .take(count - 2),
+        )
+    }
+
+    pub fn func(op: u8) -> Self {
+        let ptr_value = Interpreter::JUMPTABLE[op as usize] as usize;
+        OpFnData {
+            raw: ptr_value.to_ne_bytes(),
+        }
+    }
+
+    pub fn jump_dest() -> Self {
+        let mut ptr_value = Interpreter::JUMP_DEST_FN as usize;
+        ptr_value |= 0x0100000000000000; // OpFnDataType::JumpDest
+        OpFnData {
+            raw: ptr_value.to_ne_bytes(),
+        }
+    }
+
+    pub fn code_byte_type(&self) -> CodeByteType {
+        match self.raw[7] {
+            t if t == OpFnDataType::Opcode as u8 => CodeByteType::Opcode,
+            t if t == OpFnDataType::JumpDest as u8 => CodeByteType::JumpDest,
+            _ => CodeByteType::DataOrInvalid,
+        }
+    }
+
+    pub fn get_func(&self) -> Option<OpFn> {
+        if self.raw[7] == OpFnDataType::DataOrInvalid as u8 {
+            None
+        } else {
+            let mut ptr_value = u64::from_ne_bytes(self.raw) as usize;
+            ptr_value &= 0x0000ffffffffffff;
+            // SAFETY:
+            // During code analysis self.raw was created from a function pointer. The highest bit
+            // was used for marking it as such, but was masked out. As long as only the lower 6
+            // bytes are used for pointers, the value is the same as before the conversion.
+            Some(unsafe { std::mem::transmute::<usize, OpFn>(ptr_value) })
+        }
+    }
+
+    pub fn get_data(&self) -> [u8; OP_FN_DATA_SIZE] {
+        // SAFETY:
+        // A pointer to an 8 byte array can be safely cast to a pointer to an 4 byte and then read
+        // as such, because the alignment is the same and all reads are in bounds.
+        unsafe { std::ptr::read(self.raw.as_ptr() as *const [u8; OP_FN_DATA_SIZE]) }
+    }
+}
+
+#[cfg(all(
+    not(feature = "opcode-fn-ptr-conversion"),
+    feature = "opcode-fn-ptr-conversion-inline"
+))]
+impl Debug for OpFnData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpFnData").field("raw", &self.raw).finish()
+    }
+}
+
+#[cfg(feature = "opcode-fn-ptr-conversion")]
 #[derive(Clone, PartialEq, Eq)]
 pub struct OpFnData {
     func: Option<OpFn>,
     data: u256,
 }
 
+#[cfg(feature = "opcode-fn-ptr-conversion")]
 impl OpFnData {
     pub fn data(data: u256) -> Self {
         OpFnData { func: None, data }
@@ -62,6 +175,7 @@ impl OpFnData {
     }
 }
 
+#[cfg(feature = "opcode-fn-ptr-conversion")]
 impl Debug for OpFnData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OpFnData")

--- a/rust/src/types/opcode.rs
+++ b/rust/src/types/opcode.rs
@@ -178,9 +178,15 @@ pub enum Opcode {
     Shr = SHR,
     Sar = SAR,
     Sha3 = SHA3,
-    #[cfg(feature = "opcode-fn-ptr-conversion")]
+    #[cfg(any(
+        feature = "opcode-fn-ptr-conversion",
+        feature = "opcode-fn-ptr-conversion-inline"
+    ))]
     NoOp = SHA3 + 1,
-    #[cfg(feature = "opcode-fn-ptr-conversion")]
+    #[cfg(any(
+        feature = "opcode-fn-ptr-conversion",
+        feature = "opcode-fn-ptr-conversion-inline"
+    ))]
     SkipNoOps = SHA3 + 2,
     Address = ADDRESS,
     Balance = BALANCE,
@@ -309,7 +315,10 @@ pub enum Opcode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CodeByteType {
     JumpDest,
-    #[cfg(feature = "opcode-fn-ptr-conversion")]
+    #[cfg(any(
+        feature = "opcode-fn-ptr-conversion",
+        feature = "opcode-fn-ptr-conversion-inline"
+    ))]
     Push,
     Opcode,
     DataOrInvalid,
@@ -331,9 +340,15 @@ pub fn code_byte_type(code_byte: u8) -> (CodeByteType, usize) {
         | LOG4 | CREATE | CALL | CALLCODE | RETURN | DELEGATECALL | CREATE2 | STATICCALL
         | REVERT | INVALID | SELFDESTRUCT => (CodeByteType::Opcode, 0),
         PUSH1..=PUSH32 => (
-            #[cfg(not(feature = "opcode-fn-ptr-conversion"))]
+            #[cfg(all(
+                not(feature = "opcode-fn-ptr-conversion"),
+                not(feature = "opcode-fn-ptr-conversion-inline")
+            ))]
             CodeByteType::Opcode,
-            #[cfg(feature = "opcode-fn-ptr-conversion")]
+            #[cfg(any(
+                feature = "opcode-fn-ptr-conversion",
+                feature = "opcode-fn-ptr-conversion-inline"
+            ))]
             CodeByteType::Push,
             (code_byte - Opcode::Push1 as u8 + 1) as usize,
         ),


### PR DESCRIPTION
This PR adds the feature "opcode-fn-ptr-conversion-inline". This feature is similar to "opcode-fn-ptr-conversion" but instead of storing an optional function pointer and an u256 (40 bytes in total), it does the following:
- use [u8; 8] with alignment 8
- use the most significat byte to distinguish between jumpdest, normal opcodes and data
- in case of jumpdest and normal opcodes store the function pointer in the lower 6 bytes (linux pointers only need 6 bytes)
- in case of data use the lower 4 bytes to store up to 4 bytes of data

Most of the changes are just changes to the attributes because both features share a lot of code and some changes to tests because signatures and semantics change slightly.
The important changes are:
- code_analysis.rs: CodeAnalysis::analyze_code
- code_reader.rs: CodeReader::get_push_data and CodeReader::jump_to
- op_fn_data.rs: OpFnData

The performance is not as good as "opcode-fn-ptr-conversion".
CT passed.

PS. The feature guards are cleaned up in #930.