### PR TITLE
evmrs: remove revisions older than Istanbul

### DIFF
--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -1344,8 +1344,8 @@ impl<'a> Interpreter<'a> {
         Ok(())
     }
 
+    #[allow(clippy::unused_self)]
     fn invalid(&mut self) -> OpResult {
-        check_min_revision(Revision::EVMC_HOMESTEAD, self.revision)?;
         Err(FailStatus::InvalidInstruction)
     }
 
@@ -1603,9 +1603,8 @@ impl<'a> Interpreter<'a> {
         let gas_left = self.gas_left.as_u64();
         let limit = gas_left - gas_left / 64;
         let mut endowment = gas.into_u64_saturating();
-        if self.revision >= Revision::EVMC_TANGERINE_WHISTLE {
-            endowment = min(endowment, limit); // cap gas at all but one 64th of gas left
-        }
+        endowment = min(endowment, limit); // cap gas at all but one 64th of gas left
+
         let stipend = if value == u256::ZERO { 0 } else { 2_300 };
         self.gas_left.add(stipend);
 
@@ -1701,9 +1700,7 @@ impl<'a> Interpreter<'a> {
         let gas_left = self.gas_left.as_u64();
         let limit = gas_left - gas_left / 64;
         let mut endowment = gas.into_u64_saturating();
-        if self.revision >= Revision::EVMC_TANGERINE_WHISTLE {
-            endowment = min(endowment, limit); // cap gas at all but one 64th of gas left
-        }
+        endowment = min(endowment, limit); // cap gas at all but one 64th of gas left
 
         let call_message = if DELEGATE {
             ExecutionMessage::new(
@@ -1816,7 +1813,7 @@ mod tests {
         let mut context = MockExecutionContextTrait::new();
         let message = MockExecutionMessage::default().into();
         let mut interpreter =
-            Interpreter::new(Revision::EVMC_FRONTIER, &message, &mut context, &[]);
+            Interpreter::new(Revision::EVMC_ISTANBUL, &message, &mut context, &[]);
         let result = interpreter.run();
         assert!(result.is_ok());
         assert_eq!(interpreter.exec_status, ExecStatus::Stopped);
@@ -1829,7 +1826,7 @@ mod tests {
         let mut context = MockExecutionContextTrait::new();
         let message = MockExecutionMessage::default().into();
         let mut interpreter = Interpreter::new_steppable(
-            Revision::EVMC_FRONTIER,
+            Revision::EVMC_ISTANBUL,
             &message,
             &mut context,
             &[Opcode::Add as u8],
@@ -1855,7 +1852,7 @@ mod tests {
         let mut context = MockExecutionContextTrait::new();
         let message = MockExecutionMessage::default().into();
         let result = Interpreter::new_steppable(
-            Revision::EVMC_FRONTIER,
+            Revision::EVMC_ISTANBUL,
             &message,
             &mut context,
             &[Opcode::Push1 as u8, 0x00],
@@ -1877,7 +1874,7 @@ mod tests {
         let mut context = MockExecutionContextTrait::new();
         let message = MockExecutionMessage::default().into();
         let mut interpreter = Interpreter::new(
-            Revision::EVMC_FRONTIER,
+            Revision::EVMC_ISTANBUL,
             &message,
             &mut context,
             &[Opcode::Add as u8],
@@ -1895,7 +1892,7 @@ mod tests {
         let mut context = MockExecutionContextTrait::new();
         let message = MockExecutionMessage::default().into();
         let mut interpreter = Interpreter::new(
-            Revision::EVMC_FRONTIER,
+            Revision::EVMC_ISTANBUL,
             &message,
             &mut context,
             &[Opcode::Add as u8, Opcode::Add as u8],
@@ -1917,7 +1914,7 @@ mod tests {
         let mut context = MockExecutionContextTrait::new();
         let message = MockExecutionMessage::default().into();
         let mut interpreter = Interpreter::new(
-            Revision::EVMC_FRONTIER,
+            Revision::EVMC_ISTANBUL,
             &message,
             &mut context,
             &[Opcode::Add as u8],
@@ -1938,7 +1935,7 @@ mod tests {
         let mut context = MockExecutionContextTrait::new();
         let message = MockExecutionMessage::default().into();
         let mut interpreter = Interpreter::new(
-            Revision::EVMC_FRONTIER,
+            Revision::EVMC_ISTANBUL,
             &message,
             &mut context,
             &[Opcode::Add as u8, Opcode::Add as u8],
@@ -1964,7 +1961,7 @@ mod tests {
         let mut context = MockExecutionContextTrait::new();
         let message = MockExecutionMessage::default().into();
         let mut interpreter = Interpreter::new(
-            Revision::EVMC_FRONTIER,
+            Revision::EVMC_ISTANBUL,
             &message,
             &mut context,
             &[Opcode::JumpDest as u8; 10_000_000],
@@ -1984,7 +1981,7 @@ mod tests {
         };
         let message = message.into();
         let mut interpreter = Interpreter::new(
-            Revision::EVMC_FRONTIER,
+            Revision::EVMC_ISTANBUL,
             &message,
             &mut context,
             &[Opcode::Add as u8],
@@ -2067,7 +2064,7 @@ mod tests {
         ];
 
         let mut interpreter = Interpreter::new_steppable(
-            Revision::EVMC_FRONTIER,
+            Revision::EVMC_ISTANBUL,
             &message,
             &mut context,
             &[Opcode::Call as u8],

--- a/rust/src/types/status_code.rs
+++ b/rust/src/types/status_code.rs
@@ -93,7 +93,7 @@ impl From<FailStatus> for StepResult {
         Self::new(
             fail_status.into(),
             fail_status.into(),
-            Revision::EVMC_FRONTIER,
+            Revision::EVMC_ISTANBUL,
             0,
             0,
             0,

--- a/rust/src/utils/gas.rs
+++ b/rust/src/utils/gas.rs
@@ -159,7 +159,7 @@ mod tests {
                 .return_const(exists);
 
             let mut interpreter = Interpreter::new(
-                Revision::EVMC_FRONTIER,
+                Revision::EVMC_ISTANBUL,
                 &message,
                 &mut context,
                 &[Opcode::Call as u8],
@@ -195,7 +195,7 @@ mod tests {
     fn consume_address_access_cost() {
         let cases = [
             (
-                Revision::EVMC_FRONTIER,
+                Revision::EVMC_ISTANBUL,
                 AccessStatus::EVMC_ACCESS_COLD,
                 Gas::new(0),
             ),

--- a/rust/src/utils/helpers.rs
+++ b/rust/src/utils/helpers.rs
@@ -62,9 +62,7 @@ pub fn check_min_revision(min_revision: Revision, revision: Revision) -> Result<
 
 #[inline(always)]
 pub fn check_not_read_only(state: &Interpreter) -> Result<(), FailStatus> {
-    if state.revision >= Revision::EVMC_BYZANTIUM
-        && state.message.flags() == MessageFlags::EVMC_STATIC as u32
-    {
+    if state.message.flags() == MessageFlags::EVMC_STATIC as u32 {
         return Err(FailStatus::StaticModeViolation);
     }
     Ok(())
@@ -131,15 +129,15 @@ mod tests {
     #[test]
     fn check_min_revision() {
         assert_eq!(
-            utils::check_min_revision(Revision::EVMC_FRONTIER, Revision::EVMC_FRONTIER),
+            utils::check_min_revision(Revision::EVMC_ISTANBUL, Revision::EVMC_ISTANBUL),
             Ok(())
         );
         assert_eq!(
-            utils::check_min_revision(Revision::EVMC_FRONTIER, Revision::EVMC_CANCUN),
+            utils::check_min_revision(Revision::EVMC_ISTANBUL, Revision::EVMC_CANCUN),
             Ok(())
         );
         assert_eq!(
-            utils::check_min_revision(Revision::EVMC_CANCUN, Revision::EVMC_FRONTIER),
+            utils::check_min_revision(Revision::EVMC_CANCUN, Revision::EVMC_ISTANBUL),
             Err(FailStatus::UndefinedInstruction)
         );
     }
@@ -148,10 +146,7 @@ mod tests {
     fn check_not_read_only() {
         let message = MockExecutionMessage::default().into();
         let mut context = MockExecutionContextTrait::new();
-        let interpreter = Interpreter::new(Revision::EVMC_FRONTIER, &message, &mut context, &[]);
-        assert_eq!(utils::check_not_read_only(&interpreter), Ok(()));
-
-        let interpreter = Interpreter::new(Revision::EVMC_BYZANTIUM, &message, &mut context, &[]);
+        let interpreter = Interpreter::new(Revision::EVMC_CANCUN, &message, &mut context, &[]);
         assert_eq!(utils::check_not_read_only(&interpreter), Ok(()));
 
         let message = MockExecutionMessage {
@@ -159,7 +154,7 @@ mod tests {
             ..Default::default()
         };
         let message = message.into();
-        let interpreter = Interpreter::new(Revision::EVMC_BYZANTIUM, &message, &mut context, &[]);
+        let interpreter = Interpreter::new(Revision::EVMC_CANCUN, &message, &mut context, &[]);
         assert_eq!(
             utils::check_not_read_only(&interpreter),
             Err(FailStatus::StaticModeViolation)


### PR DESCRIPTION
This PR removes all checks for revisions < Instanbul because support for those is not needed and it is assumed that the revision is always at least Istanbul.