### PR TITLE
evmrs: refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,11 @@ tosca-cpp-coverage: tosca-cpp
 
 tosca-rust:
 	cd rust; \
-	cargo build --release
+	cargo build --lib --release
 
 tosca-rust-coverage:
 	cd rust; \
-	RUSTFLAGS="-C instrument-coverage" cargo build --release
+	RUSTFLAGS="-C instrument-coverage" cargo build --lib --release
 
 evmone:
 	@cd third_party/evmone ; \

--- a/rust/BUILD.md
+++ b/rust/BUILD.md
@@ -144,8 +144,8 @@ Also see [compare-features.sh](./scripts/compare-features.sh) which when provide
 
 ```sh
 cargo install --locked samply
-# same steps as for Perf + Flamegraph but instead of `perf script | ...` run 
-samply import perf.data
+# now run the same commands as for Perf + Flamegraph except for the last line with `perf script ...`
+samply import perf.data # this converts perf.data, opens firefox profiler in your default browser and serves the data
 ```
 
 ### Samply + Firefox Profiler
@@ -153,7 +153,7 @@ samply import perf.data
 ```sh
 cargo install --locked samply
 cargo build --package benchmarks --profile profiling
-samply record ./target/profiling/benchmarks
+samply record ./target/profiling/benchmarks # this collects profiling data, opens firefox profiler in your default browser and serves the data
 ```
 
 ### Intel VTune

--- a/rust/BUILD.md
+++ b/rust/BUILD.md
@@ -8,11 +8,11 @@
 
 - build `evmrs` in release mode
     ```sh
-    cargo build --release # OR run `make` or `make tosca-rust` in Tosca directory
+    cargo build --lib --release # OR run `make` or `make tosca-rust` in Tosca directory
     ```
 - build `evmrs` with debug symbols (the `profiling` profile inherits `release` and enables debug symbols)
     ```sh
-    cargo build --profile profiling
+    cargo build --lib --profile profiling
     ```
 
 ## Lint
@@ -37,7 +37,7 @@ cargo doc --workspace --document-private-items --open
     ```
 - Go tests
     ```sh
-    cargo build --release # OR run `make` or `make tosca-rust` in Tosca directory
+    cargo build --lib --release # OR run `make` or `make tosca-rust` in Tosca directory
     go test ../go/interpreter/evmrs/...
     ```
 - CT
@@ -61,7 +61,7 @@ To generate code coverage for CT see [coverage.sh](./scripts/coverage.sh).
 
 ## Optimizations
 
-By default, `evmrs` is build with the simplest and most idiomatic implementation.
+By default, `evmrs` is build with the simplest implementation.
 All optimizations are behind feature flags.
 A list of all features can be found in the `[features]` section in [Cargo.toml](./Cargo.toml).
 For convenience there is also a feature named `performance` which enables all other features that improve overall performance.
@@ -74,7 +74,7 @@ cargo build --features mimalloc,stack-array
 ### Optimization Workflow
 
 1. Identify a possible optimization opportunity by
-    - running the Go VM benchmarks and comparing them, in cases where `evmrs` is slower than the other interpreters
+    - running the Go VM benchmarks and comparing `evmrs` with other interpreters
         ```sh
         cargo run --package bencher
         ```
@@ -142,7 +142,11 @@ Also see [compare-features.sh](./scripts/compare-features.sh) which when provide
 
 ### Perf + Firefox Profiler
 
-TODO
+```sh
+cargo install --locked samply
+# same steps as for Perf + Flamegraph but instead of `perf script | ...` run 
+samply import perf.data
+```
 
 ### Samply + Firefox Profiler
 

--- a/rust/scripts/run_ct.sh
+++ b/rust/scripts/run_ct.sh
@@ -32,6 +32,6 @@ go run ../go/ct/driver run evmrs | tee $OUTPUT_DIR/ct-full-performance
 
 cargo clean
 go clean --cache
-RUSTFLAGS="-C instrument-coverage" cargo build --lib --release --all-features
+cargo build --lib --release --all-features
 go test ../go/... | tee $OUTPUT_DIR/go-test-all-features
 go run ../go/ct/driver run evmrs | tee $OUTPUT_DIR/ct-full-all-features

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -1316,7 +1316,7 @@ impl<'a> Interpreter<'a> {
         let data = self.memory.get_mut_slice(offset, len, &mut self.gas_left)?;
         #[cfg(not(feature = "custom-evmc"))]
         {
-            self.output = Some((data).to_owned());
+            self.output = Some(data.to_owned());
         }
         #[cfg(feature = "custom-evmc")]
         {
@@ -1334,7 +1334,7 @@ impl<'a> Interpreter<'a> {
         // gas_refund = original_gas_refund;
         #[cfg(not(feature = "custom-evmc"))]
         {
-            self.output = Some((data).to_owned());
+            self.output = Some(data.to_owned());
         }
         #[cfg(feature = "custom-evmc")]
         {


### PR DESCRIPTION
- only build lib in Makefile (and update BUILD.md accordingly)
- document how to use Perf + Firefox Profiler
- build evmrs without coverage instrumentation in run_ct.sh now that we have #932