### PR TITLE
evmrs: skip jumpdest and step check

### DIFF
--- a/rust/src/types/code_analysis.rs
+++ b/rust/src/types/code_analysis.rs
@@ -70,22 +70,23 @@ pub struct CodeAnalysis {
 }
 
 impl CodeAnalysis {
+    /// If the const generic J is false, jumpdests are skipped.
     #[allow(unused_variables)]
-    pub fn new(code: &[u8], code_hash: Option<u256>) -> AnalysisContainer<Self> {
+    pub fn new<const J: bool>(code: &[u8], code_hash: Option<u256>) -> AnalysisContainer<Self> {
         #[cfg(feature = "code-analysis-cache")]
         match code_hash {
             Some(code_hash) if code_hash != u256::ZERO => CODE_ANALYSIS_CACHE
                 .get_or_insert(u256Hash(code_hash), || {
-                    AnalysisContainer::new(Self::analyze_code(code))
+                    AnalysisContainer::new(Self::analyze_code::<J>(code))
                 }),
-            _ => AnalysisContainer::new(Self::analyze_code(code)),
+            _ => AnalysisContainer::new(Self::analyze_code::<J>(code)),
         }
         #[cfg(not(feature = "code-analysis-cache"))]
-        Self::analyze_code(code)
+        Self::analyze_code::<J>(code)
     }
 
     #[cfg(not(feature = "needs-fn-ptr-conversion"))]
-    fn analyze_code(code: &[u8]) -> Self {
+    fn analyze_code<const J: bool>(code: &[u8]) -> Self {
         let mut code_byte_types = vec![CodeByteType::DataOrInvalid; code.len()];
 
         let mut pc = 0;
@@ -100,7 +101,7 @@ impl CodeAnalysis {
         }
     }
     #[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
-    fn analyze_code(code: &[u8]) -> Self {
+    fn analyze_code<const J: bool>(code: &[u8]) -> Self {
         let mut analysis = Vec::with_capacity(code.len());
         // +32+1 because if last op is push32 we need mapping from after converted to after code+32
         let mut pc_map = PcMap::new(code.len() + 32 + 1);
@@ -126,14 +127,14 @@ impl CodeAnalysis {
                     let avail = min(data_len, code.len() - pc);
                     data[32 - data_len..32 - data_len + avail]
                         .copy_from_slice(&code[pc..pc + avail]);
-                    analysis.push(OpFnData::func(op, data));
+                    analysis.push(OpFnData::func::<J>(op, data));
                     pc_map.add_mapping(pc - 1, analysis.len() - 1);
 
                     no_ops += data_len;
                     pc += data_len;
                 }
                 CodeByteType::Opcode => {
-                    analysis.push(OpFnData::func(op, u256::ZERO));
+                    analysis.push(OpFnData::func::<J>(op, u256::ZERO));
                     pc_map.add_mapping(pc - 1, analysis.len() - 1);
                 }
                 CodeByteType::DataOrInvalid => {
@@ -153,7 +154,7 @@ impl CodeAnalysis {
         not(feature = "fn-ptr-conversion-expanded-dispatch"),
         feature = "fn-ptr-conversion-inline-dispatch"
     ))]
-    fn analyze_code(code: &[u8]) -> Self {
+    fn analyze_code<const J: bool>(code: &[u8]) -> Self {
         let mut analysis = Vec::with_capacity(code.len());
         // +32+1 because if last op is push32 we need mapping from after converted to after code+32
         let mut pc_map = PcMap::new(code.len() + 32 + 1);
@@ -169,7 +170,7 @@ impl CodeAnalysis {
                     pc_map.add_mapping(pc - 1, analysis.len());
                     match no_ops {
                         0 => (),
-                        1 => analysis.push(OpFnData::func(Opcode::NoOp as u8)),
+                        1 => analysis.push(OpFnData::func::<J>(Opcode::NoOp as u8)),
                         2.. => analysis.extend(OpFnData::skip_no_ops_iter(no_ops)),
                     }
                     no_ops = 0;
@@ -177,7 +178,7 @@ impl CodeAnalysis {
                     pc_map.add_mapping(pc - 1, analysis.len() - 1);
                 }
                 CodeByteType::Push => {
-                    analysis.push(OpFnData::func(op));
+                    analysis.push(OpFnData::func::<J>(op));
                     pc_map.add_mapping(pc - 1, analysis.len() - 1);
 
                     let mut capped_inc = data_len.rem_euclid(OP_FN_DATA_SIZE);
@@ -200,7 +201,7 @@ impl CodeAnalysis {
                     }
                 }
                 CodeByteType::Opcode => {
-                    analysis.push(OpFnData::func(op));
+                    analysis.push(OpFnData::func::<J>(op));
                     pc_map.add_mapping(pc - 1, analysis.len() - 1);
                 }
                 CodeByteType::DataOrInvalid => {
@@ -248,19 +249,19 @@ mod tests {
     #[test]
     fn analyze_code_single_byte() {
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::Add as u8]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[Opcode::Add as u8]).analysis,
             [CodeByteType::Opcode]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::Push2 as u8]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[Opcode::Push2 as u8]).analysis,
             [CodeByteType::Opcode]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::JumpDest as u8]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[Opcode::JumpDest as u8]).analysis,
             [CodeByteType::JumpDest]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[0xc0]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[0xc0]).analysis,
             [CodeByteType::DataOrInvalid]
         );
     }
@@ -269,19 +270,19 @@ mod tests {
     #[test]
     fn analyze_code_single_byte() {
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::Add as u8]).analysis,
-            [OpFnData::func(Opcode::Add as u8, u256::ZERO)]
+            CodeAnalysis::analyze_code::<false>(&[Opcode::Add as u8]).analysis,
+            [OpFnData::func::<false>(Opcode::Add as u8, u256::ZERO)]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::Push2 as u8]).analysis,
-            [OpFnData::func(Opcode::Push2 as u8, u256::ZERO)]
+            CodeAnalysis::analyze_code::<false>(&[Opcode::Push2 as u8]).analysis,
+            [OpFnData::func::<false>(Opcode::Push2 as u8, u256::ZERO)]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::JumpDest as u8]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[Opcode::JumpDest as u8]).analysis,
             [OpFnData::jump_dest()]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[0xc0]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[0xc0]).analysis,
             [OpFnData::data(u256::ZERO)]
         );
     }
@@ -292,22 +293,22 @@ mod tests {
     #[test]
     fn analyze_code_single_byte() {
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::Add as u8]).analysis,
-            [OpFnData::func(Opcode::Add as u8)]
+            CodeAnalysis::analyze_code::<false>(&[Opcode::Add as u8]).analysis,
+            [OpFnData::func::<false>(Opcode::Add as u8)]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::Push2 as u8]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[Opcode::Push2 as u8]).analysis,
             [
-                OpFnData::func(Opcode::Push2 as u8),
+                OpFnData::func::<false>(Opcode::Push2 as u8),
                 OpFnData::data([0; OP_FN_DATA_SIZE])
             ]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::JumpDest as u8]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[Opcode::JumpDest as u8]).analysis,
             [OpFnData::jump_dest()]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[0xc0]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[0xc0]).analysis,
             [OpFnData::data([0; OP_FN_DATA_SIZE])]
         );
     }
@@ -316,11 +317,12 @@ mod tests {
     #[test]
     fn analyze_code_jumpdest() {
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::JumpDest as u8, Opcode::Add as u8]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[Opcode::JumpDest as u8, Opcode::Add as u8])
+                .analysis,
             [CodeByteType::JumpDest, CodeByteType::Opcode]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::JumpDest as u8, 0xc0]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[Opcode::JumpDest as u8, 0xc0]).analysis,
             [CodeByteType::JumpDest, CodeByteType::DataOrInvalid]
         );
     }
@@ -331,14 +333,15 @@ mod tests {
         use crate::u256;
 
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::JumpDest as u8, Opcode::Add as u8]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[Opcode::JumpDest as u8, Opcode::Add as u8])
+                .analysis,
             [
                 OpFnData::jump_dest(),
-                OpFnData::func(Opcode::Add as u8, u256::ZERO)
+                OpFnData::func::<false>(Opcode::Add as u8, u256::ZERO)
             ]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::JumpDest as u8, 0xc0]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[Opcode::JumpDest as u8, 0xc0]).analysis,
             [OpFnData::jump_dest(), OpFnData::data(u256::ZERO)]
         );
     }
@@ -349,11 +352,15 @@ mod tests {
     #[test]
     fn analyze_code_jumpdest() {
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::JumpDest as u8, Opcode::Add as u8]).analysis,
-            [OpFnData::jump_dest(), OpFnData::func(Opcode::Add as u8)]
+            CodeAnalysis::analyze_code::<false>(&[Opcode::JumpDest as u8, Opcode::Add as u8])
+                .analysis,
+            [
+                OpFnData::jump_dest(),
+                OpFnData::func::<false>(Opcode::Add as u8)
+            ]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::JumpDest as u8, 0xc0]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[Opcode::JumpDest as u8, 0xc0]).analysis,
             [OpFnData::jump_dest(), OpFnData::data([0; OP_FN_DATA_SIZE])]
         );
     }
@@ -361,7 +368,7 @@ mod tests {
     #[test]
     fn analyze_code_push_with_data() {
         assert_eq!(
-            CodeAnalysis::analyze_code(&[
+            CodeAnalysis::analyze_code::<false>(&[
                 Opcode::Push1 as u8,
                 Opcode::Add as u8,
                 Opcode::Add as u8
@@ -374,7 +381,8 @@ mod tests {
             ]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::Push1 as u8, Opcode::Add as u8, 0xc0]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[Opcode::Push1 as u8, Opcode::Add as u8, 0xc0])
+                .analysis,
             [
                 CodeByteType::Opcode,
                 CodeByteType::DataOrInvalid,
@@ -382,7 +390,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[
+            CodeAnalysis::analyze_code::<false>(&[
                 Opcode::Push1 as u8,
                 Opcode::Add as u8,
                 0xc0,
@@ -397,7 +405,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[
+            CodeAnalysis::analyze_code::<false>(&[
                 Opcode::Push2 as u8,
                 Opcode::Add as u8,
                 Opcode::Add as u8,
@@ -412,7 +420,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[
+            CodeAnalysis::analyze_code::<false>(&[
                 Opcode::Push2 as u8,
                 Opcode::Add as u8,
                 Opcode::Add as u8,
@@ -434,26 +442,27 @@ mod tests {
         use crate::u256;
 
         assert_eq!(
-            CodeAnalysis::analyze_code(&[
+            CodeAnalysis::analyze_code::<false>(&[
                 Opcode::Push1 as u8,
                 Opcode::Add as u8,
                 Opcode::Add as u8
             ])
             .analysis,
             [
-                OpFnData::func(Opcode::Push1 as u8, (Opcode::Add as u8).into()),
-                OpFnData::func(Opcode::Add as u8, u256::ZERO),
+                OpFnData::func::<false>(Opcode::Push1 as u8, (Opcode::Add as u8).into()),
+                OpFnData::func::<false>(Opcode::Add as u8, u256::ZERO),
             ]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::Push1 as u8, Opcode::Add as u8, 0xc0]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[Opcode::Push1 as u8, Opcode::Add as u8, 0xc0])
+                .analysis,
             [
-                OpFnData::func(Opcode::Push1 as u8, (Opcode::Add as u8).into()),
+                OpFnData::func::<false>(Opcode::Push1 as u8, (Opcode::Add as u8).into()),
                 OpFnData::data(u256::ZERO),
             ]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[
+            CodeAnalysis::analyze_code::<false>(&[
                 Opcode::Push1 as u8,
                 Opcode::Add as u8,
                 0xc0,
@@ -461,13 +470,13 @@ mod tests {
             ])
             .analysis,
             [
-                OpFnData::func(Opcode::Push1 as u8, (Opcode::Add as u8).into()),
+                OpFnData::func::<false>(Opcode::Push1 as u8, (Opcode::Add as u8).into()),
                 OpFnData::data(u256::ZERO),
-                OpFnData::func(Opcode::Add as u8, u256::ZERO),
+                OpFnData::func::<false>(Opcode::Add as u8, u256::ZERO),
             ]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[
+            CodeAnalysis::analyze_code::<false>(&[
                 Opcode::Push2 as u8,
                 Opcode::Add as u8,
                 Opcode::Add as u8,
@@ -475,15 +484,15 @@ mod tests {
             ])
             .analysis,
             [
-                OpFnData::func(
+                OpFnData::func::<false>(
                     Opcode::Push2 as u8,
                     (((Opcode::Add as u8 as u64) << 8) + Opcode::Add as u8 as u64).into()
                 ),
-                OpFnData::func(Opcode::Add as u8, u256::ZERO),
+                OpFnData::func::<false>(Opcode::Add as u8, u256::ZERO),
             ]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[
+            CodeAnalysis::analyze_code::<false>(&[
                 Opcode::Push2 as u8,
                 Opcode::Add as u8,
                 Opcode::Add as u8,
@@ -491,7 +500,7 @@ mod tests {
             ])
             .analysis,
             [
-                OpFnData::func(
+                OpFnData::func::<false>(
                     Opcode::Push2 as u8,
                     (((Opcode::Add as u8 as u64) << 8) + Opcode::Add as u8 as u64).into()
                 ),
@@ -504,13 +513,13 @@ mod tests {
         code[21] = 2;
         code[22] = Opcode::Add as u8;
         assert_eq!(
-            CodeAnalysis::analyze_code(&code).analysis,
+            CodeAnalysis::analyze_code::<false>(&code).analysis,
             [
-                OpFnData::func(
+                OpFnData::func::<false>(
                     Opcode::Push21 as u8,
                     (u256::ONE << u256::from(8 * 20u8)) + u256::from(2u8)
                 ),
-                OpFnData::func(Opcode::Add as u8, u256::ZERO),
+                OpFnData::func::<false>(Opcode::Add as u8, u256::ZERO),
             ]
         );
     }
@@ -521,28 +530,29 @@ mod tests {
     #[test]
     fn analyze_code_push_with_data() {
         assert_eq!(
-            CodeAnalysis::analyze_code(&[
+            CodeAnalysis::analyze_code::<false>(&[
                 Opcode::Push1 as u8,
                 Opcode::Add as u8,
                 Opcode::Add as u8
             ])
             .analysis,
             [
-                OpFnData::func(Opcode::Push1 as u8,),
+                OpFnData::func::<false>(Opcode::Push1 as u8,),
                 OpFnData::data([0, 0, 0, Opcode::Add as u8]),
-                OpFnData::func(Opcode::Add as u8),
+                OpFnData::func::<false>(Opcode::Add as u8),
             ]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[Opcode::Push1 as u8, Opcode::Add as u8, 0xc0]).analysis,
+            CodeAnalysis::analyze_code::<false>(&[Opcode::Push1 as u8, Opcode::Add as u8, 0xc0])
+                .analysis,
             [
-                OpFnData::func(Opcode::Push1 as u8,),
+                OpFnData::func::<false>(Opcode::Push1 as u8,),
                 OpFnData::data([0, 0, 0, Opcode::Add as u8]),
                 OpFnData::data([0; OP_FN_DATA_SIZE]),
             ]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[
+            CodeAnalysis::analyze_code::<false>(&[
                 Opcode::Push1 as u8,
                 Opcode::Add as u8,
                 0xc0,
@@ -550,14 +560,14 @@ mod tests {
             ])
             .analysis,
             [
-                OpFnData::func(Opcode::Push1 as u8,),
+                OpFnData::func::<false>(Opcode::Push1 as u8,),
                 OpFnData::data([0, 0, 0, Opcode::Add as u8]),
                 OpFnData::data([0; OP_FN_DATA_SIZE]),
-                OpFnData::func(Opcode::Add as u8),
+                OpFnData::func::<false>(Opcode::Add as u8),
             ]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[
+            CodeAnalysis::analyze_code::<false>(&[
                 Opcode::Push2 as u8,
                 Opcode::Add as u8,
                 Opcode::Add as u8,
@@ -565,13 +575,13 @@ mod tests {
             ])
             .analysis,
             [
-                OpFnData::func(Opcode::Push2 as u8,),
+                OpFnData::func::<false>(Opcode::Push2 as u8,),
                 OpFnData::data([0, 0, Opcode::Add as u8, Opcode::Add as u8]),
-                OpFnData::func(Opcode::Add as u8),
+                OpFnData::func::<false>(Opcode::Add as u8),
             ]
         );
         assert_eq!(
-            CodeAnalysis::analyze_code(&[
+            CodeAnalysis::analyze_code::<false>(&[
                 Opcode::Push2 as u8,
                 Opcode::Add as u8,
                 Opcode::Add as u8,
@@ -579,7 +589,7 @@ mod tests {
             ])
             .analysis,
             [
-                OpFnData::func(Opcode::Push2 as u8,),
+                OpFnData::func::<false>(Opcode::Push2 as u8,),
                 OpFnData::data([0, 0, Opcode::Add as u8, Opcode::Add as u8]),
                 OpFnData::data([0; OP_FN_DATA_SIZE]),
             ]
@@ -590,16 +600,16 @@ mod tests {
         code[21] = 3;
         code[22] = Opcode::Add as u8;
         assert_eq!(
-            CodeAnalysis::analyze_code(&code).analysis,
+            CodeAnalysis::analyze_code::<false>(&code).analysis,
             [
-                OpFnData::func(Opcode::Push21 as u8),
+                OpFnData::func::<false>(Opcode::Push21 as u8),
                 OpFnData::data([0, 0, 0, 2]),
                 OpFnData::data([1, 1, 1, 1]),
                 OpFnData::data([1, 1, 1, 1]),
                 OpFnData::data([1, 1, 1, 1]),
                 OpFnData::data([1, 1, 1, 1]),
                 OpFnData::data([1, 1, 1, 3]),
-                OpFnData::func(Opcode::Add as u8),
+                OpFnData::func::<false>(Opcode::Add as u8),
             ]
         );
     }

--- a/rust/src/types/code_reader.rs
+++ b/rust/src/types/code_reader.rs
@@ -30,8 +30,9 @@ pub enum GetOpcodeError {
 }
 
 impl<'a> CodeReader<'a> {
-    pub fn new(code: &'a [u8], code_hash: Option<u256>, pc: usize) -> Self {
-        let code_analysis = CodeAnalysis::new(code, code_hash);
+    /// If the const generic J is false, jumpdests are skipped.
+    pub fn new<const J: bool>(code: &'a [u8], code_hash: Option<u256>, pc: usize) -> Self {
+        let code_analysis = CodeAnalysis::new::<J>(code, code_hash);
         #[cfg(feature = "needs-fn-ptr-conversion")]
         let pc = code_analysis.pc_map.to_converted(pc);
         Self {
@@ -155,7 +156,7 @@ mod tests {
     fn code_reader_internals() {
         let code = [Opcode::Add as u8, Opcode::Add as u8, 0xc0];
         let pc = 1;
-        let code_reader = CodeReader::new(&code, None, pc);
+        let code_reader = CodeReader::new::<false>(&code, None, pc);
         assert_eq!(*code_reader, code);
         assert_eq!(code_reader.len(), code.len());
         assert_eq!(code_reader.pc(), pc);
@@ -166,34 +167,34 @@ mod tests {
     fn code_reader_pc() {
         let code = [Opcode::Push1 as u8, Opcode::Add as u8, Opcode::Add as u8];
 
-        let code_reader = CodeReader::new(&code, None, 0);
+        let code_reader = CodeReader::new::<false>(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         assert_eq!(code_reader.pc(), 0);
 
-        let mut code_reader = CodeReader::new(&code, None, 0);
+        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         code_reader.get_push_data();
         assert_eq!(code_reader.pc, 1);
         assert_eq!(code_reader.pc(), 2);
 
-        let code_reader = CodeReader::new(&code, None, 2);
+        let code_reader = CodeReader::new::<false>(&code, None, 2);
         assert_eq!(code_reader.pc, 1);
         assert_eq!(code_reader.pc(), 2);
 
         let mut code = [Opcode::Add as u8; 23];
         code[0] = Opcode::Push21 as u8;
 
-        let code_reader = CodeReader::new(&code, None, 0);
+        let code_reader = CodeReader::new::<false>(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         assert_eq!(code_reader.pc(), 0);
 
-        let mut code_reader = CodeReader::new(&code, None, 0);
+        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         code_reader.get_push_data();
         assert_eq!(code_reader.pc, 1);
         assert_eq!(code_reader.pc(), 22);
 
-        let code_reader = CodeReader::new(&code, None, 22);
+        let code_reader = CodeReader::new::<false>(&code, None, 22);
         assert_eq!(code_reader.pc, 1);
         assert_eq!(code_reader.pc(), 22);
     }
@@ -205,36 +206,36 @@ mod tests {
     fn code_reader_pc() {
         let code = [Opcode::Push1 as u8, Opcode::Add as u8, Opcode::Add as u8];
 
-        let code_reader = CodeReader::new(&code, None, 0);
+        let code_reader = CodeReader::new::<false>(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         assert_eq!(code_reader.pc(), 0);
 
-        let mut code_reader = CodeReader::new(&code, None, 0);
+        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         code_reader.next();
         code_reader.get_push_data(1);
         assert_eq!(code_reader.pc, 2);
         assert_eq!(code_reader.pc(), 2);
 
-        let code_reader = CodeReader::new(&code, None, 2);
+        let code_reader = CodeReader::new::<false>(&code, None, 2);
         assert_eq!(code_reader.pc, 2);
         assert_eq!(code_reader.pc(), 2);
 
         let mut code = [Opcode::Add as u8; 23];
         code[0] = Opcode::Push21 as u8;
 
-        let code_reader = CodeReader::new(&code, None, 0);
+        let code_reader = CodeReader::new::<false>(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         assert_eq!(code_reader.pc(), 0);
 
-        let mut code_reader = CodeReader::new(&code, None, 0);
+        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         code_reader.next();
         code_reader.get_push_data(21);
         assert_eq!(code_reader.pc, 7);
         assert_eq!(code_reader.pc(), 22);
 
-        let code_reader = CodeReader::new(&code, None, 22);
+        let code_reader = CodeReader::new::<false>(&code, None, 22);
         assert_eq!(code_reader.pc, 7);
         assert_eq!(code_reader.pc(), 22);
     }
@@ -242,7 +243,7 @@ mod tests {
     #[test]
     fn code_reader_get() {
         let mut code_reader =
-            CodeReader::new(&[Opcode::Add as u8, Opcode::Add as u8, 0xc0], None, 0);
+            CodeReader::new::<false>(&[Opcode::Add as u8, Opcode::Add as u8, 0xc0], None, 0);
         #[cfg(not(feature = "needs-fn-ptr-conversion"))]
         assert_eq!(code_reader.get(), Ok(Opcode::Add));
         #[cfg(feature = "needs-fn-ptr-conversion")]
@@ -260,7 +261,7 @@ mod tests {
 
     #[test]
     fn code_reader_try_jump() {
-        let mut code_reader = CodeReader::new(
+        let mut code_reader = CodeReader::new::<false>(
             &[
                 Opcode::Push1 as u8,
                 Opcode::JumpDest as u8,
@@ -287,22 +288,22 @@ mod tests {
     #[cfg(not(feature = "needs-fn-ptr-conversion"))]
     #[test]
     fn code_reader_get_push_data() {
-        let mut code_reader = CodeReader::new(&[0xff; 32], None, 0);
+        let mut code_reader = CodeReader::new::<false>(&[0xff; 32], None, 0);
         assert_eq!(code_reader.get_push_data(0u8.into()), u256::ZERO);
 
-        let mut code_reader = CodeReader::new(&[0xff; 32], None, 0);
+        let mut code_reader = CodeReader::new::<false>(&[0xff; 32], None, 0);
         assert_eq!(code_reader.get_push_data(1u8.into()), 0xffu8.into());
 
-        let mut code_reader = CodeReader::new(&[0xff; 32], None, 0);
+        let mut code_reader = CodeReader::new::<false>(&[0xff; 32], None, 0);
         assert_eq!(code_reader.get_push_data(32u8.into()), u256::MAX);
 
-        let mut code_reader = CodeReader::new(&[0xff; 32], None, 31);
+        let mut code_reader = CodeReader::new::<false>(&[0xff; 32], None, 31);
         assert_eq!(
             code_reader.get_push_data(32u8.into()),
             u256::from(0xffu8) << u256::from(248u8)
         );
 
-        let mut code_reader = CodeReader::new(&[0xff; 32], None, 32);
+        let mut code_reader = CodeReader::new::<false>(&[0xff; 32], None, 32);
         assert_eq!(code_reader.get_push_data(32u8.into()), u256::ZERO);
     }
     #[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
@@ -311,7 +312,7 @@ mod tests {
         // pc on data is non longer possible because there are not data items anymore
         let mut code = [0xff; 33];
         code[0] = Opcode::Push32 as u8;
-        let mut code_reader = CodeReader::new(&code, None, 0);
+        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
         assert_eq!(code_reader.get_push_data(), u256::MAX);
     }
     #[cfg(all(
@@ -324,18 +325,18 @@ mod tests {
         // pc on data is undefined behavior so we have to advance the pc by calling next
         let mut code = [0xff; 33];
         code[0] = Opcode::Push32 as u8;
-        let mut code_reader = CodeReader::new(&code, None, 0);
+        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
         code_reader.next();
         assert_eq!(code_reader.get_push_data(0u8.into()), u256::ZERO);
 
-        let mut code_reader = CodeReader::new(&code, None, 0);
+        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
         code_reader.next();
         assert_eq!(
             code_reader.get_push_data(1u8.into()),
             (u32::MAX as u64).into()
         );
 
-        let mut code_reader = CodeReader::new(&code, None, 0);
+        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
         code_reader.next();
         assert_eq!(code_reader.get_push_data(32u8.into()), u256::MAX);
     }

--- a/rust/src/types/code_reader.rs
+++ b/rust/src/types/code_reader.rs
@@ -31,8 +31,8 @@ pub enum GetOpcodeError {
 
 impl<'a> CodeReader<'a> {
     /// If the const generic J is false, jumpdests are skipped.
-    pub fn new<const J: bool>(code: &'a [u8], code_hash: Option<u256>, pc: usize) -> Self {
-        let code_analysis = CodeAnalysis::new::<J>(code, code_hash);
+    pub fn new<const JUMPDEST: bool>(code: &'a [u8], code_hash: Option<u256>, pc: usize) -> Self {
+        let code_analysis = CodeAnalysis::new::<JUMPDEST>(code, code_hash);
         #[cfg(feature = "needs-fn-ptr-conversion")]
         let pc = code_analysis.pc_map.to_converted(pc);
         Self {

--- a/rust/src/types/op_fn_data.rs
+++ b/rust/src/types/op_fn_data.rs
@@ -62,7 +62,7 @@ impl OpFnData {
         )
     }
 
-    pub fn func<const J: bool>(op: u8) -> Self {
+    pub fn func<const JUMPDEST: bool>(op: u8) -> Self {
         let ptr_value = Interpreter::JUMPTABLE[op as usize] as usize;
         OpFnData {
             raw: ptr_value.to_ne_bytes(),
@@ -144,9 +144,9 @@ impl OpFnData {
         )
     }
 
-    pub fn func<const J: bool>(op: u8, data: u256) -> Self {
+    pub fn func<const JUMPDEST: bool>(op: u8, data: u256) -> Self {
         OpFnData {
-            func: Some(if J {
+            func: Some(if JUMPDEST {
                 Interpreter::JUMPTABLE[op as usize]
             } else {
                 Interpreter::JUMPTABLE_SKIP_JUMPDEST[op as usize]

--- a/rust/src/types/op_fn_data.rs
+++ b/rust/src/types/op_fn_data.rs
@@ -62,7 +62,7 @@ impl OpFnData {
         )
     }
 
-    pub fn func(op: u8) -> Self {
+    pub fn func<const J: bool>(op: u8) -> Self {
         let ptr_value = Interpreter::JUMPTABLE[op as usize] as usize;
         OpFnData {
             raw: ptr_value.to_ne_bytes(),
@@ -144,9 +144,13 @@ impl OpFnData {
         )
     }
 
-    pub fn func(op: u8, data: u256) -> Self {
+    pub fn func<const J: bool>(op: u8, data: u256) -> Self {
         OpFnData {
-            func: Some(Interpreter::JUMPTABLE[op as usize]),
+            func: Some(if J {
+                Interpreter::JUMPTABLE[op as usize]
+            } else {
+                Interpreter::JUMPTABLE_SKIP_JUMPDEST[op as usize]
+            }),
             data,
         }
     }


### PR DESCRIPTION
This PR adds the possibility to skip the step check (checking if steps are set and > 0) and jumpdests (by executing them inside jump / jumpi). This is then enabled for the non-steppable interface.
This only works when feature tail-call is not enabled, and improves performance here by about 10%.