### PR TITLE
evmrs: remove feature stack-array and add feature unsafe-stack

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ needs-cache = ["dep:lru"]
 # optimizations:
 performance = [
     "mimalloc",
-    "stack-array",
+    "unsafe-stack",
     "custom-evmc",
     "hash-cache",
     "code-analysis-cache",
@@ -35,7 +35,7 @@ performance = [
     "fn-ptr-conversion-expanded-dispatch",
 ]
 mimalloc = ["dep:mimalloc"]
-stack-array = []
+unsafe-stack = []
 custom-evmc = ["dep:evmc-vm-tosca-refactor"]
 hash-cache = ["needs-cache"]
 code-analysis-cache = ["dep:nohash-hasher", "needs-cache"]

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [features]
 performance = ["evmrs/performance"]
 mimalloc = ["evmrs/mimalloc"]
-stack-array = ["evmrs/stack-array"]
+unsafe-stack = ["evmrs/unsafe-stack"]
 custom-evmc = ["evmrs/custom-evmc"]
 hash-cache = ["evmrs/hash-cache"]
 code-analysis-cache = ["evmrs/code-analysis-cache"]


### PR DESCRIPTION
With feature stack-array, the evm stack (32k) is stored on the program stack. This blows up the stack size and causes the max-call-depth test to crash with a stack overflow.
By putting the evm stack on the heap (Box<[MaybeUninit<u256>; 1024]>) this can be avoided with no noticable performance impact.
After some investigation, it turns out that speedup of the implementation using the Box got over the naive implementation using a Vec, was because the vector was checking if it has to grow on every push.
By eliminating that check with some unsafe code (which uses the fact that the vector gets created with a capacity of 1024 and therefore growing is never necessary) both implementations have similar performance. With some more unsafe code swap_with_top and nth can be written such that they compile to the same assembly as the Box version.

This PR therefore removes the feature stack-array, and adds a new feature unsafe-stack which enabled the unsafe parts.

left = with unsafe-stack
right = without unsafe-stack
```
                   │ evmrs#performance │   evmrs#performance,~unsafe-stack    │
                   │      sec/op       │    sec/op     vs base                │
StaticOverhead/1/          2.519µ ± 1%    2.637µ ± 0%   +4.66% (p=0.000 n=20)
Inc/1/                     5.135µ ± 0%    5.639µ ± 0%   +9.82% (p=0.000 n=20)
Inc/10/                    5.140µ ± 0%    5.607µ ± 1%   +9.09% (p=0.000 n=20)
Fib/1/                     4.635µ ± 0%    5.153µ ± 0%  +11.18% (p=0.000 n=20)
Fib/5/                     14.76µ ± 0%    19.90µ ± 0%  +34.76% (p=0.000 n=20)
Fib/10/                    139.5µ ± 0%    192.7µ ± 0%  +38.06% (p=0.000 n=20)
Fib/15/                    1.340m ± 0%    1.818m ± 0%  +35.64% (p=0.000 n=20)
Fib/20/                    14.56m ± 0%    19.85m ± 0%  +36.33% (p=0.000 n=20)
Sha3/1/                    2.860µ ± 0%    3.117µ ± 0%   +8.97% (p=0.000 n=20)
Sha3/10/                   4.467µ ± 1%    4.900µ ± 0%   +9.68% (p=0.000 n=20)
Sha3/100/                  18.82µ ± 0%    20.64µ ± 0%   +9.66% (p=0.000 n=20)
Sha3/1000/                 192.9µ ± 0%    210.0µ ± 0%   +8.89% (p=0.000 n=20)
Arith/1/                   5.849µ ± 0%    6.598µ ± 0%  +12.81% (p=0.000 n=20)
Arith/10/                  12.33µ ± 1%    15.23µ ± 0%  +23.57% (p=0.000 n=20)
Arith/100/                 81.68µ ± 0%   108.70µ ± 0%  +33.09% (p=0.000 n=20)
Arith/280/                 230.9µ ± 0%    290.0µ ± 0%  +25.61% (p=0.000 n=20)
Memory/1/                  8.276µ ± 2%    9.565µ ± 1%  +15.57% (p=0.000 n=20)
Memory/10/                 14.78µ ± 0%    17.47µ ± 0%  +18.22% (p=0.000 n=20)
Memory/100/                85.15µ ± 0%   108.73µ ± 0%  +27.68% (p=0.000 n=20)
Memory/1000/               714.7µ ± 0%    892.3µ ± 0%  +24.85% (p=0.000 n=20)
Memory/10000/              6.872m ± 0%    8.558m ± 0%  +24.52% (p=0.000 n=20)
Analysis/jumpdest/         2.503µ ± 1%    2.607µ ± 0%   +4.20% (p=0.000 n=20)
Analysis/stop/             2.510µ ± 1%    2.607µ ± 0%   +3.82% (p=0.000 n=20)
Analysis/push1/            2.496µ ± 0%    2.603µ ± 0%   +4.31% (p=0.000 n=20)
Analysis/push32/           2.499µ ± 0%    2.602µ ± 0%   +4.10% (p=0.000 n=20)
geomean                    28.04µ         32.81µ       +17.01%
```