### PR TITLE
evmrs: add fuzzing

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -150,6 +150,25 @@ jobs:
         MIRIFLAGS: "-Zmiri-disable-stacked-borrows -Zmiri-permissive-provenance -Zmiri-backtrace=full"
       run: cargo +nightly hack miri run --package benchmarks --each-feature --exclude-features mimalloc,performance -- 1 all-short
 
+  fuzz:
+    name: fuzz
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: install rust
+      uses: dtolnay/rust-toolchain@stable
+    - name: load cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: rust
+    - name: install cargo-fuzz
+      run: cargo install cargo-fuzz
+    - name: cargo fuzz evmc execute
+      working-directory: rust
+      run: cargo fuzz run --sanitizer none evmc_execute -- -max_total_time=10
+
   deps:
     name: unused deps
     runs-on: ubuntu-latest

--- a/rust/BUILD.md
+++ b/rust/BUILD.md
@@ -162,3 +162,39 @@ samply record ./target/profiling/benchmarks # this collects profiling data, open
 cargo build --package benchmarks --profile profiling
 ```
 run `./target/profiling/benchmarks` with Intel VTune 
+
+## Miri & Sanitizers
+
+### Miri
+
+[Miri](https://github.com/rust-lang/miri) *is an Undefined Behavior detection tool for Rust*. It interprets Rust mid-intermediate representation as has therefore much more information available than when executing a binary. However, that makes it also relatively slow. Furthermore, it is only available on nightly Rust, which is not a big deal because it is only used for testing anyway.
+*Because miri runs as a platform independent interpreter, it has no access to most platform-specific APIs or FFI.* It is therefore not possible to run it with a custom allocator an hence also not with feature *mimalloc* or *performance*.
+
+```sh
+# install miri
+rustup +nightly component add miri
+
+export MIRIFLAGS "-Zmiri-disable-stacked-borrows -Zmiri-permissive-provenance -Zmiri-backtrace=full"
+
+# run tests with miri
+cargo +nightly miri test
+# run benchmark binary with miri
+cargo +nightly miri run --package benchmarks -- 1 all-short
+```
+
+## Fuzzing
+
+Fuzzing is done with [libfuzzer](https://llvm.org/docs/LibFuzzer.html) an *in-process, coverage-guided, evolutionary fuzzing engine*.
+It is using the Rust binding [libfuzzer-sys](https://crates.io/crates/libfuzzer-sys) together with cargo integration [cargo fuzz](https://crates.io/crates/cargo-fuzz).
+
+```sh
+# install cargo integration
+cargo install cargo-fuzz
+
+# run fuzzer
+cargo fuzz run --sanitizer none evmc_execute
+# run fuzzer and stop after 10s
+cargo fuzz run --sanitizer none evmc_execute -- -max_total_time=10
+# run fuzzer with multiple jobs
+cargo fuzz run --jobs <jobs> --sanitizer none evmc_execute
+```

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -88,6 +88,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +185,8 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -385,6 +396,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +487,7 @@ dependencies = [
 name = "evmrs"
 version = "0.1.0"
 dependencies = [
+ "arbitrary",
  "bnum",
  "driver",
  "evmc-vm 12.0.0-alpha.0 (git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions)",
@@ -490,6 +513,16 @@ name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+
+[[package]]
+name = "fuzz"
+version = "0.0.0"
+dependencies = [
+ "arbitrary",
+ "driver",
+ "evmrs",
+ "libfuzzer-sys",
+]
 
 [[package]]
 name = "generic-array"
@@ -624,6 +657,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +700,16 @@ name = "libc"
 version = "0.2.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libloading"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["driver", "benchmarks", "bencher", "llvm-profile-wrappers"]
+members = ["driver", "benchmarks", "bencher", "llvm-profile-wrappers", "fuzz"]
 
 [package]
 name = "evmrs"
@@ -18,6 +18,7 @@ debug = true
 default = []
 # Flag mock enables code generation for test mocking. This allows generating mocks for other build configuration but "test". 
 mock = ["dep:mockall"]
+fuzzing = ["dep:arbitrary"]
 # partial features (enabled by other features to simplyfy conditional compilation attributes. Not intended to be used on their own)
 needs-jumptable = []
 needs-fn-ptr-conversion = ["needs-jumptable"]
@@ -52,6 +53,7 @@ evmc-vm-tosca = { package = "evmc-vm", git = "https://github.com/Fantom-foundati
 evmc-vm-tosca-refactor = { package = "evmc-vm", git = "https://github.com/LorenzSchueler/evmc", branch = "tosca-extensions-execution-message-slice-output-box", optional = true }
 sha3 = "0.10.8"
 mockall = { version = "0.13.0", optional = true }
+arbitrary = { version = "1.4.1", features = ["derive"], optional = true }
 mimalloc = { version = "0.1.43", optional = true }
 lru = { version = "0.12.5", optional = true }
 nohash-hasher = { version = "0.2.0", optional = true }

--- a/rust/fuzz/.gitignore
+++ b/rust/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/rust/fuzz/Cargo.toml
+++ b/rust/fuzz/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1.4.1" }
+evmrs = { path = "..", features = ["mock", "fuzzing"] }
+driver = { path = "../driver", features = ["mock"] }
+
+[[bin]]
+name = "evmc_execute"
+path = "fuzz_targets/evmc_execute.rs"
+test = false
+doc = false
+bench = false

--- a/rust/fuzz/fuzz_targets/evmc_execute.rs
+++ b/rust/fuzz/fuzz_targets/evmc_execute.rs
@@ -1,0 +1,212 @@
+#![no_main]
+
+use core::slice;
+use std::fmt::Debug;
+
+use arbitrary::Arbitrary;
+use driver::{host_interface::mocked_host_interface, Instance};
+use evmrs::{
+    evmc_vm::{
+        ffi::{evmc_host_interface, evmc_message},
+        AccessStatus, ExecutionResult, ExecutionTxContext, MessageKind, Revision, StatusCode,
+        StorageStatus, Uint256,
+    },
+    u256, MockExecutionContextTrait,
+};
+use libfuzzer_sys::fuzz_target;
+
+struct InterpreterArgs<'a> {
+    instance: Instance,
+    host: evmc_host_interface,
+    context: MockExecutionContextTrait,
+    revision: Revision,
+    message: evmc_message,
+    code: &'a [u8],
+}
+
+impl<'a> Debug for InterpreterArgs<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InterpreterArgs")
+            .field("host", &self.host)
+            .field("context", &self.context)
+            .field("revision", &self.revision)
+            .field("message", &self.message)
+            .field("code", &self.code)
+            .finish()
+    }
+}
+
+impl<'a> Arbitrary<'a> for InterpreterArgs<'a> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let input = <&[u8]>::arbitrary(u)?;
+        let code = <&[u8]>::arbitrary(u)?;
+        let message = evmc_message {
+            kind: u
+                .choose(&[
+                    MessageKind::EVMC_CALL,
+                    MessageKind::EVMC_CALLCODE,
+                    MessageKind::EVMC_CREATE,
+                    MessageKind::EVMC_CREATE2,
+                    MessageKind::EVMC_DELEGATECALL,
+                    MessageKind::EVMC_EOFCREATE,
+                ])?
+                .clone(),
+            flags: u32::arbitrary(u)?,
+            depth: i32::arbitrary(u)?,
+            gas: u.int_in_range(0..=500_000_000_000)?, // see go/ct/evm_fuzz_test.go
+            recipient: u256::arbitrary(u)?.into(),
+            sender: u256::arbitrary(u)?.into(),
+            input_data: input.as_ptr(),
+            input_size: input.len(),
+            value: u256::arbitrary(u)?.into(),
+            create2_salt: u256::arbitrary(u)?.into(),
+            code_address: u256::arbitrary(u)?.into(),
+            code: code.as_ptr(),
+            code_size: code.len(),
+            code_hash: std::ptr::null(),
+        };
+
+        let mut context = MockExecutionContextTrait::new();
+        let len = u.arbitrary_len::<[u8; 32]>()?;
+        let bytes = u.bytes(len * 32)?;
+        let blob_hashes: &[Uint256] =
+            unsafe { slice::from_raw_parts(bytes.as_ptr() as *const Uint256, len) };
+        let txcontext = ExecutionTxContext {
+            tx_gas_price: u256::arbitrary(u)?.into(),
+            tx_origin: u256::arbitrary(u)?.into(),
+            block_coinbase: u256::arbitrary(u)?.into(),
+            block_number: Arbitrary::arbitrary(u)?,
+            block_timestamp: Arbitrary::arbitrary(u)?,
+            block_gas_limit: Arbitrary::arbitrary(u)?,
+            block_prev_randao: u256::arbitrary(u)?.into(),
+            chain_id: u256::arbitrary(u)?.into(),
+            block_base_fee: u256::arbitrary(u)?.into(),
+            blob_base_fee: u256::arbitrary(u)?.into(),
+            blob_hashes: blob_hashes.as_ptr(),
+            blob_hashes_count: blob_hashes.len(),
+            initcodes: std::ptr::null(),
+            initcodes_count: 0,
+        };
+        context.expect_get_tx_context().return_const(txcontext);
+        context
+            .expect_account_exists()
+            .return_const(bool::arbitrary(u)?);
+        context
+            .expect_get_storage()
+            .return_const(Uint256::from(u256::arbitrary(u)?));
+        context.expect_set_storage().return_const(
+            u.choose(&[
+                StorageStatus::EVMC_STORAGE_ASSIGNED,
+                StorageStatus::EVMC_STORAGE_ADDED,
+                StorageStatus::EVMC_STORAGE_DELETED,
+                StorageStatus::EVMC_STORAGE_MODIFIED,
+                StorageStatus::EVMC_STORAGE_DELETED_ADDED,
+                StorageStatus::EVMC_STORAGE_MODIFIED_DELETED,
+                StorageStatus::EVMC_STORAGE_DELETED_RESTORED,
+                StorageStatus::EVMC_STORAGE_ADDED_DELETED,
+                StorageStatus::EVMC_STORAGE_MODIFIED_RESTORED,
+            ])?
+            .clone(),
+        );
+        context
+            .expect_get_balance()
+            .return_const(Uint256::from(u256::arbitrary(u)?));
+        context
+            .expect_get_code_size()
+            .return_const(usize::arbitrary(u)?);
+        context
+            .expect_get_code_hash()
+            .return_const(Uint256::from(u256::arbitrary(u)?));
+        context
+            .expect_copy_code()
+            .return_const(usize::arbitrary(u)?);
+        context
+            .expect_selfdestruct()
+            .return_const(bool::arbitrary(u)?);
+        let execution_result = ExecutionResult {
+            status_code: u
+                .choose(&[
+                    StatusCode::EVMC_SUCCESS,
+                    StatusCode::EVMC_FAILURE,
+                    StatusCode::EVMC_REVERT,
+                    StatusCode::EVMC_OUT_OF_GAS,
+                    StatusCode::EVMC_INVALID_INSTRUCTION,
+                    StatusCode::EVMC_UNDEFINED_INSTRUCTION,
+                    StatusCode::EVMC_STACK_OVERFLOW,
+                    StatusCode::EVMC_STACK_UNDERFLOW,
+                    StatusCode::EVMC_BAD_JUMP_DESTINATION,
+                    StatusCode::EVMC_INVALID_MEMORY_ACCESS,
+                    StatusCode::EVMC_CALL_DEPTH_EXCEEDED,
+                    StatusCode::EVMC_STATIC_MODE_VIOLATION,
+                    StatusCode::EVMC_PRECOMPILE_FAILURE,
+                    StatusCode::EVMC_CONTRACT_VALIDATION_FAILURE,
+                    StatusCode::EVMC_ARGUMENT_OUT_OF_RANGE,
+                    StatusCode::EVMC_WASM_UNREACHABLE_INSTRUCTION,
+                    StatusCode::EVMC_WASM_TRAP,
+                    StatusCode::EVMC_INSUFFICIENT_BALANCE,
+                    StatusCode::EVMC_INTERNAL_ERROR,
+                    StatusCode::EVMC_REJECTED,
+                    StatusCode::EVMC_OUT_OF_MEMORY,
+                ])?
+                .clone(),
+            gas_left: Arbitrary::arbitrary(u)?,
+            gas_refund: Arbitrary::arbitrary(u)?,
+            output: Arbitrary::arbitrary(u)?,
+            create_address: Option::<u256>::arbitrary(u)?.map(Into::into),
+        };
+        let clone_result = move || ExecutionResult {
+            status_code: execution_result.status_code,
+            gas_left: execution_result.gas_left,
+            gas_refund: execution_result.gas_refund,
+            output: execution_result.output.clone(),
+            create_address: execution_result.create_address,
+        };
+        context.expect_call().returning(move |_| clone_result());
+        context
+            .expect_get_block_hash()
+            .return_const(Uint256::from(u256::arbitrary(u)?));
+        let _ = context.expect_emit_log().return_const(());
+        context.expect_access_account().return_const(
+            u.choose(&[
+                AccessStatus::EVMC_ACCESS_COLD,
+                AccessStatus::EVMC_ACCESS_WARM,
+            ])?
+            .clone(),
+        );
+        context.expect_access_storage().return_const(
+            u.choose(&[
+                AccessStatus::EVMC_ACCESS_COLD,
+                AccessStatus::EVMC_ACCESS_WARM,
+            ])?
+            .clone(),
+        );
+        context
+            .expect_get_transient_storage()
+            .return_const(Uint256::from(u256::arbitrary(u)?));
+        let _ = context.expect_set_transient_storage().return_const(());
+
+        let args = Self {
+            instance: Instance::default(),
+            host: mocked_host_interface(),
+            context,
+            revision: unsafe { std::mem::transmute(u.int_in_range(0..=14)?) },
+            message,
+            code: Arbitrary::arbitrary(u)?,
+        };
+        Ok(args)
+    }
+}
+
+fuzz_target!(|args: InterpreterArgs| {
+    let mut args = args; // fuzz_target does not accept mutable arguments
+
+    // Note: cargo-fuzz compiles with -Cpanic=abort so the catch_unwind in evmrs::ffi no longer
+    // catches panics.
+    let _result = args.instance.run(
+        &args.host,
+        &mut args.context,
+        args.revision,
+        &args.message,
+        &args.code,
+    );
+});

--- a/rust/src/types/amount.rs
+++ b/rust/src/types/amount.rs
@@ -7,6 +7,8 @@ use std::{
     },
 };
 
+#[cfg(feature = "fuzzing")]
+use arbitrary::Arbitrary;
 use bnum::types::{I256, U256, U512};
 use evmc_vm::{Address, Uint256};
 use zerocopy::{transmute, transmute_ref, FromBytes, Immutable, IntoBytes};
@@ -14,6 +16,7 @@ use zerocopy::{transmute, transmute_ref, FromBytes, Immutable, IntoBytes};
 /// This represents a 256-bit integer. Internally it is a 32 byte array of [`u8`] in big endian.
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, FromBytes, IntoBytes, Immutable)]
+#[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
 #[repr(align(8))]
 pub struct u256([u8; 32]);
 

--- a/rust/src/types/memory.rs
+++ b/rust/src/types/memory.rs
@@ -130,15 +130,15 @@ mod tests {
     #[test]
     fn expand() {
         let mut memory = Memory::new(Vec::new());
-        assert_eq!(memory.expand(1, &mut Gas::new(1_000)), Ok(()));
+        assert_eq!(memory.expand(1, &mut Gas::try_new(1_000).unwrap()), Ok(()));
         assert_eq!(memory.into_inner(), [0; 32]);
 
         let mut memory = Memory::new(Vec::new());
-        assert_eq!(memory.expand(32, &mut Gas::new(1_000)), Ok(()));
+        assert_eq!(memory.expand(32, &mut Gas::try_new(1_000).unwrap()), Ok(()));
         assert_eq!(memory.into_inner(), [0; 32]);
 
         let mut memory = Memory::new(vec![1; 32]);
-        assert_eq!(memory.expand(64, &mut Gas::new(1_000)), Ok(()));
+        assert_eq!(memory.expand(64, &mut Gas::try_new(1_000).unwrap()), Ok(()));
         assert_eq!(memory.into_inner(), {
             let mut mem = [1; 64];
             mem[32..].copy_from_slice(&[0; 32]);
@@ -147,7 +147,7 @@ mod tests {
 
         let mut memory = Memory::new(Vec::new());
         assert_eq!(
-            memory.expand(u64::MAX, &mut Gas::new(1_000)),
+            memory.expand(u64::MAX, &mut Gas::try_new(1_000).unwrap()),
             Err(FailStatus::OutOfGas)
         );
     }
@@ -155,30 +155,30 @@ mod tests {
     #[test]
     fn consume_expansion_cost() {
         let memory = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(0);
+        let mut gas_left = Gas::try_new(0).unwrap();
         assert_eq!(memory.consume_expansion_cost(0, &mut gas_left), Ok(()));
         assert_eq!(gas_left, 0);
 
-        let mut gas_left = Gas::new(3);
+        let mut gas_left = Gas::try_new(3).unwrap();
         assert_eq!(memory.consume_expansion_cost(1, &mut gas_left), Ok(()));
         assert_eq!(gas_left, 0);
 
-        let mut gas_left = Gas::new(3);
+        let mut gas_left = Gas::try_new(3).unwrap();
         assert_eq!(memory.consume_expansion_cost(32, &mut gas_left), Ok(()));
         assert_eq!(gas_left, 0);
 
         let memory = Memory::new(vec![0; 32]);
-        let mut gas_left = Gas::new(3);
+        let mut gas_left = Gas::try_new(3).unwrap();
         assert_eq!(memory.consume_expansion_cost(64, &mut gas_left), Ok(()));
         assert_eq!(gas_left, 0);
 
         assert_eq!(
-            memory.consume_expansion_cost(u64::MAX, &mut Gas::new(10_000)),
+            memory.consume_expansion_cost(u64::MAX, &mut Gas::try_new(10_000).unwrap()),
             Err(FailStatus::OutOfGas)
         );
 
         assert_eq!(
-            memory.consume_expansion_cost(u64::MAX / 100, &mut Gas::new(10_000)),
+            memory.consume_expansion_cost(u64::MAX / 100, &mut Gas::try_new(10_000).unwrap()),
             Err(FailStatus::OutOfGas)
         );
     }
@@ -186,21 +186,21 @@ mod tests {
     #[test]
     fn get_mut_slice() {
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(0);
+        let mut gas_left = Gas::try_new(0).unwrap();
         assert_eq!(
             mem.get_mut_slice(u256::ZERO, 0, &mut gas_left),
             Ok([].as_mut_slice())
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(0);
+        let mut gas_left = Gas::try_new(0).unwrap();
         assert_eq!(
             mem.get_mut_slice(u256::ZERO, 1, &mut gas_left),
             Err(FailStatus::OutOfGas)
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(3);
+        let mut gas_left = Gas::try_new(3).unwrap();
         assert_eq!(
             mem.get_mut_slice(u256::ZERO, 1, &mut gas_left),
             Ok([0].as_mut_slice())
@@ -208,7 +208,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(3);
+        let mut gas_left = Gas::try_new(3).unwrap();
         assert_eq!(
             mem.get_mut_slice(u256::ZERO, 32, &mut gas_left),
             Ok([0; 32].as_mut_slice())
@@ -216,7 +216,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(6);
+        let mut gas_left = Gas::try_new(6).unwrap();
         assert_eq!(
             mem.get_mut_slice(u256::ZERO, 32 + 1, &mut gas_left),
             Ok([0; 32 + 1].as_mut_slice())
@@ -224,14 +224,14 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::new(0);
+        let mut gas_left = Gas::try_new(0).unwrap();
         assert_eq!(
             mem.get_mut_slice(u256::ZERO, 1, &mut gas_left),
             Ok([1].as_mut_slice())
         );
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::new(0);
+        let mut gas_left = Gas::try_new(0).unwrap();
         assert_eq!(
             mem.get_mut_slice(u256::ZERO, 32, &mut gas_left),
             Ok([1; 32].as_mut_slice())
@@ -239,7 +239,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::new(3);
+        let mut gas_left = Gas::try_new(3).unwrap();
         let mut result = [1; 32 + 1];
         result[32] = 0;
         assert_eq!(
@@ -249,7 +249,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32 * 2]);
-        let mut gas_left = Gas::new(3);
+        let mut gas_left = Gas::try_new(3).unwrap();
         let mut result = [1; 32 * 2];
         result[32..].copy_from_slice(&[0; 32]);
         assert_eq!(
@@ -259,7 +259,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(1_000_000);
+        let mut gas_left = Gas::try_new(1_000_000).unwrap();
         assert_eq!(
             mem.get_mut_slice(u256::MAX, 1, &mut gas_left),
             Err(FailStatus::OutOfGas)
@@ -269,29 +269,29 @@ mod tests {
     #[test]
     fn get_word() {
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(0);
+        let mut gas_left = Gas::try_new(0).unwrap();
         assert_eq!(
             mem.get_word(u256::ZERO, &mut gas_left),
             Err(FailStatus::OutOfGas)
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(3);
+        let mut gas_left = Gas::try_new(3).unwrap();
         assert_eq!(mem.get_word(u256::ZERO, &mut gas_left), Ok(u256::ZERO));
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(6);
+        let mut gas_left = Gas::try_new(6).unwrap();
         assert_eq!(mem.get_word(u256::ONE, &mut gas_left), Ok(u256::ZERO));
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![0xff; 32]);
-        let mut gas_left = Gas::new(0);
+        let mut gas_left = Gas::try_new(0).unwrap();
         assert_eq!(mem.get_word(u256::ZERO, &mut gas_left), Ok(u256::MAX));
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![0xff; 32]);
-        let mut gas_left = Gas::new(3);
+        let mut gas_left = Gas::try_new(3).unwrap();
         assert_eq!(mem.get_word(32u8.into(), &mut gas_left), Ok(u256::ZERO));
         assert_eq!(gas_left, 0);
     }
@@ -299,29 +299,29 @@ mod tests {
     #[test]
     fn get_byte() {
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(0);
+        let mut gas_left = Gas::try_new(0).unwrap();
         assert_eq!(
             mem.get_mut_byte(u256::ZERO, &mut gas_left),
             Err(FailStatus::OutOfGas)
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(3);
+        let mut gas_left = Gas::try_new(3).unwrap();
         assert_eq!(mem.get_mut_byte(u256::ZERO, &mut gas_left), Ok(&mut 0));
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(6);
+        let mut gas_left = Gas::try_new(6).unwrap();
         assert_eq!(mem.get_mut_byte(32u8.into(), &mut gas_left), Ok(&mut 0));
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::new(0);
+        let mut gas_left = Gas::try_new(0).unwrap();
         assert_eq!(mem.get_mut_byte(u256::ZERO, &mut gas_left), Ok(&mut 1));
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::new(3);
+        let mut gas_left = Gas::try_new(3).unwrap();
         assert_eq!(mem.get_mut_byte(32u8.into(), &mut gas_left), Ok(&mut 0));
         assert_eq!(gas_left, 0);
     }
@@ -329,42 +329,42 @@ mod tests {
     #[test]
     fn copy_within() {
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(0);
+        let mut gas_left = Gas::try_new(0).unwrap();
         assert_eq!(
             mem.copy_within(u256::ZERO, u256::ZERO, u256::ZERO, &mut gas_left),
             Ok(())
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(0);
+        let mut gas_left = Gas::try_new(0).unwrap();
         assert_eq!(
             mem.copy_within(u256::ONE, u256::ZERO, u256::ZERO, &mut gas_left),
             Err(FailStatus::OutOfGas)
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(0);
+        let mut gas_left = Gas::try_new(0).unwrap();
         assert_eq!(
             mem.copy_within(u256::ZERO, u256::ONE, u256::ZERO, &mut gas_left),
             Err(FailStatus::OutOfGas)
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(0);
+        let mut gas_left = Gas::try_new(0).unwrap();
         assert_eq!(
             mem.copy_within(u256::ZERO, u256::ZERO, u256::ONE, &mut gas_left),
             Err(FailStatus::OutOfGas)
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(1_000_000);
+        let mut gas_left = Gas::try_new(1_000_000).unwrap();
         assert_eq!(
             mem.copy_within(u256::MAX, u256::ZERO, u256::ZERO, &mut gas_left),
             Err(FailStatus::OutOfGas)
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::new(3 + 3);
+        let mut gas_left = Gas::try_new(3 + 3).unwrap();
         assert_eq!(
             mem.copy_within(u256::ZERO, u256::ZERO, u256::ONE, &mut gas_left),
             Ok(())
@@ -372,7 +372,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::new(3);
+        let mut gas_left = Gas::try_new(3).unwrap();
         assert_eq!(
             mem.copy_within(u256::ZERO, u256::ZERO, u256::ONE, &mut gas_left),
             Ok(())
@@ -380,7 +380,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::new(3 + 6);
+        let mut gas_left = Gas::try_new(3 + 6).unwrap();
         assert_eq!(
             mem.copy_within(u256::ZERO, u256::ZERO, 33u8.into(), &mut gas_left),
             Ok(())
@@ -388,7 +388,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::new(3 + 3);
+        let mut gas_left = Gas::try_new(3 + 3).unwrap();
         assert_eq!(
             mem.copy_within(32u8.into(), u256::ZERO, u256::ONE, &mut gas_left),
             Ok(())
@@ -396,7 +396,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::new(3 + 3);
+        let mut gas_left = Gas::try_new(3 + 3).unwrap();
         assert_eq!(
             mem.copy_within(u256::ZERO, 32u8.into(), u256::ONE, &mut gas_left),
             Ok(())

--- a/rust/src/utils/helpers.rs
+++ b/rust/src/utils/helpers.rs
@@ -92,27 +92,39 @@ mod tests {
     fn copy_padded() {
         let src = [];
         let mut dest = [];
-        assert_eq!(dest.copy_padded(&src, &mut Gas::new(1_000_000)), Ok(()));
+        assert_eq!(
+            dest.copy_padded(&src, &mut Gas::try_new(1_000_000).unwrap()),
+            Ok(())
+        );
 
         let src = [];
         let mut dest = [1];
-        assert_eq!(dest.copy_padded(&src, &mut Gas::new(1_000_000)), Ok(()));
+        assert_eq!(
+            dest.copy_padded(&src, &mut Gas::try_new(1_000_000).unwrap()),
+            Ok(())
+        );
         assert_eq!(dest, [0]);
 
         let src = [2];
         let mut dest = [1];
-        assert_eq!(dest.copy_padded(&src, &mut Gas::new(1_000_000)), Ok(()));
+        assert_eq!(
+            dest.copy_padded(&src, &mut Gas::try_new(1_000_000).unwrap()),
+            Ok(())
+        );
         assert_eq!(dest, [2]);
 
         let src = [3];
         let mut dest = [1, 2];
-        assert_eq!(dest.copy_padded(&src, &mut Gas::new(1_000_000)), Ok(()));
+        assert_eq!(
+            dest.copy_padded(&src, &mut Gas::try_new(1_000_000).unwrap()),
+            Ok(())
+        );
         assert_eq!(dest, [3, 0]);
 
         let src = [2];
         let mut dest = [1];
         assert_eq!(
-            dest.copy_padded(&src, &mut Gas::new(0)),
+            dest.copy_padded(&src, &mut Gas::try_new(0).unwrap()),
             Err(FailStatus::OutOfGas)
         );
     }
@@ -146,7 +158,8 @@ mod tests {
     fn check_not_read_only() {
         let message = MockExecutionMessage::default().into();
         let mut context = MockExecutionContextTrait::new();
-        let interpreter = Interpreter::new(Revision::EVMC_CANCUN, &message, &mut context, &[]);
+        let interpreter =
+            Interpreter::try_new(Revision::EVMC_CANCUN, &message, &mut context, &[]).unwrap();
         assert_eq!(utils::check_not_read_only(&interpreter), Ok(()));
 
         let message = MockExecutionMessage {
@@ -154,7 +167,8 @@ mod tests {
             ..Default::default()
         };
         let message = message.into();
-        let interpreter = Interpreter::new(Revision::EVMC_CANCUN, &message, &mut context, &[]);
+        let interpreter =
+            Interpreter::try_new(Revision::EVMC_CANCUN, &message, &mut context, &[]).unwrap();
         assert_eq!(
             utils::check_not_read_only(&interpreter),
             Err(FailStatus::StaticModeViolation)


### PR DESCRIPTION
- add a fuzzer target for the evmc execute interface
- run fuzzer in CI (10s only) to make sure setup works
- document in BUILD.md how to run miri and fuzzer
- handle gas over-/underflow
- add GasRefund type