### PR TITLE
evmrs: add logging interpreter

### DIFF
--- a/go/interpreter/evmrs/evmrs.go
+++ b/go/interpreter/evmrs/evmrs.go
@@ -37,6 +37,19 @@ func init() {
 			return &evmrsInstance{evm}, nil
 		})
 	}
+
+	{
+		evm, err := evmc.LoadEvmcInterpreter("libevmrs.so")
+		if err != nil {
+			panic(fmt.Errorf("failed to load evmrs library: %s", err))
+		}
+		if err = evm.SetOption("logging", "true"); err != nil {
+			panic(fmt.Errorf("failed to configure EVM instance: %s", err))
+		}
+		tosca.MustRegisterInterpreterFactory("evmrs-logging", func(any) (tosca.Interpreter, error) {
+			return &evmrsInstance{evm}, nil
+		})
+	}
 }
 
 type evmrsInstance struct {

--- a/rust/src/evmc.rs
+++ b/rust/src/evmc.rs
@@ -43,7 +43,7 @@ impl EvmcVm for EvmRs {
         let mut interpreter = Interpreter::new(revision, message, context, code);
         let run_result = match self.observer_type {
             ObserverType::NoOp => interpreter.run(&mut NoOpObserver()),
-            ObserverType::Logging => interpreter.run(&mut LoggingObserver {}),
+            ObserverType::Logging => interpreter.run(&mut LoggingObserver::new(std::io::stdout())),
         };
         if let Err(status_code) = run_result {
             return ExecutionResult::from(status_code);
@@ -125,7 +125,7 @@ impl SteppableEvmcVm for EvmRs {
         );
         let run_result = match self.observer_type {
             ObserverType::NoOp => interpreter.run(&mut NoOpObserver()),
-            ObserverType::Logging => interpreter.run(&mut LoggingObserver {}),
+            ObserverType::Logging => interpreter.run(&mut LoggingObserver::new(std::io::stdout())),
         };
         if let Err(status_code) = run_result {
             return StepResult::from(status_code);

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -7,6 +7,7 @@ mod execution_context;
 pub mod hash_cache;
 mod memory;
 mod mock_execution_message;
+mod observer;
 #[cfg(feature = "needs-fn-ptr-conversion")]
 mod op_fn_data;
 mod opcode;
@@ -26,6 +27,7 @@ pub use code_reader::{CodeReader, GetOpcodeError};
 pub use execution_context::*;
 pub use memory::Memory;
 pub use mock_execution_message::MockExecutionMessage;
+pub use observer::*;
 #[cfg(feature = "needs-fn-ptr-conversion")]
 pub use op_fn_data::OpFnData;
 pub use opcode::*;

--- a/rust/src/types/observer.rs
+++ b/rust/src/types/observer.rs
@@ -1,0 +1,52 @@
+use std::borrow::Cow;
+
+use crate::interpreter::Interpreter;
+
+pub trait Observer {
+    fn pre_op(&mut self, interpreter: &Interpreter);
+
+    fn post_op(&mut self, interpreter: &Interpreter);
+
+    fn log(&mut self, message: Cow<str>);
+}
+
+pub struct NoOpObserver();
+
+impl Observer for NoOpObserver {
+    fn pre_op(&mut self, _interpreter: &Interpreter) {}
+
+    fn post_op(&mut self, _interpreter: &Interpreter) {}
+
+    fn log(&mut self, _message: Cow<str>) {}
+}
+
+pub struct LoggingObserver();
+
+impl Observer for LoggingObserver {
+    fn pre_op(&mut self, interpreter: &Interpreter) {
+        println!(
+            "pre opcode={:?} gas={} stack-size={}",
+            interpreter.code_reader.get(),
+            interpreter.gas_left.as_u64(),
+            interpreter.stack.len()
+        );
+    }
+
+    fn post_op(&mut self, interpreter: &Interpreter) {
+        println!(
+            "post gas={} stack-size={}",
+            interpreter.gas_left.as_u64(),
+            interpreter.stack.len()
+        );
+    }
+
+    fn log(&mut self, message: Cow<str>) {
+        println!("{message}");
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ObserverType {
+    NoOp,
+    Logging,
+}

--- a/rust/src/types/observer.rs
+++ b/rust/src/types/observer.rs
@@ -1,6 +1,8 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, io::Write};
 
 use crate::interpreter::Interpreter;
+#[cfg(feature = "needs-fn-ptr-conversion")]
+use crate::Opcode;
 
 pub trait Observer {
     fn pre_op(&mut self, interpreter: &Interpreter);
@@ -20,28 +22,45 @@ impl Observer for NoOpObserver {
     fn log(&mut self, _message: Cow<str>) {}
 }
 
-pub struct LoggingObserver();
+pub struct LoggingObserver<W: Write> {
+    writer: W,
+}
 
-impl Observer for LoggingObserver {
+impl<W: Write> LoggingObserver<W> {
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+}
+
+impl<W: Write> Observer for LoggingObserver<W> {
     fn pre_op(&mut self, interpreter: &Interpreter) {
-        println!(
-            "pre opcode={:?} gas={} stack-size={}",
-            interpreter.code_reader.get(),
-            interpreter.gas_left.as_u64(),
-            interpreter.stack.len()
-        );
+        // pre_op is called after the op is fetched so this will always be Ok(..)
+        #[cfg(not(feature = "needs-fn-ptr-conversion"))]
+        let op = interpreter.code_reader.get().unwrap();
+        #[cfg(feature = "needs-fn-ptr-conversion")]
+        let op = {
+            let op = interpreter.code_reader[interpreter.code_reader.pc()];
+            // SAFETY:
+            // pre_op is called after the op is fetched, which means that code_reader.get() returned
+            // Some(..) which in turn means that the code analysis determined that this byte is a
+            // valid Opcode.
+            unsafe { std::mem::transmute::<u8, Opcode>(op) }
+        };
+        let gas = interpreter.gas_left.as_u64();
+        let top = interpreter
+            .stack
+            .peek()
+            .map(ToString::to_string)
+            .unwrap_or("-empty-".to_owned());
+        writeln!(self.writer, "{op:?}, {gas}, {top}").unwrap();
+        self.writer.flush().unwrap();
     }
 
-    fn post_op(&mut self, interpreter: &Interpreter) {
-        println!(
-            "post gas={} stack-size={}",
-            interpreter.gas_left.as_u64(),
-            interpreter.stack.len()
-        );
-    }
+    fn post_op(&mut self, _interpreter: &Interpreter) {}
 
     fn log(&mut self, message: Cow<str>) {
-        println!("{message}");
+        writeln!(self.writer, "{message}").unwrap();
+        self.writer.flush().unwrap();
     }
 }
 

--- a/rust/src/types/stack.rs
+++ b/rust/src/types/stack.rs
@@ -66,6 +66,18 @@ impl Stack {
         Ok(unsafe { std::ptr::read(pop_start as *const [u256; N]) })
     }
 
+    pub fn peek(&self) -> Option<&u256> {
+        if self.len == 0 {
+            None
+        } else {
+            let top = &self.data[self.len - 1];
+            // SAFETY:
+            // The first self.len elements are initialized.
+            let top = unsafe { std::mem::transmute::<&MaybeUninit<u256>, &u256>(top) };
+            Some(top)
+        }
+    }
+
     pub fn swap_with_top(&mut self, nth: usize) -> Result<(), FailStatus> {
         self.check_underflow(nth + 1)?;
 
@@ -148,6 +160,10 @@ impl Stack {
         array.copy_from_slice(&self.0[new_len..]);
         self.0.truncate(new_len);
         Ok(array)
+    }
+
+    pub fn peek(&self) -> Option<&u256> {
+        self.0.last()
     }
 
     pub fn nth(&self, nth: usize) -> Result<u256, FailStatus> {


### PR DESCRIPTION
This PR adds a logging version of evmrs. It works similar to how it is done in evmzero. The run method is now generic over an Observer. If the NoOpOberver is used, the calls to pre_op and post_op are no ops and should be eliminated by the compiler. The LoggingProfiler prints the state of the interpreter.