### PR TITLE
evmrs: optimize u256 <-> U256 conversion

### DIFF
--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -1378,8 +1378,6 @@ impl<'a> Interpreter<'a> {
         let [len, offset] = self.stack.pop()?;
         let len = u64::try_from(len).map_err(|_| FailStatus::OutOfGas)?;
         let data = self.memory.get_mut_slice(offset, len, &mut self.gas_left)?;
-        // TODO revert self changes
-        // gas_refund = original_gas_refund;
         #[cfg(not(feature = "custom-evmc"))]
         {
             self.output = Some(data.to_owned());


### PR DESCRIPTION
This PR optimizes the conversions u256 <-> U256.
The conversion u256 -> U256 before had a call (because for what ever reason U256::from_be_slice was not inlined) and a jump (for the unwrap). Both of those are now gone.
Additionally the conversions u256 <-> U256 are now also used for the conversions u256 <-> I256 and u256 <-> U512.

Unfortunately this does not improve performance, however I think it is still worth changing.