### PR TITLE
evmrs: fix performance regression introduced in #942

### DIFF
--- a/rust/src/evmc.rs
+++ b/rust/src/evmc.rs
@@ -42,10 +42,7 @@ impl EvmcVm for EvmRs {
             // If this is not the case it violates the EVMC spec and is an irrecoverable error.
             process::abort();
         };
-        let mut interpreter = match Interpreter::try_new(revision, message, context, code) {
-            Ok(interpreter) => interpreter,
-            Err(fail_status) => return ExecutionResult::from(fail_status),
-        };
+        let mut interpreter = Interpreter::new(revision, message, context, code);
         let run_result = match self.observer_type {
             ObserverType::NoOp => interpreter.run::<_, STEP_CHECK, JUMPDESTS>(&mut NoOpObserver()),
             ObserverType::Logging => interpreter
@@ -119,7 +116,7 @@ impl SteppableEvmcVm for EvmRs {
         };
         let stack = Stack::new(&stack.iter().map(|i| u256::from(*i)).collect::<Vec<_>>());
         let memory = Memory::new(memory.to_owned());
-        let mut interpreter = match Interpreter::try_new_steppable(
+        let mut interpreter = Interpreter::new_steppable(
             revision,
             message,
             context,
@@ -130,10 +127,7 @@ impl SteppableEvmcVm for EvmRs {
             memory,
             Some(last_call_return_data.to_owned()),
             Some(steps),
-        ) {
-            Ok(interpreter) => interpreter,
-            Err(fail_status) => return StepResult::from(fail_status),
-        };
+        );
         let run_result = match self.observer_type {
             ObserverType::NoOp => interpreter.run::<_, STEP_CHECK, JUMPDESTS>(&mut NoOpObserver()),
             ObserverType::Logging => interpreter

--- a/rust/src/types/memory.rs
+++ b/rust/src/types/memory.rs
@@ -130,15 +130,15 @@ mod tests {
     #[test]
     fn expand() {
         let mut memory = Memory::new(Vec::new());
-        assert_eq!(memory.expand(1, &mut Gas::try_new(1_000).unwrap()), Ok(()));
+        assert_eq!(memory.expand(1, &mut Gas::new(1_000)), Ok(()));
         assert_eq!(memory.into_inner(), [0; 32]);
 
         let mut memory = Memory::new(Vec::new());
-        assert_eq!(memory.expand(32, &mut Gas::try_new(1_000).unwrap()), Ok(()));
+        assert_eq!(memory.expand(32, &mut Gas::new(1_000)), Ok(()));
         assert_eq!(memory.into_inner(), [0; 32]);
 
         let mut memory = Memory::new(vec![1; 32]);
-        assert_eq!(memory.expand(64, &mut Gas::try_new(1_000).unwrap()), Ok(()));
+        assert_eq!(memory.expand(64, &mut Gas::new(1_000)), Ok(()));
         assert_eq!(memory.into_inner(), {
             let mut mem = [1; 64];
             mem[32..].copy_from_slice(&[0; 32]);
@@ -147,7 +147,7 @@ mod tests {
 
         let mut memory = Memory::new(Vec::new());
         assert_eq!(
-            memory.expand(u64::MAX, &mut Gas::try_new(1_000).unwrap()),
+            memory.expand(u64::MAX, &mut Gas::new(1_000)),
             Err(FailStatus::OutOfGas)
         );
     }
@@ -155,30 +155,30 @@ mod tests {
     #[test]
     fn consume_expansion_cost() {
         let memory = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(0).unwrap();
+        let mut gas_left = Gas::new(0);
         assert_eq!(memory.consume_expansion_cost(0, &mut gas_left), Ok(()));
         assert_eq!(gas_left, 0);
 
-        let mut gas_left = Gas::try_new(3).unwrap();
+        let mut gas_left = Gas::new(3);
         assert_eq!(memory.consume_expansion_cost(1, &mut gas_left), Ok(()));
         assert_eq!(gas_left, 0);
 
-        let mut gas_left = Gas::try_new(3).unwrap();
+        let mut gas_left = Gas::new(3);
         assert_eq!(memory.consume_expansion_cost(32, &mut gas_left), Ok(()));
         assert_eq!(gas_left, 0);
 
         let memory = Memory::new(vec![0; 32]);
-        let mut gas_left = Gas::try_new(3).unwrap();
+        let mut gas_left = Gas::new(3);
         assert_eq!(memory.consume_expansion_cost(64, &mut gas_left), Ok(()));
         assert_eq!(gas_left, 0);
 
         assert_eq!(
-            memory.consume_expansion_cost(u64::MAX, &mut Gas::try_new(10_000).unwrap()),
+            memory.consume_expansion_cost(u64::MAX, &mut Gas::new(10_000)),
             Err(FailStatus::OutOfGas)
         );
 
         assert_eq!(
-            memory.consume_expansion_cost(u64::MAX / 100, &mut Gas::try_new(10_000).unwrap()),
+            memory.consume_expansion_cost(u64::MAX / 100, &mut Gas::new(10_000)),
             Err(FailStatus::OutOfGas)
         );
     }
@@ -186,21 +186,21 @@ mod tests {
     #[test]
     fn get_mut_slice() {
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(0).unwrap();
+        let mut gas_left = Gas::new(0);
         assert_eq!(
             mem.get_mut_slice(u256::ZERO, 0, &mut gas_left),
             Ok([].as_mut_slice())
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(0).unwrap();
+        let mut gas_left = Gas::new(0);
         assert_eq!(
             mem.get_mut_slice(u256::ZERO, 1, &mut gas_left),
             Err(FailStatus::OutOfGas)
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(3).unwrap();
+        let mut gas_left = Gas::new(3);
         assert_eq!(
             mem.get_mut_slice(u256::ZERO, 1, &mut gas_left),
             Ok([0].as_mut_slice())
@@ -208,7 +208,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(3).unwrap();
+        let mut gas_left = Gas::new(3);
         assert_eq!(
             mem.get_mut_slice(u256::ZERO, 32, &mut gas_left),
             Ok([0; 32].as_mut_slice())
@@ -216,7 +216,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(6).unwrap();
+        let mut gas_left = Gas::new(6);
         assert_eq!(
             mem.get_mut_slice(u256::ZERO, 32 + 1, &mut gas_left),
             Ok([0; 32 + 1].as_mut_slice())
@@ -224,14 +224,14 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::try_new(0).unwrap();
+        let mut gas_left = Gas::new(0);
         assert_eq!(
             mem.get_mut_slice(u256::ZERO, 1, &mut gas_left),
             Ok([1].as_mut_slice())
         );
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::try_new(0).unwrap();
+        let mut gas_left = Gas::new(0);
         assert_eq!(
             mem.get_mut_slice(u256::ZERO, 32, &mut gas_left),
             Ok([1; 32].as_mut_slice())
@@ -239,7 +239,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::try_new(3).unwrap();
+        let mut gas_left = Gas::new(3);
         let mut result = [1; 32 + 1];
         result[32] = 0;
         assert_eq!(
@@ -249,7 +249,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32 * 2]);
-        let mut gas_left = Gas::try_new(3).unwrap();
+        let mut gas_left = Gas::new(3);
         let mut result = [1; 32 * 2];
         result[32..].copy_from_slice(&[0; 32]);
         assert_eq!(
@@ -259,7 +259,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(1_000_000).unwrap();
+        let mut gas_left = Gas::new(1_000_000);
         assert_eq!(
             mem.get_mut_slice(u256::MAX, 1, &mut gas_left),
             Err(FailStatus::OutOfGas)
@@ -269,29 +269,29 @@ mod tests {
     #[test]
     fn get_word() {
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(0).unwrap();
+        let mut gas_left = Gas::new(0);
         assert_eq!(
             mem.get_word(u256::ZERO, &mut gas_left),
             Err(FailStatus::OutOfGas)
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(3).unwrap();
+        let mut gas_left = Gas::new(3);
         assert_eq!(mem.get_word(u256::ZERO, &mut gas_left), Ok(u256::ZERO));
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(6).unwrap();
+        let mut gas_left = Gas::new(6);
         assert_eq!(mem.get_word(u256::ONE, &mut gas_left), Ok(u256::ZERO));
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![0xff; 32]);
-        let mut gas_left = Gas::try_new(0).unwrap();
+        let mut gas_left = Gas::new(0);
         assert_eq!(mem.get_word(u256::ZERO, &mut gas_left), Ok(u256::MAX));
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![0xff; 32]);
-        let mut gas_left = Gas::try_new(3).unwrap();
+        let mut gas_left = Gas::new(3);
         assert_eq!(mem.get_word(32u8.into(), &mut gas_left), Ok(u256::ZERO));
         assert_eq!(gas_left, 0);
     }
@@ -299,29 +299,29 @@ mod tests {
     #[test]
     fn get_byte() {
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(0).unwrap();
+        let mut gas_left = Gas::new(0);
         assert_eq!(
             mem.get_mut_byte(u256::ZERO, &mut gas_left),
             Err(FailStatus::OutOfGas)
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(3).unwrap();
+        let mut gas_left = Gas::new(3);
         assert_eq!(mem.get_mut_byte(u256::ZERO, &mut gas_left), Ok(&mut 0));
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(6).unwrap();
+        let mut gas_left = Gas::new(6);
         assert_eq!(mem.get_mut_byte(32u8.into(), &mut gas_left), Ok(&mut 0));
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::try_new(0).unwrap();
+        let mut gas_left = Gas::new(0);
         assert_eq!(mem.get_mut_byte(u256::ZERO, &mut gas_left), Ok(&mut 1));
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::try_new(3).unwrap();
+        let mut gas_left = Gas::new(3);
         assert_eq!(mem.get_mut_byte(32u8.into(), &mut gas_left), Ok(&mut 0));
         assert_eq!(gas_left, 0);
     }
@@ -329,42 +329,42 @@ mod tests {
     #[test]
     fn copy_within() {
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(0).unwrap();
+        let mut gas_left = Gas::new(0);
         assert_eq!(
             mem.copy_within(u256::ZERO, u256::ZERO, u256::ZERO, &mut gas_left),
             Ok(())
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(0).unwrap();
+        let mut gas_left = Gas::new(0);
         assert_eq!(
             mem.copy_within(u256::ONE, u256::ZERO, u256::ZERO, &mut gas_left),
             Err(FailStatus::OutOfGas)
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(0).unwrap();
+        let mut gas_left = Gas::new(0);
         assert_eq!(
             mem.copy_within(u256::ZERO, u256::ONE, u256::ZERO, &mut gas_left),
             Err(FailStatus::OutOfGas)
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(0).unwrap();
+        let mut gas_left = Gas::new(0);
         assert_eq!(
             mem.copy_within(u256::ZERO, u256::ZERO, u256::ONE, &mut gas_left),
             Err(FailStatus::OutOfGas)
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(1_000_000).unwrap();
+        let mut gas_left = Gas::new(1_000_000);
         assert_eq!(
             mem.copy_within(u256::MAX, u256::ZERO, u256::ZERO, &mut gas_left),
             Err(FailStatus::OutOfGas)
         );
 
         let mut mem = Memory::new(Vec::new());
-        let mut gas_left = Gas::try_new(3 + 3).unwrap();
+        let mut gas_left = Gas::new(3 + 3);
         assert_eq!(
             mem.copy_within(u256::ZERO, u256::ZERO, u256::ONE, &mut gas_left),
             Ok(())
@@ -372,7 +372,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::try_new(3).unwrap();
+        let mut gas_left = Gas::new(3);
         assert_eq!(
             mem.copy_within(u256::ZERO, u256::ZERO, u256::ONE, &mut gas_left),
             Ok(())
@@ -380,7 +380,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::try_new(3 + 6).unwrap();
+        let mut gas_left = Gas::new(3 + 6);
         assert_eq!(
             mem.copy_within(u256::ZERO, u256::ZERO, 33u8.into(), &mut gas_left),
             Ok(())
@@ -388,7 +388,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::try_new(3 + 3).unwrap();
+        let mut gas_left = Gas::new(3 + 3);
         assert_eq!(
             mem.copy_within(32u8.into(), u256::ZERO, u256::ONE, &mut gas_left),
             Ok(())
@@ -396,7 +396,7 @@ mod tests {
         assert_eq!(gas_left, 0);
 
         let mut mem = Memory::new(vec![1; 32]);
-        let mut gas_left = Gas::try_new(3 + 3).unwrap();
+        let mut gas_left = Gas::new(3 + 3);
         assert_eq!(
             mem.copy_within(u256::ZERO, 32u8.into(), u256::ONE, &mut gas_left),
             Ok(())

--- a/rust/src/utils/helpers.rs
+++ b/rust/src/utils/helpers.rs
@@ -92,39 +92,27 @@ mod tests {
     fn copy_padded() {
         let src = [];
         let mut dest = [];
-        assert_eq!(
-            dest.copy_padded(&src, &mut Gas::try_new(1_000_000).unwrap()),
-            Ok(())
-        );
+        assert_eq!(dest.copy_padded(&src, &mut Gas::new(1_000_000)), Ok(()));
 
         let src = [];
         let mut dest = [1];
-        assert_eq!(
-            dest.copy_padded(&src, &mut Gas::try_new(1_000_000).unwrap()),
-            Ok(())
-        );
+        assert_eq!(dest.copy_padded(&src, &mut Gas::new(1_000_000)), Ok(()));
         assert_eq!(dest, [0]);
 
         let src = [2];
         let mut dest = [1];
-        assert_eq!(
-            dest.copy_padded(&src, &mut Gas::try_new(1_000_000).unwrap()),
-            Ok(())
-        );
+        assert_eq!(dest.copy_padded(&src, &mut Gas::new(1_000_000)), Ok(()));
         assert_eq!(dest, [2]);
 
         let src = [3];
         let mut dest = [1, 2];
-        assert_eq!(
-            dest.copy_padded(&src, &mut Gas::try_new(1_000_000).unwrap()),
-            Ok(())
-        );
+        assert_eq!(dest.copy_padded(&src, &mut Gas::new(1_000_000)), Ok(()));
         assert_eq!(dest, [3, 0]);
 
         let src = [2];
         let mut dest = [1];
         assert_eq!(
-            dest.copy_padded(&src, &mut Gas::try_new(0).unwrap()),
+            dest.copy_padded(&src, &mut Gas::new(0)),
             Err(FailStatus::OutOfGas)
         );
     }
@@ -158,8 +146,7 @@ mod tests {
     fn check_not_read_only() {
         let message = MockExecutionMessage::default().into();
         let mut context = MockExecutionContextTrait::new();
-        let interpreter =
-            Interpreter::try_new(Revision::EVMC_CANCUN, &message, &mut context, &[]).unwrap();
+        let interpreter = Interpreter::new(Revision::EVMC_CANCUN, &message, &mut context, &[]);
         assert_eq!(utils::check_not_read_only(&interpreter), Ok(()));
 
         let message = MockExecutionMessage {
@@ -167,8 +154,7 @@ mod tests {
             ..Default::default()
         };
         let message = message.into();
-        let interpreter =
-            Interpreter::try_new(Revision::EVMC_CANCUN, &message, &mut context, &[]).unwrap();
+        let interpreter = Interpreter::new(Revision::EVMC_CANCUN, &message, &mut context, &[]);
         assert_eq!(
             utils::check_not_read_only(&interpreter),
             Err(FailStatus::StaticModeViolation)


### PR DESCRIPTION
This PR fixes a performance regression introduced in #942. It mainly affected the static overhead and therefore all short benchmarks.

Instead of returning an error when the gas is negative, the gas is now just set to 0 and will then return out-of-gas error once the first opcode is executed. This has the advantage that the case for negative gas no longer needs to be handled explicitly.