### PR TITLE
 evmrs: add partial features to simplify feature guards 

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -58,7 +58,7 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo clippy
       working-directory: rust
-      run: cargo hack --workspace --each-feature clippy --examples --tests --benches -- --deny warnings
+      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-fn-ptr-conversion,needs-jumptable clippy --examples --tests --benches -- --deny warnings
     
   doc:
     name: doc
@@ -79,7 +79,7 @@ jobs:
       env:
         RUSTDOCFLAGS: "-D warnings" 
       working-directory: rust
-      run: cargo hack --workspace --each-feature doc --no-deps
+      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-fn-ptr-conversion,needs-jumptable doc --no-deps
 
   build:
     name: build
@@ -98,7 +98,7 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo build
       working-directory: rust
-      run: cargo hack --workspace --each-feature build
+      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-fn-ptr-conversion,needs-jumptable build
 
   test:
     name: test
@@ -117,10 +117,10 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo test
       working-directory: rust
-      run: cargo hack --workspace --each-feature test
+      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-fn-ptr-conversion,needs-jumptable test
     - name: cargo test tail call elimination
       working-directory: rust
-      run: cargo test --profile release --features tail-call
+      run: cargo test --profile release --features  tail-call
 
   deps:
     name: unused deps

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,29 +18,33 @@ debug = true
 default = []
 # Flag mock enables code generation for test mocking. This allows generating mocks for other build configuration but "test". 
 mock = ["dep:mockall"]
+# partial features (enabled by other features to simplyfy conditional compilation attributes. Not intended to be used on their own)
+needs-jumptable = []
+needs-fn-ptr-conversion = ["needs-jumptable"]
+needs-cache = ["dep:lru"]
 # optimizations:
 performance = [
     "mimalloc",
     "stack-array",
     "custom-evmc",
-    "jumptable",
     "hash-cache",
     "code-analysis-cache",
     "tail-call",
-    "opcode-fn-ptr-conversion",
+    "jumptable-dispatch",
+    "fn-ptr-conversion-expanded-dispatch",
 ]
 mimalloc = ["dep:mimalloc"]
 stack-array = []
 custom-evmc = ["dep:evmc-vm-tosca-refactor"]
-jumptable = []
-hash-cache = ["dep:lru"]
-code-analysis-cache = ["dep:lru", "dep:nohash-hasher"]
+hash-cache = ["needs-cache"]
+code-analysis-cache = ["dep:nohash-hasher", "needs-cache"]
 thread-local-cache = []
 tail-call = []
-# opcode-fn-ptr-conversion takes precedence over jumptable, switch (default) and opcode-fn-ptr-conversion-inline
-opcode-fn-ptr-conversion = []
-# opcode-fn-ptr-conversion-inline takes precedence over jumptable and switch (default)
-opcode-fn-ptr-conversion-inline = []
+jumptable-dispatch = ["needs-jumptable"]
+# fn-ptr-conversion takes precedence over jumptable, switch (default) and fn-ptr-conversion-inline
+fn-ptr-conversion-expanded-dispatch = ["needs-fn-ptr-conversion"]
+# fn-ptr-conversion-inline takes precedence over jumptable and switch (default)
+fn-ptr-conversion-inline-dispatch = ["needs-fn-ptr-conversion"]
 
 [dependencies]
 bnum = "0.12.0"

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -8,12 +8,14 @@ performance = ["evmrs/performance"]
 mimalloc = ["evmrs/mimalloc"]
 stack-array = ["evmrs/stack-array"]
 custom-evmc = ["evmrs/custom-evmc"]
-jumptable = ["evmrs/jumptable"]
 hash-cache = ["evmrs/hash-cache"]
 code-analysis-cache = ["evmrs/code-analysis-cache"]
 thread-local-cache = ["evmrs/thread-local-cache"]
 tail-call = ["evmrs/tail-call"]
-opcode-fn-ptr-conversion = ["evmrs/opcode-fn-ptr-conversion"]
+jumptable-dispatch = ["evmrs/jumptable-dispatch"]
+fn-ptr-conversion-expanded-dispatch = [
+    "evmrs/fn-ptr-conversion-expanded-dispatch",
+]
 
 [dependencies]
 evmrs = { path = ".." }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,6 +5,37 @@ mod interpreter;
 mod types;
 mod utils;
 
+#[cfg(all(
+    feature = "needs-cache",
+    not(feature = "code-analysis-cache"),
+    not(feature = "hash-cache"),
+))]
+compile_error!(
+    "Feature `needs-cache` is only a helper feature and not supposed to be enabled on its own.
+    Either disable it or enable one or all of `code-analysis-cache` or `hash-cache`."
+);
+
+#[cfg(all(
+    feature = "needs-fn-ptr-conversion",
+    not(feature = "fn-ptr-conversion-expanded-dispatch"),
+    not(feature = "fn-ptr-conversion-inline-dispatch"),
+))]
+compile_error!(
+    "Feature `needs-fn-ptr-conversion` is only a helper feature and not supposed to be enabled on its own.
+    Either disable it or enable one or all of `fn-ptr-conversion-expanded-dispatch` or `fn-ptr-conversion-inline-dispatch`."
+);
+
+#[cfg(all(
+    feature = "needs-jumptable",
+    not(feature = "jumptable-dispatch"),
+    not(feature = "fn-ptr-conversion-expanded-dispatch"),
+    not(feature = "fn-ptr-conversion-inline-dispatch"),
+))]
+compile_error!(
+    "Feature `needs-jumptable` is only a helper feature and not supposed to be enabled on its own.
+    Either disable it or enable one or all of `jumptable-dispatch`, `fn-ptr-conversion-expanded-dispatch` or `fn-ptr-conversion-inline-dispatch`."
+);
+
 #[cfg(not(feature = "custom-evmc"))]
 pub extern crate evmc_vm_tosca as evmc_vm;
 #[cfg(feature = "custom-evmc")]

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -1,5 +1,5 @@
 mod amount;
-#[cfg(any(feature = "hash-cache", feature = "code-analysis-cache"))]
+#[cfg(feature = "needs-cache")]
 mod cache;
 mod code_analysis;
 mod code_reader;
@@ -7,44 +7,29 @@ mod execution_context;
 pub mod hash_cache;
 mod memory;
 mod mock_execution_message;
-#[cfg(any(
-    feature = "opcode-fn-ptr-conversion",
-    feature = "opcode-fn-ptr-conversion-inline"
-))]
+#[cfg(feature = "needs-fn-ptr-conversion")]
 mod op_fn_data;
 mod opcode;
-#[cfg(any(
-    feature = "opcode-fn-ptr-conversion",
-    feature = "opcode-fn-ptr-conversion-inline"
-))]
+#[cfg(feature = "needs-fn-ptr-conversion")]
 mod pc_map;
 mod stack;
 mod status_code;
 mod tx_context;
 
 pub use amount::u256;
-#[cfg(any(feature = "hash-cache", feature = "code-analysis-cache"))]
+#[cfg(feature = "needs-cache")]
 pub use cache::Cache;
-#[cfg(all(
-    feature = "thread-local-cache",
-    any(feature = "hash-cache", feature = "code-analysis-cache")
-))]
+#[cfg(all(feature = "thread-local-cache", feature = "needs-cache"))]
 pub use cache::LocalKeyExt;
 pub use code_analysis::{AnalysisContainer, CodeAnalysis};
 pub use code_reader::{CodeReader, GetOpcodeError};
 pub use execution_context::*;
 pub use memory::Memory;
 pub use mock_execution_message::MockExecutionMessage;
-#[cfg(any(
-    feature = "opcode-fn-ptr-conversion",
-    feature = "opcode-fn-ptr-conversion-inline"
-))]
+#[cfg(feature = "needs-fn-ptr-conversion")]
 pub use op_fn_data::OpFnData;
 pub use opcode::*;
-#[cfg(any(
-    feature = "opcode-fn-ptr-conversion",
-    feature = "opcode-fn-ptr-conversion-inline"
-))]
+#[cfg(feature = "needs-fn-ptr-conversion")]
 pub use pc_map::PcMap;
 pub use stack::Stack;
 pub use status_code::{ExecStatus, FailStatus};

--- a/rust/src/types/op_fn_data.rs
+++ b/rust/src/types/op_fn_data.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-#[cfg(feature = "opcode-fn-ptr-conversion")]
+#[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
 use crate::u256;
 use crate::{
     interpreter::{Interpreter, OpFn},
@@ -8,14 +8,14 @@ use crate::{
 };
 
 #[cfg(all(
-    not(feature = "opcode-fn-ptr-conversion"),
-    feature = "opcode-fn-ptr-conversion-inline"
+    not(feature = "fn-ptr-conversion-expanded-dispatch"),
+    feature = "fn-ptr-conversion-inline-dispatch"
 ))]
 pub const OP_FN_DATA_SIZE: usize = 4;
 
 #[cfg(all(
-    not(feature = "opcode-fn-ptr-conversion"),
-    feature = "opcode-fn-ptr-conversion-inline"
+    not(feature = "fn-ptr-conversion-expanded-dispatch"),
+    feature = "fn-ptr-conversion-inline-dispatch"
 ))]
 #[derive(Debug, PartialEq, Eq)]
 #[repr(u8)]
@@ -26,8 +26,8 @@ enum OpFnDataType {
 }
 
 #[cfg(all(
-    not(feature = "opcode-fn-ptr-conversion"),
-    feature = "opcode-fn-ptr-conversion-inline"
+    not(feature = "fn-ptr-conversion-expanded-dispatch"),
+    feature = "fn-ptr-conversion-inline-dispatch"
 ))]
 #[derive(Clone, PartialEq, Eq)]
 #[repr(align(8))]
@@ -36,8 +36,8 @@ pub struct OpFnData {
 }
 
 #[cfg(all(
-    not(feature = "opcode-fn-ptr-conversion"),
-    feature = "opcode-fn-ptr-conversion-inline"
+    not(feature = "fn-ptr-conversion-expanded-dispatch"),
+    feature = "fn-ptr-conversion-inline-dispatch"
 ))]
 impl OpFnData {
     pub fn data(data: [u8; OP_FN_DATA_SIZE]) -> Self {
@@ -108,8 +108,8 @@ impl OpFnData {
 }
 
 #[cfg(all(
-    not(feature = "opcode-fn-ptr-conversion"),
-    feature = "opcode-fn-ptr-conversion-inline"
+    not(feature = "fn-ptr-conversion-expanded-dispatch"),
+    feature = "fn-ptr-conversion-inline-dispatch"
 ))]
 impl Debug for OpFnData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -117,14 +117,14 @@ impl Debug for OpFnData {
     }
 }
 
-#[cfg(feature = "opcode-fn-ptr-conversion")]
+#[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
 #[derive(Clone, PartialEq, Eq)]
 pub struct OpFnData {
     func: Option<OpFn>,
     data: u256,
 }
 
-#[cfg(feature = "opcode-fn-ptr-conversion")]
+#[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
 impl OpFnData {
     pub fn data(data: u256) -> Self {
         OpFnData { func: None, data }
@@ -175,7 +175,7 @@ impl OpFnData {
     }
 }
 
-#[cfg(feature = "opcode-fn-ptr-conversion")]
+#[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
 impl Debug for OpFnData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OpFnData")

--- a/rust/src/types/opcode.rs
+++ b/rust/src/types/opcode.rs
@@ -178,15 +178,9 @@ pub enum Opcode {
     Shr = SHR,
     Sar = SAR,
     Sha3 = SHA3,
-    #[cfg(any(
-        feature = "opcode-fn-ptr-conversion",
-        feature = "opcode-fn-ptr-conversion-inline"
-    ))]
+    #[cfg(feature = "needs-fn-ptr-conversion")]
     NoOp = SHA3 + 1,
-    #[cfg(any(
-        feature = "opcode-fn-ptr-conversion",
-        feature = "opcode-fn-ptr-conversion-inline"
-    ))]
+    #[cfg(feature = "needs-fn-ptr-conversion")]
     SkipNoOps = SHA3 + 2,
     Address = ADDRESS,
     Balance = BALANCE,
@@ -315,10 +309,7 @@ pub enum Opcode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CodeByteType {
     JumpDest,
-    #[cfg(any(
-        feature = "opcode-fn-ptr-conversion",
-        feature = "opcode-fn-ptr-conversion-inline"
-    ))]
+    #[cfg(feature = "needs-fn-ptr-conversion")]
     Push,
     Opcode,
     DataOrInvalid,
@@ -340,15 +331,9 @@ pub fn code_byte_type(code_byte: u8) -> (CodeByteType, usize) {
         | LOG4 | CREATE | CALL | CALLCODE | RETURN | DELEGATECALL | CREATE2 | STATICCALL
         | REVERT | INVALID | SELFDESTRUCT => (CodeByteType::Opcode, 0),
         PUSH1..=PUSH32 => (
-            #[cfg(all(
-                not(feature = "opcode-fn-ptr-conversion"),
-                not(feature = "opcode-fn-ptr-conversion-inline")
-            ))]
+            #[cfg(not(feature = "needs-fn-ptr-conversion"))]
             CodeByteType::Opcode,
-            #[cfg(any(
-                feature = "opcode-fn-ptr-conversion",
-                feature = "opcode-fn-ptr-conversion-inline"
-            ))]
+            #[cfg(feature = "needs-fn-ptr-conversion")]
             CodeByteType::Push,
             (code_byte - Opcode::Push1 as u8 + 1) as usize,
         ),


### PR DESCRIPTION
This PR adds helper features to clean up the feature guards. Those features are not meant to be used on their own and will explicitly fail to compile with a message explaining which features to enable. In addition some features have been renamed.

Renamed features:
- jumptable -> jumptable-dispatch
- opcode-fn-ptr-conversion -> fn-ptr-conversion-expanded-dispatch
- opcode-fn-ptr-conversion-inline -> fn-ptr-conversion-inline-dispatch

Helper features:
- needs-cache
- needs-jumptable
- needs-fn-ptr-conversion