### PR TITLE
evmrs: set alignment of u256 to 16

### DIFF
--- a/rust/src/types/amount.rs
+++ b/rust/src/types/amount.rs
@@ -20,7 +20,7 @@ use zerocopy::{transmute, transmute_ref, FromBytes, Immutable, IntoBytes};
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, FromBytes, IntoBytes, Immutable)]
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
-#[repr(align(8))]
+#[repr(align(16))] // 16 byte alignment is faster than 1, 8 or 32 byte alignment on x86-64.
 pub struct u256([u8; 32]);
 
 impl Deref for u256 {


### PR DESCRIPTION
This PR sets the alignment of u256 to 16 bytes. This is faster than 8 or 32 byte alignment.
The reason for being faster than 32 byte alignment seems to be that on x86, stacks are 16 byte aligned. When using 32 byte alignment the stack has to be realigned which is not necessary for 16 byte alignment.

Comparison with 8 byte alignment:
```
                   │ 2024-11-24T14:47#fbcd8b2#20/evmrs#performance │ 2024-11-24T15:08#fbcd8b2#20-align16/evmrs#performance │
                   │                    sec/op                     │            sec/op              vs base                │
StaticOverhead/1/                                      2.464µ ± 1%                     2.441µ ± 1%   -0.91% (p=0.015 n=20)
Inc/1/                                                 5.263µ ± 0%                     5.116µ ± 0%   -2.78% (p=0.000 n=20)
Inc/10/                                                5.269µ ± 0%                     5.115µ ± 0%   -2.93% (p=0.000 n=20)
Fib/1/                                                 4.804µ ± 0%                     4.606µ ± 0%   -4.12% (p=0.000 n=20)
Fib/5/                                                 16.72µ ± 0%                     14.48µ ± 0%  -13.37% (p=0.000 n=20)
Fib/10/                                                168.5µ ± 0%                     136.4µ ± 0%  -19.05% (p=0.000 n=20)
Fib/15/                                                1.703m ± 0%                     1.299m ± 0%  -23.75% (p=0.000 n=20)
Fib/20/                                                25.32m ± 0%                     14.00m ± 0%  -44.72% (p=0.000 n=20)
Sha3/1/                                                2.904µ ± 0%                     2.856µ ± 0%   -1.67% (p=0.000 n=20)
Sha3/10/                                               4.652µ ± 1%                     4.648µ ± 0%        ~ (p=0.625 n=20)
Sha3/100/                                              21.28µ ± 0%                     21.06µ ± 0%   -1.04% (p=0.000 n=20)
Sha3/1000/                                             215.3µ ± 0%                     215.4µ ± 0%        ~ (p=0.104 n=20)
Arith/1/                                               6.090µ ± 0%                     5.814µ ± 0%   -4.52% (p=0.000 n=20)
Arith/10/                                              12.80µ ± 0%                     12.08µ ± 0%   -5.63% (p=0.000 n=20)
Arith/100/                                             86.51µ ± 0%                     75.38µ ± 0%  -12.87% (p=0.000 n=20)
Arith/280/                                             237.5µ ± 0%                     222.3µ ± 0%   -6.40% (p=0.000 n=20)
Memory/1/                                              8.360µ ± 1%                     8.262µ ± 1%   -1.17% (p=0.006 n=20)
Memory/10/                                             15.19µ ± 0%                     14.75µ ± 0%   -2.89% (p=0.000 n=20)
Memory/100/                                            87.25µ ± 0%                     86.02µ ± 0%   -1.41% (p=0.000 n=20)
Memory/1000/                                           721.4µ ± 0%                     719.5µ ± 0%   -0.26% (p=0.000 n=20)
Memory/10000/                                          6.993m ± 0%                     6.915m ± 0%   -1.12% (p=0.000 n=20)
Analysis/jumpdest/                                     2.498µ ± 0%                     2.493µ ± 0%        ~ (p=0.256 n=20)
Analysis/stop/                                         2.493µ ± 0%                     2.508µ ± 0%   +0.62% (p=0.002 n=20)
Analysis/push1/                                        2.486µ ± 0%                     2.485µ ± 0%        ~ (p=0.516 n=20)
Analysis/push32/                                       2.484µ ± 0%                     2.486µ ± 0%        ~ (p=0.143 n=20)
geomean                                                30.00µ                          28.00µ        -6.68%
```