### PR TITLE
evmrs: skip step check in tail calls

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -58,7 +58,7 @@ jobs:
       run: cargo install cargo-hack
     - name: cargo clippy
       working-directory: rust
-      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-fn-ptr-conversion,needs-jumptable clippy --examples --tests --benches -- --deny warnings
+      run: cargo hack --workspace --each-feature --exclude-features needs-cache,needs-fn-ptr-conversion,needs-jumptable clippy --all-targets -- --deny warnings
     
   doc:
     name: doc

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,7 +15,7 @@ inherits = "release"
 debug = true
 
 [features]
-default = ["performance"]
+default = []
 # Flag mock enables code generation for test mocking. This allows generating mocks for other build configuration but "test". 
 mock = ["dep:mockall"]
 fuzzing = ["dep:arbitrary"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,7 +15,7 @@ inherits = "release"
 debug = true
 
 [features]
-default = []
+default = ["performance"]
 # Flag mock enables code generation for test mocking. This allows generating mocks for other build configuration but "test". 
 mock = ["dep:mockall"]
 fuzzing = ["dep:arbitrary"]

--- a/rust/fuzz/fuzz_targets/evmc_execute.rs
+++ b/rust/fuzz/fuzz_targets/evmc_execute.rs
@@ -41,16 +41,14 @@ impl<'a> Arbitrary<'a> for InterpreterArgs<'a> {
         let input = <&[u8]>::arbitrary(u)?;
         let code = <&[u8]>::arbitrary(u)?;
         let message = evmc_message {
-            kind: u
-                .choose(&[
-                    MessageKind::EVMC_CALL,
-                    MessageKind::EVMC_CALLCODE,
-                    MessageKind::EVMC_CREATE,
-                    MessageKind::EVMC_CREATE2,
-                    MessageKind::EVMC_DELEGATECALL,
-                    MessageKind::EVMC_EOFCREATE,
-                ])?
-                .clone(),
+            kind: *u.choose(&[
+                MessageKind::EVMC_CALL,
+                MessageKind::EVMC_CALLCODE,
+                MessageKind::EVMC_CREATE,
+                MessageKind::EVMC_CREATE2,
+                MessageKind::EVMC_DELEGATECALL,
+                MessageKind::EVMC_EOFCREATE,
+            ])?,
             flags: u32::arbitrary(u)?,
             depth: i32::arbitrary(u)?,
             gas: u.int_in_range(0..=5_000_000_000)?, // see go/ct/evm_fuzz_test.go
@@ -94,20 +92,17 @@ impl<'a> Arbitrary<'a> for InterpreterArgs<'a> {
         context
             .expect_get_storage()
             .return_const(Uint256::from(u256::arbitrary(u)?));
-        context.expect_set_storage().return_const(
-            u.choose(&[
-                StorageStatus::EVMC_STORAGE_ASSIGNED,
-                StorageStatus::EVMC_STORAGE_ADDED,
-                StorageStatus::EVMC_STORAGE_DELETED,
-                StorageStatus::EVMC_STORAGE_MODIFIED,
-                StorageStatus::EVMC_STORAGE_DELETED_ADDED,
-                StorageStatus::EVMC_STORAGE_MODIFIED_DELETED,
-                StorageStatus::EVMC_STORAGE_DELETED_RESTORED,
-                StorageStatus::EVMC_STORAGE_ADDED_DELETED,
-                StorageStatus::EVMC_STORAGE_MODIFIED_RESTORED,
-            ])?
-            .clone(),
-        );
+        context.expect_set_storage().return_const(*u.choose(&[
+            StorageStatus::EVMC_STORAGE_ASSIGNED,
+            StorageStatus::EVMC_STORAGE_ADDED,
+            StorageStatus::EVMC_STORAGE_DELETED,
+            StorageStatus::EVMC_STORAGE_MODIFIED,
+            StorageStatus::EVMC_STORAGE_DELETED_ADDED,
+            StorageStatus::EVMC_STORAGE_MODIFIED_DELETED,
+            StorageStatus::EVMC_STORAGE_DELETED_RESTORED,
+            StorageStatus::EVMC_STORAGE_ADDED_DELETED,
+            StorageStatus::EVMC_STORAGE_MODIFIED_RESTORED,
+        ])?);
         context
             .expect_get_balance()
             .return_const(Uint256::from(u256::arbitrary(u)?));
@@ -124,31 +119,29 @@ impl<'a> Arbitrary<'a> for InterpreterArgs<'a> {
             .expect_selfdestruct()
             .return_const(bool::arbitrary(u)?);
         let execution_result = ExecutionResult {
-            status_code: u
-                .choose(&[
-                    StatusCode::EVMC_SUCCESS,
-                    StatusCode::EVMC_FAILURE,
-                    StatusCode::EVMC_REVERT,
-                    StatusCode::EVMC_OUT_OF_GAS,
-                    StatusCode::EVMC_INVALID_INSTRUCTION,
-                    StatusCode::EVMC_UNDEFINED_INSTRUCTION,
-                    StatusCode::EVMC_STACK_OVERFLOW,
-                    StatusCode::EVMC_STACK_UNDERFLOW,
-                    StatusCode::EVMC_BAD_JUMP_DESTINATION,
-                    StatusCode::EVMC_INVALID_MEMORY_ACCESS,
-                    StatusCode::EVMC_CALL_DEPTH_EXCEEDED,
-                    StatusCode::EVMC_STATIC_MODE_VIOLATION,
-                    StatusCode::EVMC_PRECOMPILE_FAILURE,
-                    StatusCode::EVMC_CONTRACT_VALIDATION_FAILURE,
-                    StatusCode::EVMC_ARGUMENT_OUT_OF_RANGE,
-                    StatusCode::EVMC_WASM_UNREACHABLE_INSTRUCTION,
-                    StatusCode::EVMC_WASM_TRAP,
-                    StatusCode::EVMC_INSUFFICIENT_BALANCE,
-                    StatusCode::EVMC_INTERNAL_ERROR,
-                    StatusCode::EVMC_REJECTED,
-                    StatusCode::EVMC_OUT_OF_MEMORY,
-                ])?
-                .clone(),
+            status_code: *u.choose(&[
+                StatusCode::EVMC_SUCCESS,
+                StatusCode::EVMC_FAILURE,
+                StatusCode::EVMC_REVERT,
+                StatusCode::EVMC_OUT_OF_GAS,
+                StatusCode::EVMC_INVALID_INSTRUCTION,
+                StatusCode::EVMC_UNDEFINED_INSTRUCTION,
+                StatusCode::EVMC_STACK_OVERFLOW,
+                StatusCode::EVMC_STACK_UNDERFLOW,
+                StatusCode::EVMC_BAD_JUMP_DESTINATION,
+                StatusCode::EVMC_INVALID_MEMORY_ACCESS,
+                StatusCode::EVMC_CALL_DEPTH_EXCEEDED,
+                StatusCode::EVMC_STATIC_MODE_VIOLATION,
+                StatusCode::EVMC_PRECOMPILE_FAILURE,
+                StatusCode::EVMC_CONTRACT_VALIDATION_FAILURE,
+                StatusCode::EVMC_ARGUMENT_OUT_OF_RANGE,
+                StatusCode::EVMC_WASM_UNREACHABLE_INSTRUCTION,
+                StatusCode::EVMC_WASM_TRAP,
+                StatusCode::EVMC_INSUFFICIENT_BALANCE,
+                StatusCode::EVMC_INTERNAL_ERROR,
+                StatusCode::EVMC_REJECTED,
+                StatusCode::EVMC_OUT_OF_MEMORY,
+            ])?,
             gas_left: Arbitrary::arbitrary(u)?,
             gas_refund: Arbitrary::arbitrary(u)?,
             output: Arbitrary::arbitrary(u)?,
@@ -166,44 +159,36 @@ impl<'a> Arbitrary<'a> for InterpreterArgs<'a> {
             .expect_get_block_hash()
             .return_const(Uint256::from(u256::arbitrary(u)?));
         context.expect_emit_log().return_const(());
-        context.expect_access_account().return_const(
-            u.choose(&[
-                AccessStatus::EVMC_ACCESS_COLD,
-                AccessStatus::EVMC_ACCESS_WARM,
-            ])?
-            .clone(),
-        );
-        context.expect_access_storage().return_const(
-            u.choose(&[
-                AccessStatus::EVMC_ACCESS_COLD,
-                AccessStatus::EVMC_ACCESS_WARM,
-            ])?
-            .clone(),
-        );
+        context.expect_access_account().return_const(*u.choose(&[
+            AccessStatus::EVMC_ACCESS_COLD,
+            AccessStatus::EVMC_ACCESS_WARM,
+        ])?);
+        context.expect_access_storage().return_const(*u.choose(&[
+            AccessStatus::EVMC_ACCESS_COLD,
+            AccessStatus::EVMC_ACCESS_WARM,
+        ])?);
         context
             .expect_get_transient_storage()
             .return_const(Uint256::from(u256::arbitrary(u)?));
         context.expect_set_transient_storage().return_const(());
 
-        let revision = u
-            .choose(&[
-                Revision::EVMC_FRONTIER,
-                Revision::EVMC_HOMESTEAD,
-                Revision::EVMC_TANGERINE_WHISTLE,
-                Revision::EVMC_SPURIOUS_DRAGON,
-                Revision::EVMC_BYZANTIUM,
-                Revision::EVMC_CONSTANTINOPLE,
-                Revision::EVMC_PETERSBURG,
-                Revision::EVMC_ISTANBUL,
-                Revision::EVMC_BERLIN,
-                Revision::EVMC_LONDON,
-                Revision::EVMC_PARIS,
-                Revision::EVMC_SHANGHAI,
-                Revision::EVMC_CANCUN,
-                Revision::EVMC_PRAGUE,
-                Revision::EVMC_OSAKA,
-            ])?
-            .clone();
+        let revision = *u.choose(&[
+            Revision::EVMC_FRONTIER,
+            Revision::EVMC_HOMESTEAD,
+            Revision::EVMC_TANGERINE_WHISTLE,
+            Revision::EVMC_SPURIOUS_DRAGON,
+            Revision::EVMC_BYZANTIUM,
+            Revision::EVMC_CONSTANTINOPLE,
+            Revision::EVMC_PETERSBURG,
+            Revision::EVMC_ISTANBUL,
+            Revision::EVMC_BERLIN,
+            Revision::EVMC_LONDON,
+            Revision::EVMC_PARIS,
+            Revision::EVMC_SHANGHAI,
+            Revision::EVMC_CANCUN,
+            Revision::EVMC_PRAGUE,
+            Revision::EVMC_OSAKA,
+        ])?;
         let args = Self {
             instance: Instance::default(),
             host: mocked_host_interface(),
@@ -226,6 +211,6 @@ fuzz_target!(|args: InterpreterArgs| {
         &mut args.context,
         args.revision,
         &args.message,
-        &args.code,
+        args.code,
     );
 });

--- a/rust/src/evmc.rs
+++ b/rust/src/evmc.rs
@@ -42,13 +42,11 @@ impl EvmcVm for EvmRs {
             // If this is not the case it violates the EVMC spec and is an irrecoverable error.
             process::abort();
         };
-        let interpreter = Interpreter::new(revision, message, context, code);
+        let interpreter =
+            Interpreter::<STEP_CHECK, JUMPDESTS>::new(revision, message, context, code);
         match self.observer_type {
-            ObserverType::NoOp => {
-                interpreter.run::<_, _, STEP_CHECK, JUMPDESTS>(&mut NoOpObserver())
-            }
-            ObserverType::Logging => interpreter
-                .run::<_, _, STEP_CHECK, JUMPDESTS>(&mut LoggingObserver::new(std::io::stdout())),
+            ObserverType::NoOp => interpreter.run(&mut NoOpObserver()),
+            ObserverType::Logging => interpreter.run(&mut LoggingObserver::new(std::io::stdout())),
         }
     }
 
@@ -114,7 +112,7 @@ impl SteppableEvmcVm for EvmRs {
         };
         let stack = Stack::new(&stack.iter().map(|i| u256::from(*i)).collect::<Vec<_>>());
         let memory = Memory::new(memory.to_owned());
-        let interpreter = Interpreter::new_steppable(
+        let interpreter = Interpreter::<STEP_CHECK, JUMPDESTS>::new_steppable(
             revision,
             message,
             context,
@@ -127,11 +125,8 @@ impl SteppableEvmcVm for EvmRs {
             Some(steps),
         );
         match self.observer_type {
-            ObserverType::NoOp => {
-                interpreter.run::<_, _, STEP_CHECK, JUMPDESTS>(&mut NoOpObserver())
-            }
-            ObserverType::Logging => interpreter
-                .run::<_, _, STEP_CHECK, JUMPDESTS>(&mut LoggingObserver::new(std::io::stdout())),
+            ObserverType::NoOp => interpreter.run(&mut NoOpObserver()),
+            ObserverType::Logging => interpreter.run(&mut LoggingObserver::new(std::io::stdout())),
         }
     }
 }

--- a/rust/src/evmc.rs
+++ b/rust/src/evmc.rs
@@ -31,7 +31,6 @@ impl EvmcVm for EvmRs {
         message: &'a ExecutionMessage,
         context: Option<&'a mut ExecutionContext<'a>>,
     ) -> ExecutionResult {
-        const STEPPABLE: bool = false;
         assert_ne!(
             EVMC_CAPABILITY,
             evmc_capabilities::EVMC_CAPABILITY_PRECOMPILES
@@ -41,7 +40,7 @@ impl EvmcVm for EvmRs {
             // If this is not the case it violates the EVMC spec and is an irrecoverable error.
             process::abort();
         };
-        let interpreter = Interpreter::<STEPPABLE>::new(revision, message, context, code);
+        let interpreter = Interpreter::new(revision, message, context, code);
         match self.observer_type {
             ObserverType::NoOp => interpreter.run(&mut NoOpObserver()),
             ObserverType::Logging => interpreter.run(&mut LoggingObserver::new(std::io::stdout())),
@@ -73,7 +72,6 @@ impl SteppableEvmcVm for EvmRs {
         last_call_return_data: &'a mut [u8],
         steps: i32,
     ) -> StepResult {
-        const STEPPABLE: bool = true;
         if step_status_code != EvmcStepStatusCode::EVMC_STEP_RUNNING {
             return StepResult::new(
                 step_status_code,
@@ -109,7 +107,7 @@ impl SteppableEvmcVm for EvmRs {
         };
         let stack = Stack::new(&stack.iter().map(|i| u256::from(*i)).collect::<Vec<_>>());
         let memory = Memory::new(memory.to_owned());
-        let interpreter = Interpreter::<STEPPABLE>::new_steppable(
+        let interpreter = Interpreter::new_steppable(
             revision,
             message,
             context,

--- a/rust/src/evmc.rs
+++ b/rust/src/evmc.rs
@@ -31,8 +31,7 @@ impl EvmcVm for EvmRs {
         message: &'a ExecutionMessage,
         context: Option<&'a mut ExecutionContext<'a>>,
     ) -> ExecutionResult {
-        const STEP_CHECK: bool = false;
-        const JUMPDESTS: bool = false;
+        const STEPPABLE: bool = false;
         assert_ne!(
             EVMC_CAPABILITY,
             evmc_capabilities::EVMC_CAPABILITY_PRECOMPILES
@@ -42,8 +41,7 @@ impl EvmcVm for EvmRs {
             // If this is not the case it violates the EVMC spec and is an irrecoverable error.
             process::abort();
         };
-        let interpreter =
-            Interpreter::<STEP_CHECK, JUMPDESTS>::new(revision, message, context, code);
+        let interpreter = Interpreter::<STEPPABLE>::new(revision, message, context, code);
         match self.observer_type {
             ObserverType::NoOp => interpreter.run(&mut NoOpObserver()),
             ObserverType::Logging => interpreter.run(&mut LoggingObserver::new(std::io::stdout())),
@@ -75,8 +73,7 @@ impl SteppableEvmcVm for EvmRs {
         last_call_return_data: &'a mut [u8],
         steps: i32,
     ) -> StepResult {
-        const STEP_CHECK: bool = true;
-        const JUMPDESTS: bool = true;
+        const STEPPABLE: bool = true;
         if step_status_code != EvmcStepStatusCode::EVMC_STEP_RUNNING {
             return StepResult::new(
                 step_status_code,
@@ -112,7 +109,7 @@ impl SteppableEvmcVm for EvmRs {
         };
         let stack = Stack::new(&stack.iter().map(|i| u256::from(*i)).collect::<Vec<_>>());
         let memory = Memory::new(memory.to_owned());
-        let interpreter = Interpreter::<STEP_CHECK, JUMPDESTS>::new_steppable(
+        let interpreter = Interpreter::<STEPPABLE>::new_steppable(
             revision,
             message,
             context,

--- a/rust/src/types/code_reader.rs
+++ b/rust/src/types/code_reader.rs
@@ -156,7 +156,7 @@ mod tests {
     fn code_reader_internals() {
         let code = [Opcode::Add as u8, Opcode::Add as u8, 0xc0];
         let pc = 1;
-        let code_reader = CodeReader::new::<false>(&code, None, pc);
+        let code_reader = CodeReader::<false>::new(&code, None, pc);
         assert_eq!(*code_reader, code);
         assert_eq!(code_reader.len(), code.len());
         assert_eq!(code_reader.pc(), pc);
@@ -167,34 +167,34 @@ mod tests {
     fn code_reader_pc() {
         let code = [Opcode::Push1 as u8, Opcode::Add as u8, Opcode::Add as u8];
 
-        let code_reader = CodeReader::new::<false>(&code, None, 0);
+        let code_reader = CodeReader::<false>::new(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         assert_eq!(code_reader.pc(), 0);
 
-        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
+        let mut code_reader = CodeReader::<false>::new(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         code_reader.get_push_data();
         assert_eq!(code_reader.pc, 1);
         assert_eq!(code_reader.pc(), 2);
 
-        let code_reader = CodeReader::new::<false>(&code, None, 2);
+        let code_reader = CodeReader::<false>::new(&code, None, 2);
         assert_eq!(code_reader.pc, 1);
         assert_eq!(code_reader.pc(), 2);
 
         let mut code = [Opcode::Add as u8; 23];
         code[0] = Opcode::Push21 as u8;
 
-        let code_reader = CodeReader::new::<false>(&code, None, 0);
+        let code_reader = CodeReader::<false>::new(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         assert_eq!(code_reader.pc(), 0);
 
-        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
+        let mut code_reader = CodeReader::<false>::new(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         code_reader.get_push_data();
         assert_eq!(code_reader.pc, 1);
         assert_eq!(code_reader.pc(), 22);
 
-        let code_reader = CodeReader::new::<false>(&code, None, 22);
+        let code_reader = CodeReader::<false>::new(&code, None, 22);
         assert_eq!(code_reader.pc, 1);
         assert_eq!(code_reader.pc(), 22);
     }
@@ -206,36 +206,36 @@ mod tests {
     fn code_reader_pc() {
         let code = [Opcode::Push1 as u8, Opcode::Add as u8, Opcode::Add as u8];
 
-        let code_reader = CodeReader::new::<false>(&code, None, 0);
+        let code_reader = CodeReader::<false>::new(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         assert_eq!(code_reader.pc(), 0);
 
-        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
+        let mut code_reader = CodeReader::<false>::new(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         code_reader.next();
         code_reader.get_push_data(1);
         assert_eq!(code_reader.pc, 2);
         assert_eq!(code_reader.pc(), 2);
 
-        let code_reader = CodeReader::new::<false>(&code, None, 2);
+        let code_reader = CodeReader::<false>::new(&code, None, 2);
         assert_eq!(code_reader.pc, 2);
         assert_eq!(code_reader.pc(), 2);
 
         let mut code = [Opcode::Add as u8; 23];
         code[0] = Opcode::Push21 as u8;
 
-        let code_reader = CodeReader::new::<false>(&code, None, 0);
+        let code_reader = CodeReader::<false>::new(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         assert_eq!(code_reader.pc(), 0);
 
-        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
+        let mut code_reader = CodeReader::<false>::new(&code, None, 0);
         assert_eq!(code_reader.pc, 0);
         code_reader.next();
         code_reader.get_push_data(21);
         assert_eq!(code_reader.pc, 7);
         assert_eq!(code_reader.pc(), 22);
 
-        let code_reader = CodeReader::new::<false>(&code, None, 22);
+        let code_reader = CodeReader::<false>::new(&code, None, 22);
         assert_eq!(code_reader.pc, 7);
         assert_eq!(code_reader.pc(), 22);
     }
@@ -243,7 +243,7 @@ mod tests {
     #[test]
     fn code_reader_get() {
         let mut code_reader =
-            CodeReader::new::<false>(&[Opcode::Add as u8, Opcode::Add as u8, 0xc0], None, 0);
+            CodeReader::<false>::new(&[Opcode::Add as u8, Opcode::Add as u8, 0xc0], None, 0);
         #[cfg(not(feature = "needs-fn-ptr-conversion"))]
         assert_eq!(code_reader.get(), Ok(Opcode::Add));
         #[cfg(feature = "needs-fn-ptr-conversion")]
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn code_reader_try_jump() {
-        let mut code_reader = CodeReader::new::<false>(
+        let mut code_reader = CodeReader::<false>::new(
             &[
                 Opcode::Push1 as u8,
                 Opcode::JumpDest as u8,
@@ -288,22 +288,22 @@ mod tests {
     #[cfg(not(feature = "needs-fn-ptr-conversion"))]
     #[test]
     fn code_reader_get_push_data() {
-        let mut code_reader = CodeReader::new::<false>(&[0xff; 32], None, 0);
+        let mut code_reader = CodeReader::<false>::new(&[0xff; 32], None, 0);
         assert_eq!(code_reader.get_push_data(0u8.into()), u256::ZERO);
 
-        let mut code_reader = CodeReader::new::<false>(&[0xff; 32], None, 0);
+        let mut code_reader = CodeReader::<false>::new(&[0xff; 32], None, 0);
         assert_eq!(code_reader.get_push_data(1u8.into()), 0xffu8.into());
 
-        let mut code_reader = CodeReader::new::<false>(&[0xff; 32], None, 0);
+        let mut code_reader = CodeReader::<false>::new(&[0xff; 32], None, 0);
         assert_eq!(code_reader.get_push_data(32u8.into()), u256::MAX);
 
-        let mut code_reader = CodeReader::new::<false>(&[0xff; 32], None, 31);
+        let mut code_reader = CodeReader::<false>::new(&[0xff; 32], None, 31);
         assert_eq!(
             code_reader.get_push_data(32u8.into()),
             u256::from(0xffu8) << u256::from(248u8)
         );
 
-        let mut code_reader = CodeReader::new::<false>(&[0xff; 32], None, 32);
+        let mut code_reader = CodeReader::<false>::new(&[0xff; 32], None, 32);
         assert_eq!(code_reader.get_push_data(32u8.into()), u256::ZERO);
     }
     #[cfg(feature = "fn-ptr-conversion-expanded-dispatch")]
@@ -312,7 +312,7 @@ mod tests {
         // pc on data is non longer possible because there are not data items anymore
         let mut code = [0xff; 33];
         code[0] = Opcode::Push32 as u8;
-        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
+        let mut code_reader = CodeReader::<false>::new(&code, None, 0);
         assert_eq!(code_reader.get_push_data(), u256::MAX);
     }
     #[cfg(all(
@@ -325,18 +325,18 @@ mod tests {
         // pc on data is undefined behavior so we have to advance the pc by calling next
         let mut code = [0xff; 33];
         code[0] = Opcode::Push32 as u8;
-        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
+        let mut code_reader = CodeReader::<false>::new(&code, None, 0);
         code_reader.next();
         assert_eq!(code_reader.get_push_data(0u8.into()), u256::ZERO);
 
-        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
+        let mut code_reader = CodeReader::<false>::new(&code, None, 0);
         code_reader.next();
         assert_eq!(
             code_reader.get_push_data(1u8.into()),
             (u32::MAX as u64).into()
         );
 
-        let mut code_reader = CodeReader::new::<false>(&code, None, 0);
+        let mut code_reader = CodeReader::<false>::new(&code, None, 0);
         code_reader.next();
         assert_eq!(code_reader.get_push_data(32u8.into()), u256::MAX);
     }

--- a/rust/src/types/code_reader.rs
+++ b/rust/src/types/code_reader.rs
@@ -9,15 +9,13 @@ use crate::types::Opcode;
 use crate::types::{u256, AnalysisContainer, CodeAnalysis, CodeByteType, FailStatus};
 
 #[derive(Debug)]
-pub struct CodeReader<'a, const STEP_CHECK: bool, const JUMPDEST: bool> {
+pub struct CodeReader<'a, const STEPPABLE: bool> {
     code: &'a [u8],
-    code_analysis: AnalysisContainer<CodeAnalysis<STEP_CHECK, JUMPDEST>>,
+    code_analysis: AnalysisContainer<CodeAnalysis<STEPPABLE>>,
     pc: usize,
 }
 
-impl<'a, const STEP_CHECK: bool, const JUMPDEST: bool> Deref
-    for CodeReader<'a, STEP_CHECK, JUMPDEST>
-{
+impl<'a, const STEPPABLE: bool> Deref for CodeReader<'a, STEPPABLE> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
@@ -31,7 +29,7 @@ pub enum GetOpcodeError {
     Invalid,
 }
 
-impl<'a, const STEP_CHECK: bool, const JUMPDEST: bool> CodeReader<'a, STEP_CHECK, JUMPDEST> {
+impl<'a, const STEPPABLE: bool> CodeReader<'a, STEPPABLE> {
     /// If the const generic J is false, jumpdests are skipped.
     pub fn new(code: &'a [u8], code_hash: Option<u256>, pc: usize) -> Self {
         let code_analysis = CodeAnalysis::new(code, code_hash);
@@ -63,7 +61,7 @@ impl<'a, const STEP_CHECK: bool, const JUMPDEST: bool> CodeReader<'a, STEP_CHECK
         }
     }
     #[cfg(feature = "needs-fn-ptr-conversion")]
-    pub fn get(&self) -> Result<OpFn<STEP_CHECK, JUMPDEST>, GetOpcodeError> {
+    pub fn get(&self) -> Result<OpFn<STEPPABLE>, GetOpcodeError> {
         self.code_analysis
             .analysis
             .get(self.pc)

--- a/rust/src/types/observer.rs
+++ b/rust/src/types/observer.rs
@@ -4,20 +4,20 @@ use crate::interpreter::Interpreter;
 #[cfg(feature = "needs-fn-ptr-conversion")]
 use crate::Opcode;
 
-pub trait Observer<const STEP_CHECK: bool, const JUMPDEST: bool> {
-    fn pre_op(&mut self, interpreter: &Interpreter<STEP_CHECK, JUMPDEST>);
+pub trait Observer<const STEPPABLE: bool> {
+    fn pre_op(&mut self, interpreter: &Interpreter<STEPPABLE>);
 
-    fn post_op(&mut self, interpreter: &Interpreter<STEP_CHECK, JUMPDEST>);
+    fn post_op(&mut self, interpreter: &Interpreter<STEPPABLE>);
 
     fn log(&mut self, message: Cow<str>);
 }
 
 pub struct NoOpObserver();
 
-impl<const STEP_CHECK: bool, const JUMPDEST: bool> Observer<STEP_CHECK, JUMPDEST> for NoOpObserver {
-    fn pre_op(&mut self, _interpreter: &Interpreter<STEP_CHECK, JUMPDEST>) {}
+impl<const STEPPABLE: bool> Observer<STEPPABLE> for NoOpObserver {
+    fn pre_op(&mut self, _interpreter: &Interpreter<STEPPABLE>) {}
 
-    fn post_op(&mut self, _interpreter: &Interpreter<STEP_CHECK, JUMPDEST>) {}
+    fn post_op(&mut self, _interpreter: &Interpreter<STEPPABLE>) {}
 
     fn log(&mut self, _message: Cow<str>) {}
 }
@@ -32,10 +32,8 @@ impl<W: Write> LoggingObserver<W> {
     }
 }
 
-impl<W: Write, const STEP_CHECK: bool, const JUMPDEST: bool> Observer<STEP_CHECK, JUMPDEST>
-    for LoggingObserver<W>
-{
-    fn pre_op(&mut self, interpreter: &Interpreter<STEP_CHECK, JUMPDEST>) {
+impl<W: Write, const STEPPABLE: bool> Observer<STEPPABLE> for LoggingObserver<W> {
+    fn pre_op(&mut self, interpreter: &Interpreter<STEPPABLE>) {
         // pre_op is called after the op is fetched so this will always be Ok(..)
         #[cfg(not(feature = "needs-fn-ptr-conversion"))]
         let op = interpreter.code_reader.get().unwrap();
@@ -58,7 +56,7 @@ impl<W: Write, const STEP_CHECK: bool, const JUMPDEST: bool> Observer<STEP_CHECK
         self.writer.flush().unwrap();
     }
 
-    fn post_op(&mut self, _interpreter: &Interpreter<STEP_CHECK, JUMPDEST>) {}
+    fn post_op(&mut self, _interpreter: &Interpreter<STEPPABLE>) {}
 
     fn log(&mut self, message: Cow<str>) {
         writeln!(self.writer, "{message}").unwrap();

--- a/rust/src/utils/helpers.rs
+++ b/rust/src/utils/helpers.rs
@@ -1,9 +1,8 @@
 use std::cmp::min;
 
-use evmc_vm::{MessageFlags, Revision};
+use evmc_vm::{ExecutionMessage, MessageFlags, Revision};
 
 use crate::{
-    interpreter::Interpreter,
     types::{u256, FailStatus},
     utils::Gas,
 };
@@ -61,8 +60,8 @@ pub fn check_min_revision(min_revision: Revision, revision: Revision) -> Result<
 }
 
 #[inline(always)]
-pub fn check_not_read_only(state: &Interpreter) -> Result<(), FailStatus> {
-    if state.message.flags() == MessageFlags::EVMC_STATIC as u32 {
+pub fn check_not_read_only(message: &ExecutionMessage) -> Result<(), FailStatus> {
+    if message.flags() == MessageFlags::EVMC_STATIC as u32 {
         return Err(FailStatus::StaticModeViolation);
     }
     Ok(())

--- a/rust/src/utils/helpers.rs
+++ b/rust/src/utils/helpers.rs
@@ -146,7 +146,7 @@ mod tests {
         let message = MockExecutionMessage::default().into();
         let mut context = MockExecutionContextTrait::new();
         let interpreter = Interpreter::new(Revision::EVMC_CANCUN, &message, &mut context, &[]);
-        assert_eq!(utils::check_not_read_only(&interpreter), Ok(()));
+        assert_eq!(utils::check_not_read_only(interpreter.message), Ok(()));
 
         let message = MockExecutionMessage {
             flags: MessageFlags::EVMC_STATIC as u32,
@@ -155,7 +155,7 @@ mod tests {
         let message = message.into();
         let interpreter = Interpreter::new(Revision::EVMC_CANCUN, &message, &mut context, &[]);
         assert_eq!(
-            utils::check_not_read_only(&interpreter),
+            utils::check_not_read_only(interpreter.message),
             Err(FailStatus::StaticModeViolation)
         );
     }


### PR DESCRIPTION
This PR has the overarching goal of excluding the step check also when feature tail-call is enabled. In order to do so, instead of having various methods generic, now whole types are generic (Interpreter, OpFn, CodeAnalysis, ...). This makes it possible to call the correct version of Interpreter::next from an opcode impl, which is needed for tail-calls.

Other changes:
- merge const generics STEP_CHECK and JUMPDEST into a single const generic STEPPABLE
- implement Interpreter::new only for Interpreter<false> and Interpreter::new_steppable for Interpreter<true>. This avoids having to provide the generic argument explicitly and makes it impossible to misuse the api.

```
                   │ 2024-11-25T15:30#e4391e3#20-main/evmrs#performance │ 2024-11-27T09:42#20243ba#10/evmrs#performance │
                   │                       sec/op                       │       sec/op        vs base                   │
StaticOverhead/1/                                           2.544µ ± 0%          2.629µ ± 1%   +3.36% (p=0.000 n=20+10)
Inc/1/                                                      5.166µ ± 0%          5.103µ ± 1%   -1.23% (p=0.000 n=20+10)
Inc/10/                                                     5.165µ ± 0%          5.119µ ± 0%   -0.91% (p=0.001 n=20+10)
Fib/1/                                                      4.715µ ± 0%          4.500µ ± 1%   -4.55% (p=0.000 n=20+10)
Fib/5/                                                      15.04µ ± 1%          14.04µ ± 1%   -6.65% (p=0.000 n=20+10)
Fib/10/                                                     141.5µ ± 0%          128.7µ ± 0%   -9.02% (p=0.000 n=20+10)
Fib/15/                                                     1.343m ± 0%          1.230m ± 0%   -8.45% (p=0.000 n=20+10)
Fib/20/                                                     14.56m ± 0%          13.23m ± 0%   -9.12% (p=0.000 n=20+10)
Sha3/1/                                                     2.916µ ± 0%          2.848µ ± 1%   -2.33% (p=0.000 n=20+10)
Sha3/10/                                                    4.525µ ± 0%          4.266µ ± 0%   -5.73% (p=0.000 n=20+10)
Sha3/100/                                                   18.81µ ± 0%          18.18µ ± 1%   -3.36% (p=0.000 n=20+10)
Sha3/1000/                                                  191.9µ ± 0%          188.0µ ± 0%   -2.04% (p=0.000 n=20+10)
Arith/1/                                                    5.929µ ± 0%          5.750µ ± 1%   -3.01% (p=0.000 n=20+10)
Arith/10/                                                   12.32µ ± 0%          12.07µ ± 1%   -1.97% (p=0.000 n=20+10)
Arith/100/                                                  81.79µ ± 0%          73.53µ ± 1%  -10.10% (p=0.000 n=20+10)
Arith/280/                                                  232.9µ ± 0%          211.9µ ± 0%   -9.03% (p=0.000 n=20+10)
Memory/1/                                                   8.474µ ± 1%          7.980µ ± 2%   -5.83% (p=0.000 n=20+10)
Memory/10/                                                  14.91µ ± 1%          13.47µ ± 1%   -9.67% (p=0.000 n=20+10)
Memory/100/                                                 85.87µ ± 0%          73.02µ ± 0%  -14.96% (p=0.000 n=20+10)
Memory/1000/                                                717.4µ ± 0%          611.6µ ± 0%  -14.75% (p=0.000 n=20+10)
Memory/10000/                                               6.882m ± 0%          5.818m ± 0%  -15.46% (p=0.000 n=20+10)
Analysis/jumpdest/                                          2.533µ ± 0%          2.547µ ± 1%   +0.55% (p=0.011 n=20+10)
Analysis/stop/                                              2.531µ ± 1%          2.547µ ± 0%   +0.63% (p=0.034 n=20+10)
Analysis/push1/                                             2.526µ ± 0%          2.546µ ± 1%   +0.81% (p=0.005 n=20+10)
Analysis/push32/                                            2.529µ ± 1%          2.549µ ± 1%   +0.81% (p=0.000 n=20+10)
geomean                                                     28.28µ               26.74µ        -5.43%
```