### PR TITLE
evmrs: pgo setup

### DIFF
--- a/go/integration_test/interpreter/vm_test.go
+++ b/go/integration_test/interpreter/vm_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/Fantom-foundation/Tosca/go/examples"
+	"github.com/Fantom-foundation/Tosca/go/lib/rust"
 	"github.com/Fantom-foundation/Tosca/go/tosca"
 	"go.uber.org/mock/gomock"
 	// Enable this import to see C/C++ symbols in CPU profile data.
@@ -118,6 +119,7 @@ func BenchmarkEmpty(b *testing.B) {
 }
 
 func BenchmarkStaticOverhead(b *testing.B) {
+	defer rust.DumpRustCoverageData("/tmp/pgo-data/static_overhead") // dump profiling data for pgo
 	// this is just to the benchmark name consists of 3 parts and can be matched by regex
 	b.Run("1", func(b *testing.B) {
 		benchmark(b, examples.GetStaticOverheadExample(), 1)
@@ -125,6 +127,7 @@ func BenchmarkStaticOverhead(b *testing.B) {
 }
 
 func BenchmarkInc(b *testing.B) {
+	defer rust.DumpRustCoverageData("/tmp/pgo-data/inc") // dump profiling data for pgo
 	args := []int{1, 10}
 	for _, i := range args {
 		b.Run(fmt.Sprintf("%d", i), func(b *testing.B) {
@@ -134,6 +137,7 @@ func BenchmarkInc(b *testing.B) {
 }
 
 func BenchmarkFib(b *testing.B) {
+	defer rust.DumpRustCoverageData("/tmp/pgo-data/fib") // dump profiling data for pgo
 	args := []int{1, 5, 10, 15, 20}
 	for _, i := range args {
 		b.Run(fmt.Sprintf("%d", i), func(b *testing.B) {
@@ -143,6 +147,7 @@ func BenchmarkFib(b *testing.B) {
 }
 
 func BenchmarkSha3(b *testing.B) {
+	defer rust.DumpRustCoverageData("/tmp/pgo-data/sha3") // dump profiling data for pgo
 	args := []int{1, 10, 100, 1000}
 	for _, i := range args {
 		b.Run(fmt.Sprintf("%d", i), func(b *testing.B) {
@@ -152,6 +157,7 @@ func BenchmarkSha3(b *testing.B) {
 }
 
 func BenchmarkArith(b *testing.B) {
+	defer rust.DumpRustCoverageData("/tmp/pgo-data/arith") // dump profiling data for pgo
 	args := []int{1, 10, 100, 280}
 	for _, i := range args {
 		b.Run(fmt.Sprintf("%d", i), func(b *testing.B) {
@@ -161,6 +167,7 @@ func BenchmarkArith(b *testing.B) {
 }
 
 func BenchmarkMemory(b *testing.B) {
+	defer rust.DumpRustCoverageData("/tmp/pgo-data/memory") // dump profiling data for pgo
 	args := []int{1, 10, 100, 1000, 10000}
 	for _, i := range args {
 		b.Run(fmt.Sprintf("%d", i), func(b *testing.B) {
@@ -170,6 +177,7 @@ func BenchmarkMemory(b *testing.B) {
 }
 
 func BenchmarkAnalysis(b *testing.B) {
+	defer rust.DumpRustCoverageData("/tmp/pgo-data/analysis") // dump profiling data for pgo
 	examples := []examples.Example{
 		examples.GetJumpdestAnalysisExample(),
 		examples.GetStopAnalysisExample(),

--- a/rust/scripts/pgo.sh
+++ b/rust/scripts/pgo.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# rustup component add llvm-tools-preview
+# apt install bolt-18
+# #cargo install cargo-pgo
+
+BENCH=1
+# segfault with tail-call
+FEATURES=mimalloc,stack-array,custom-evmc,jumptable,hash-cache,code-analysis-cache,opcode-fn-ptr-conversion
+RUNS=1
+RUST_LLVM_DIR=$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin
+
+DATE=$(date +'%Y-%m-%dT%H:%M')
+GIT_REF=$(git rev-parse --short=7 HEAD)
+OUTPUT_DIR=output/benches/$DATE#$GIT_REF#$RUNS#pgo
+mkdir -p $OUTPUT_DIR
+
+# benchmark without pgo
+if [ $BENCH -eq 1 ]; then
+    cargo clean
+    cargo build --release --features $FEATURES
+    taskset --cpu-list 0 \
+        go test ../go/integration_test/interpreter/... \
+        --run none --bench ^Benchmark[a-zA-Z]+/./evmrs \
+        --count $RUNS --timeout 1h \
+        | tee $OUTPUT_DIR/without-pgo
+fi
+
+# build & run pgo instrumented
+cargo clean
+RUSTFLAGS="-Cprofile-generate=/tmp/pgo-data" \
+    cargo build --release --features $FEATURES
+
+rm -rf /tmp/pgo-data
+
+go test ../go/integration_test/interpreter/... \
+    --run none --bench ^Benchmark[a-zA-Z]+/./evmrs \
+    --count $RUNS --timeout 1h
+
+$RUST_LLVM_DIR/llvm-profdata merge -o /tmp/pgo-data/merged.profdata /tmp/pgo-data
+
+# bench pgo optimized
+if [ $BENCH -eq 1 ]; then
+    RUSTFLAGS="-Cprofile-use=/tmp/pgo-data/merged.profdata -Cllvm-args=-pgo-warn-missing-function" \
+        cargo build --release --features $FEATURES
+    taskset --cpu-list 0 \
+        go test ../go/integration_test/interpreter/... \
+        --run none --bench ^Benchmark[a-zA-Z]+/./evmrs \
+        --count $RUNS --timeout 1h \
+        | tee $OUTPUT_DIR/with-pgo
+    cd $OUTPUT_DIR
+    benchstat without-pgo with-pgo | tee comparison
+    cd -
+fi
+
+# .cargo/config.toml
+#[target.x86_64-unknown-linux-gnu]
+#rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+
+## build & run pgo optimized bolt instrumented
+#RUSTFLAGS="-Cprofile-use=/tmp/pgo-data/merged.profdata -Cllvm-args=-pgo-warn-missing-function -C link-args=-Wl,-q" \
+    #cargo build --release --features $FEATURES
+
+#llvm-bolt-18 target/release/libevmrs.so -o target/release/libevmrs.so -instrument
+#merge-fdata-18 /tmp/*.fdata > merged.profdata
+
+##perf record -e cycles:u -j any,u -a -o perf.data -- \
+    ##go test ../go/integration_test/interpreter/... \
+    ##--run none --bench ^Benchmark[a-zA-Z]+/./evmrs \
+    ##--count $RUNS --timeout 1h
+##perf2bolt -p perf.data -o perf.fdata target/release/libevmrs.so
+
+#llvm-bolt-18 target/release/libevmrs.so -o target/release/libevmrs.so -data=perf.fdata -reorder-blocks=ext-tsp -reorder-functions=hfsort -split-functions -split-all-cold -split-eh -dyno-stats
+
+## bench optimized pgo + bolt
+#if [ $BENCH -eq 1 ]; then
+    #taskset --cpu-list 0 \
+        #go test ../go/integration_test/interpreter/... \
+        #--run none --bench ^Benchmark[a-zA-Z]+/./evmrs \
+        #--count $RUNS --timeout 1h \
+        #| tee with-pgo-bolt
+    #benchstat without-pgo with-pgo with-pgo-bolt
+#fi
+
+# with cargo-pgo (does not work)
+#cargo pgo instrument build -- --features $FEATURES
+#mkdir -p target/release
+#cp target/x86_64-unknown-linux-gnu/release/libevmrs.so target/release/
+#go test ../go/integration_test/interpreter/... --run none --bench ^Benchmark[a-zA-Z]+/./evmrs --count 1
+#$RUST_LLVM_DIR/llvm-profdata merge -o /tmp/pgo-data/merged.profdata /tmp/pgo-data
+#cargo pgo optimize build -- --features $FEATURES


### PR DESCRIPTION
This PR adds a bash script to create a pgo optimized version of evmrs. In order to to so the benchmarks have to dump instumentation data.
Unfortunately this does not work if feature tail-call is enabled because in segfaults, likely because the tail calls are no longer optimized away when instrumented and therefore trigger a stack overflow.

```
goos: linux
goarch: amd64
pkg: github.com/Fantom-foundation/Tosca/go/integration_test/interpreter
cpu: Intel(R) Xeon(R) CPU E5-2690 v2 @ 3.00GHz
                        │ without-pgo  │              with-pgo               │
                        │    sec/op    │   sec/op     vs base                │
StaticOverhead/1/evmrs     2.490µ ± 1%   2.401µ ± 0%   -3.57% (p=0.000 n=20)
Inc/1/evmrs                5.835µ ± 3%   5.668µ ± 1%   -2.87% (p=0.000 n=20)
Inc/10/evmrs               6.011µ ± 2%   5.677µ ± 1%   -5.56% (p=0.000 n=20)
Fib/1/evmrs                5.429µ ± 1%   5.135µ ± 0%   -5.42% (p=0.000 n=20)
Fib/5/evmrs                23.65µ ± 1%   22.66µ ± 0%   -4.17% (p=0.000 n=20)
Fib/10/evmrs               244.4µ ± 0%   239.6µ ± 0%   -1.95% (p=0.000 n=20)
Fib/15/evmrs               2.402m ± 0%   2.346m ± 0%   -2.31% (p=0.000 n=20)
Fib/20/evmrs               26.41m ± 0%   25.54m ± 0%   -3.29% (p=0.000 n=20)
Sha3/1/evmrs               3.010µ ± 0%   2.770µ ± 0%   -7.99% (p=0.000 n=20)
Sha3/10/evmrs              4.928µ ± 1%   4.328µ ± 0%  -12.17% (p=0.000 n=20)
Sha3/100/evmrs             22.73µ ± 0%   19.69µ ± 0%  -13.34% (p=0.000 n=20)
Sha3/1000/evmrs            222.1µ ± 0%   193.6µ ± 0%  -12.82% (p=0.000 n=20)
Arith/1/evmrs              6.946µ ± 1%   6.409µ ± 1%   -7.73% (p=0.000 n=20)
Arith/10/evmrs             15.70µ ± 0%   14.51µ ± 0%   -7.60% (p=0.000 n=20)
Arith/100/evmrs            111.6µ ± 0%   105.4µ ± 0%   -5.55% (p=0.000 n=20)
Arith/280/evmrs            300.4µ ± 0%   279.1µ ± 0%   -7.09% (p=0.000 n=20)
Memory/1/evmrs             9.464µ ± 1%   8.885µ ± 1%   -6.12% (p=0.000 n=20)
Memory/10/evmrs            19.57µ ± 0%   17.89µ ± 0%   -8.61% (p=0.000 n=20)
Memory/100/evmrs           130.9µ ± 0%   120.4µ ± 0%   -7.98% (p=0.000 n=20)
Memory/1000/evmrs         1086.0µ ± 0%   998.6µ ± 0%   -8.05% (p=0.000 n=20)
Memory/10000/evmrs        10.463m ± 0%   9.621m ± 0%   -8.05% (p=0.000 n=20)
Analysis/jumpdest/evmrs    2.460µ ± 1%   2.369µ ± 0%   -3.72% (p=0.000 n=20)
Analysis/stop/evmrs        2.471µ ± 0%   2.372µ ± 0%   -4.03% (p=0.000 n=20)
Analysis/push1/evmrs       2.468µ ± 1%   2.367µ ± 0%   -4.09% (p=0.000 n=20)
Analysis/push32/evmrs      2.463µ ± 0%   2.369µ ± 1%   -3.82% (p=0.000 n=20)
geomean                    35.27µ        33.02µ        -6.37%
```