### PR TITLE
evmrs: use little endian for u256 (and stack)

### DIFF
--- a/rust/benchmarks/src/lib.rs
+++ b/rust/benchmarks/src/lib.rs
@@ -419,7 +419,7 @@ impl RunArgs {
 
         let message = MockExecutionMessage {
             input: Some(Box::leak(Box::from(input.as_slice()))),
-            code_hash: Some(Box::leak(Box::new(u256::from(code_hash).into()))),
+            code_hash: Some(Box::leak(Box::new(u256::from_le_bytes(code_hash).into()))),
             ..Default::default()
         };
 

--- a/rust/fuzz/fuzz_targets/evmc_execute.rs
+++ b/rust/fuzz/fuzz_targets/evmc_execute.rs
@@ -24,7 +24,7 @@ struct InterpreterArgs<'a> {
     code: &'a [u8],
 }
 
-impl<'a> Debug for InterpreterArgs<'a> {
+impl Debug for InterpreterArgs<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InterpreterArgs")
             .field("host", &self.host)

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -941,9 +941,9 @@ impl<'a, const STEPPABLE: bool> Interpreter<'a, STEPPABLE> {
             self.stack.push(u256::ZERO)?;
         } else {
             let end = min(call_data.len(), offset + 32);
-            self.stack.push(
-                u256::from_be_slice(&call_data[offset..end]) << (8 * (32 - (end - offset))),
-            )?;
+            let mut bytes = [0; 32];
+            bytes[..end - offset].copy_from_slice(&call_data[offset..end]);
+            self.stack.push(u256::from_be_bytes(bytes))?;
         }
         self.code_reader.next();
         self.return_from_op()

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -741,8 +741,7 @@ impl<'a, const STEPPABLE: bool> Interpreter<'a, STEPPABLE> {
     fn exp(&mut self) -> OpResult {
         self.gas_left.consume(10)?;
         let [exp, value] = self.stack.pop()?;
-        let byte_size = 32 - exp.into_iter().take_while(|byte| *byte == 0).count() as u64;
-        self.gas_left.consume(byte_size * 50)?; // * does not overflow
+        self.gas_left.consume(exp.bits().div_ceil(8) as u64 * 50)?; // * does not overflow
         self.stack.push(value.pow(exp))?;
         self.code_reader.next();
         self.return_from_op()
@@ -942,9 +941,9 @@ impl<'a, const STEPPABLE: bool> Interpreter<'a, STEPPABLE> {
             self.stack.push(u256::ZERO)?;
         } else {
             let end = min(call_data.len(), offset + 32);
-            let mut bytes = u256::ZERO;
-            bytes[..end - offset].copy_from_slice(&call_data[offset..end]);
-            self.stack.push(bytes)?;
+            self.stack.push(
+                u256::from_be_slice(&call_data[offset..end]) << (8 * (32 - (end - offset))),
+            )?;
         }
         self.code_reader.next();
         self.return_from_op()
@@ -1250,7 +1249,8 @@ impl<'a, const STEPPABLE: bool> Interpreter<'a, STEPPABLE> {
         let [value, offset] = self.stack.pop()?;
 
         let dest = self.memory.get_mut_slice(offset, 32, &mut self.gas_left)?;
-        dest.copy_from_slice(value.as_slice());
+        dest.copy_from_slice(value.as_le_bytes());
+        dest.reverse();
         self.code_reader.next();
         self.return_from_op()
     }
@@ -1260,7 +1260,7 @@ impl<'a, const STEPPABLE: bool> Interpreter<'a, STEPPABLE> {
         let [value, offset] = self.stack.pop()?;
 
         let dest = self.memory.get_mut_byte(offset, &mut self.gas_left)?;
-        *dest = value[31];
+        *dest = value.least_significant_byte();
         self.code_reader.next();
         self.return_from_op()
     }

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -390,7 +390,7 @@ impl<'a> Interpreter<'a, true> {
     }
 }
 
-impl<'a, const STEPPABLE: bool> Interpreter<'a, STEPPABLE> {
+impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
     /// If the const generic S is false, the step check is skipped.
     /// If the const generic J is false jumpdests are skipped.
     /// R is expected to be [ExecutionResult] or [StepResult].
@@ -1817,7 +1817,7 @@ impl<'a, const STEPPABLE: bool> Interpreter<'a, STEPPABLE> {
     }
 }
 
-impl<'a, const STEPPABLE: bool> From<Interpreter<'a, STEPPABLE>> for StepResult {
+impl<const STEPPABLE: bool> From<Interpreter<'_, STEPPABLE>> for StepResult {
     fn from(value: Interpreter<STEPPABLE>) -> Self {
         let stack = value
             .stack
@@ -1841,7 +1841,7 @@ impl<'a, const STEPPABLE: bool> From<Interpreter<'a, STEPPABLE>> for StepResult 
     }
 }
 
-impl<'a, const STEPPABLE: bool> From<Interpreter<'a, STEPPABLE>> for ExecutionResult {
+impl<const STEPPABLE: bool> From<Interpreter<'_, STEPPABLE>> for ExecutionResult {
     fn from(value: Interpreter<STEPPABLE>) -> Self {
         Self::new(
             value.exec_status.into(),

--- a/rust/src/types/amount.rs
+++ b/rust/src/types/amount.rs
@@ -1,9 +1,8 @@
 use std::{
-    cmp::Ordering,
     fmt::{Debug, Display, LowerHex},
     ops::{
-        Add, AddAssign, BitAnd, BitOr, BitXor, Deref, DerefMut, Div, DivAssign, Mul, MulAssign,
-        Not, Rem, RemAssign, Shl, Shr, Sub, SubAssign,
+        Add, AddAssign, BitAnd, BitOr, BitXor, Div, DivAssign, Mul, MulAssign, Not, Rem, RemAssign,
+        Shl, Shr, Sub, SubAssign,
     },
 };
 
@@ -14,51 +13,40 @@ use bnum::{
     types::{I256, U256, U512},
 };
 use evmc_vm::{Address, Uint256};
-use zerocopy::{transmute, transmute_ref, FromBytes, Immutable, IntoBytes};
+use zerocopy::{transmute, transmute_ref};
 
-/// This represents a 256-bit integer. Internally it is a 32 byte array of [`u8`] in big endian.
+/// This represents a 256-bit integer in native endian.
 #[allow(non_camel_case_types)]
-#[derive(Clone, Copy, FromBytes, IntoBytes, Immutable)]
-#[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
+#[derive(Clone, Copy)]
 #[repr(align(16))] // 16 byte alignment is faster than 1, 8 or 32 byte alignment on x86-64.
-pub struct u256([u8; 32]);
+pub struct u256(U256);
 
-impl Deref for u256 {
-    type Target = [u8; 32];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for u256 {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+#[cfg(feature = "fuzzing")]
+impl<'a> Arbitrary<'a> for u256 {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self(U256::from_digits(Arbitrary::arbitrary(u)?)))
     }
 }
 
 impl LowerHex for u256 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let digits = self.0.digits();
         if f.alternate() {
             f.write_str("0x")?;
         }
-        for (i, byte) in self.into_iter().enumerate() {
-            f.write_fmt(format_args!("{byte:02x}"))?;
-            if i % 8 == 7 && i < 31 {
-                f.write_str("_")?;
-            }
-        }
-
-        Ok(())
+        f.write_fmt(format_args!("{:016x}", digits[3]))?;
+        f.write_str("_")?;
+        f.write_fmt(format_args!("{:016x}", digits[2]))?;
+        f.write_str("_")?;
+        f.write_fmt(format_args!("{:016x}", digits[1]))?;
+        f.write_str("_")?;
+        f.write_fmt(format_args!("{:016x}", digits[0]))
     }
 }
 
 impl Display for u256 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let x = U256::from(*self);
-        f.write_fmt(format_args!("{x}"))?;
-
-        Ok(())
+        f.write_fmt(format_args!("{}", self.0))
     }
 }
 
@@ -70,109 +58,66 @@ impl Debug for u256 {
 
 impl From<Uint256> for u256 {
     fn from(value: Uint256) -> Self {
-        Self(value.bytes)
+        Self(U256::from_digits(transmute!(value.bytes)).to_be())
     }
 }
 
 impl From<u256> for Uint256 {
     fn from(value: u256) -> Self {
-        Uint256 { bytes: value.0 }
-    }
-}
-
-impl From<U256> for u256 {
-    fn from(value: U256) -> Self {
-        transmute!(*value.to_be().digits())
-    }
-}
-
-impl From<u256> for U256 {
-    fn from(value: u256) -> Self {
-        U256::from_digits(transmute!(value.0)).to_be()
-    }
-}
-
-impl From<I256> for u256 {
-    fn from(value: I256) -> Self {
-        u256::from(value.cast_unsigned())
-    }
-}
-
-impl From<u256> for I256 {
-    fn from(value: u256) -> Self {
-        U256::from(value).cast_signed()
-    }
-}
-
-impl From<U512> for u256 {
-    fn from(value: U512) -> Self {
-        u256::from(U256::cast_from(value))
-    }
-}
-
-impl From<u256> for U512 {
-    fn from(value: u256) -> Self {
-        U512::cast_from(U256::from(value))
+        Uint256 {
+            bytes: transmute!(*value.0.to_be().digits()),
+        }
     }
 }
 
 impl From<[u8; 32]> for u256 {
     fn from(value: [u8; 32]) -> Self {
-        Self(value)
+        Self(U256::from_digits(transmute!(value)))
     }
 }
 
 impl From<bool> for u256 {
     fn from(value: bool) -> Self {
-        (value as u8).into()
+        Self(U256::from(value))
     }
 }
 
 impl From<u8> for u256 {
     fn from(value: u8) -> Self {
-        Self([
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, value,
-        ])
+        Self(U256::from(value))
     }
 }
 
 impl From<u64> for u256 {
     fn from(value: u64) -> Self {
-        let bytes = value.to_be_bytes();
-        Self([
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, bytes[0],
-            bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
-        ])
+        Self(U256::from(value))
     }
 }
 
 impl From<usize> for u256 {
     fn from(value: usize) -> Self {
-        u256::from(value as u64)
+        Self(U256::from(value))
     }
 }
 
 impl From<Address> for u256 {
     fn from(value: Address) -> Self {
-        let mut bytes = Self::ZERO;
-        bytes[32 - 20..].copy_from_slice(&value.bytes);
-        bytes
+        Self(U256::from_be_slice(&value.bytes).unwrap())
     }
 }
 
 impl From<&Address> for u256 {
     fn from(value: &Address) -> Self {
-        let mut bytes = Self::ZERO;
-        bytes[32 - 20..].copy_from_slice(&value.bytes);
-        bytes
+        Self(U256::from_be_slice(&value.bytes).unwrap())
     }
 }
 
 impl From<u256> for Address {
     fn from(value: u256) -> Self {
+        let value = value.0.to_be();
+        let bytes: &[u8; 32] = transmute_ref!(value.digits());
         let mut addr = Address { bytes: [0; 20] };
-        addr.bytes.copy_from_slice(&value[32 - 20..]);
+        addr.bytes.copy_from_slice(&bytes[32 - 20..]);
         addr
     }
 }
@@ -184,11 +129,9 @@ impl TryFrom<u256> for u64 {
     type Error = U64Overflow;
 
     fn try_from(value: u256) -> Result<Self, Self::Error> {
-        let (prefix, u64_bytes) = split_into_most_significant_24_and_least_significant_8(&value);
-        if prefix != &[0; 24] {
-            Err(U64Overflow)
-        } else {
-            Ok(u64::from_be_bytes(*u64_bytes))
+        match value.into_u64_with_overflow() {
+            (_, true) => Err(U64Overflow),
+            (value, false) => Ok(value),
         }
     }
 }
@@ -197,10 +140,7 @@ impl Add for u256 {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
-        let lhs: U256 = self.into();
-        let rhs: U256 = rhs.into();
-
-        lhs.wrapping_add(rhs).into()
+        Self(self.0.wrapping_add(rhs.0))
     }
 }
 
@@ -214,10 +154,7 @@ impl Sub for u256 {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        let lhs: U256 = self.into();
-        let rhs: U256 = rhs.into();
-
-        lhs.wrapping_sub(rhs).into()
+        Self(self.0.wrapping_sub(rhs.0))
     }
 }
 
@@ -231,10 +168,7 @@ impl Mul for u256 {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self::Output {
-        let lhs: U256 = self.into();
-        let rhs: U256 = rhs.into();
-
-        lhs.wrapping_mul(rhs).into()
+        Self(self.0.wrapping_mul(rhs.0))
     }
 }
 
@@ -251,10 +185,7 @@ impl Div for u256 {
         if rhs == u256::ZERO {
             return u256::ZERO;
         }
-        let lhs: U256 = self.into();
-        let rhs: U256 = rhs.into();
-
-        lhs.wrapping_div(rhs).into()
+        Self(self.0.wrapping_div(rhs.0))
     }
 }
 
@@ -271,10 +202,7 @@ impl Rem for u256 {
         if rhs == u256::ZERO {
             return u256::ZERO;
         }
-        let lhs: U256 = self.into();
-        let rhs: U256 = rhs.into();
-
-        lhs.wrapping_rem(rhs).into()
+        Self(self.0.wrapping_rem(rhs.0))
     }
 }
 
@@ -286,7 +214,7 @@ impl RemAssign for u256 {
 
 impl PartialEq for u256 {
     fn eq(&self, other: &Self) -> bool {
-        **self == **other
+        self.0 == other.0
     }
 }
 
@@ -300,54 +228,39 @@ impl PartialOrd for u256 {
 
 impl Ord for u256 {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let lhs: U256 = (*self).into();
-        let rhs: U256 = (*other).into();
-        lhs.cmp(&rhs)
+        self.0.cmp(&other.0)
     }
 }
 
 impl BitAnd for u256 {
     type Output = Self;
 
-    fn bitand(mut self, rhs: Self) -> Self::Output {
-        for bit in 0..32 {
-            self[bit] &= rhs[bit];
-        }
-        self
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self(self.0.bitand(rhs.0))
     }
 }
 
 impl BitOr for u256 {
     type Output = Self;
 
-    fn bitor(mut self, rhs: Self) -> Self::Output {
-        for bit in 0..32 {
-            self[bit] |= rhs[bit];
-        }
-        self
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0.bitor(rhs.0))
     }
 }
 
 impl BitXor for u256 {
     type Output = Self;
 
-    fn bitxor(mut self, rhs: Self) -> Self::Output {
-        for bit in 0..32 {
-            self[bit] ^= rhs[bit];
-        }
-        self
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        Self(self.0.bitxor(rhs.0))
     }
 }
 
 impl Not for u256 {
     type Output = Self;
 
-    fn not(mut self) -> Self::Output {
-        for bit in 0..32 {
-            self[bit] = !self[bit];
-        }
-
-        self
+    fn not(self) -> Self::Output {
+        Self(self.0.not())
     }
 }
 
@@ -356,12 +269,20 @@ impl Shl for u256 {
 
     fn shl(self, rhs: Self) -> Self::Output {
         // rhs > 255
-        if rhs[..31] != [0; 31] {
+        let rhs = rhs.as_le_bytes();
+        if rhs[1..] != [0; 31] {
             return u256::ZERO;
         }
-        let value: U256 = self.into();
-        let shift = rhs[31] as u32;
-        (value.wrapping_shl(shift)).into()
+        let shift = rhs[0] as u32;
+        Self(self.0.wrapping_shl(shift))
+    }
+}
+
+impl Shl<usize> for u256 {
+    type Output = Self;
+
+    fn shl(self, rhs: usize) -> Self::Output {
+        Self(self.0.wrapping_shl(rhs as u32))
     }
 }
 
@@ -370,36 +291,32 @@ impl Shr for u256 {
 
     fn shr(self, rhs: Self) -> Self::Output {
         // rhs > 255
-        if rhs[..31] != [0; 31] {
+        let rhs = rhs.as_le_bytes();
+        if rhs[1..] != [0; 31] {
             return u256::ZERO;
         }
-        let value: U256 = self.into();
-        let shift = rhs[31] as u32;
-        (value.wrapping_shr(shift)).into()
+        let shift = rhs[0] as u32;
+        Self(self.0.wrapping_shr(shift))
     }
 }
 
 impl u256 {
-    pub const ZERO: Self = Self([0; 32]);
-    pub const ONE: Self = Self([
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 1,
-    ]);
-    pub const MAX: Self = Self([0xff; 32]);
+    pub const ZERO: Self = Self(U256::ZERO);
+    pub const ONE: Self = Self(U256::ONE);
+    pub const MAX: Self = Self(U256::MAX);
 
     pub fn into_u64_with_overflow(self) -> (u64, bool) {
-        let (prefix, u64_bytes) = split_into_most_significant_24_and_least_significant_8(&self);
-        let overflow = prefix != &[0; 24];
-        let num = u64::from_be_bytes(*u64_bytes);
-        (num, overflow)
+        let digits = self.0.digits();
+        let overflow = digits[1..] != [0; 3];
+        (digits[0], overflow)
     }
 
     pub fn into_u64_saturating(self) -> u64 {
-        let (prefix, u64_bytes) = split_into_most_significant_24_and_least_significant_8(&self);
-        if prefix != &[0; 24] {
+        let digits = self.0.digits();
+        if digits[1..] != [0; 3] {
             u64::MAX
         } else {
-            u64::from_be_bytes(*u64_bytes)
+            digits[0]
         }
     }
 
@@ -407,57 +324,60 @@ impl u256 {
         if rhs == u256::ZERO {
             return u256::ZERO;
         }
-        let lhs: I256 = self.into();
-        let rhs: I256 = rhs.into();
 
-        lhs.wrapping_div(rhs).into()
+        Self(
+            self.0
+                .cast_signed()
+                .wrapping_div(rhs.0.cast_signed())
+                .cast_unsigned(),
+        )
     }
 
     pub fn srem(self, rhs: Self) -> Self {
         if rhs == u256::ZERO {
             return u256::ZERO;
         }
-        let lhs: I256 = self.into();
-        let rhs: I256 = rhs.into();
-
-        lhs.wrapping_rem(rhs).into()
+        Self(
+            self.0
+                .cast_signed()
+                .wrapping_rem(rhs.0.cast_signed())
+                .cast_unsigned(),
+        )
     }
 
     pub fn addmod(s1: Self, s2: Self, m: Self) -> Self {
         if m == u256::ZERO {
             return u256::ZERO;
         }
-        let s1: U512 = s1.into();
-        let s2: U512 = s2.into();
-        let m: U512 = m.into();
+        let s1 = U512::cast_from(s1.0);
+        let s2 = U512::cast_from(s2.0);
+        let m = U512::cast_from(m.0);
 
-        (s1 + s2).rem(m).into()
+        Self(U256::cast_from((s1 + s2).rem(m)))
     }
 
     pub fn mulmod(s1: Self, s2: Self, m: Self) -> Self {
         if m == u256::ZERO {
             return u256::ZERO;
         }
-        let f1: U512 = s1.into();
-        let f2: U512 = s2.into();
-        let m: U512 = m.into();
+        let s1 = U512::cast_from(s1.0);
+        let s2 = U512::cast_from(s2.0);
+        let m = U512::cast_from(m.0);
 
-        (f1 * f2).rem(m).into()
+        Self(U256::cast_from((s1 * s2).rem(m)))
     }
 
     pub fn pow(self, exp: Self) -> Self {
-        let base: U256 = self.into();
-        let exp: U256 = exp.into();
         let mut res = U256::ONE;
 
-        for bit in (0..U256::BITS).rev().map(|bit| exp.bit(bit)) {
+        for bit in (0..U256::BITS).rev().map(|bit| exp.0.bit(bit)) {
             res = res.wrapping_mul(res);
             if bit {
-                res = res.wrapping_mul(base);
+                res = res.wrapping_mul(self.0);
             }
         }
 
-        res.into()
+        Self(res)
     }
 
     pub fn signextend(self, rhs: Self) -> Self {
@@ -468,76 +388,76 @@ impl u256 {
         }
 
         let byte = 31 - lhs; // lhs <= 31 so this does not underflow
-        let negative = (rhs[byte] & 0x80) > 0;
-
-        let rhs: U256 = rhs.into();
+        let negative = (rhs.as_le_bytes()[lhs] & 0x80) > 0;
 
         let res = if negative {
-            rhs | (U256::MAX << ((32 - byte) * 8))
+            rhs.0 | (U256::MAX << ((32 - byte) * 8))
         } else {
-            rhs & (U256::MAX >> (byte * 8))
+            rhs.0 & (U256::MAX >> (byte * 8))
         };
 
-        res.into()
+        Self(res)
     }
 
     pub fn slt(&self, rhs: &Self) -> bool {
-        let lhs: I256 = (*self).into();
-        let rhs: I256 = (*rhs).into();
-        lhs.cmp(&rhs) == Ordering::Less
+        let lhs: I256 = self.0.cast_signed();
+        let rhs: I256 = rhs.0.cast_signed();
+        lhs < rhs
     }
 
     pub fn sgt(&self, rhs: &Self) -> bool {
-        let lhs: I256 = (*self).into();
-        let rhs: I256 = (*rhs).into();
-        lhs.cmp(&rhs) == Ordering::Greater
+        let lhs: I256 = self.0.cast_signed();
+        let rhs: I256 = rhs.0.cast_signed();
+        lhs > rhs
     }
 
     pub fn byte(&self, index: Self) -> Self {
         if index >= 32u8.into() {
             return u256::ZERO;
         }
-        let idx = index[31];
-        self[idx as usize].into()
+        let idx = index.as_le_bytes()[0];
+        self.as_le_bytes()[31 - idx as usize].into()
     }
 
     pub fn sar(self, rhs: Self) -> Self {
-        let negative = self[0] & 0x80 > 0;
+        let lhs: I256 = self.0.cast_signed();
+        let rhs = rhs.as_le_bytes();
         // rhs > 255
-        if rhs[..31] != [0; 31] {
-            if negative {
+        if rhs[1..] != [0; 31] {
+            if lhs.is_negative() {
                 return u256::MAX;
             } else {
                 return u256::ZERO;
             }
         }
-        let value: U256 = self.into();
-        let shift = rhs[31] as u32;
-        let mut shr = value.wrapping_shr(shift);
-        if negative {
+        let shift = rhs[0] as u32;
+        let mut shr = self.0.wrapping_shr(shift);
+        if lhs.is_negative() {
             shr |= U256::MAX.wrapping_shl(255 - shift);
         }
-        shr.into()
+        Self(shr)
     }
-}
 
-fn split_into_most_significant_24_and_least_significant_8(input: &u256) -> (&[u8; 24], &[u8; 8]) {
-    #[derive(FromBytes, Immutable)]
-    #[repr(C)]
-    struct Split {
-        smb24: [u8; 24],
-        lsb8: [u8; 8],
+    pub const fn bits(&self) -> u32 {
+        self.0.bits()
     }
-    let s: &Split = transmute_ref!(input);
-    (&s.smb24, &s.lsb8)
+
+    pub fn from_be_slice(slice: &[u8]) -> Self {
+        Self(U256::from_be_slice(slice).unwrap())
+    }
+
+    pub fn least_significant_byte(&self) -> u8 {
+        self.0.digits()[0] as u8
+    }
+
+    pub fn as_le_bytes(&self) -> &[u8; 32] {
+        transmute_ref!(self.0.digits())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use bnum::{
-        cast::CastFrom,
-        types::{I256, U256, U512},
-    };
+    use evmc_vm::Address;
 
     use crate::types::amount::{u256, U64Overflow};
 
@@ -578,25 +498,14 @@ mod tests {
 
     #[test]
     fn conversions() {
-        let v1 = u256::from([
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 1,
-        ]);
-        let v255 = u256::from([
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 255,
-        ]);
-
         assert_eq!(u256::from(false), u256::ZERO);
-        assert_eq!(u256::from(true), v1);
+        assert_eq!(u256::from(true), u256::ONE);
 
         assert_eq!(u256::from(0u8), u256::ZERO);
-        assert_eq!(u256::from(1u8), v1);
-        assert_eq!(u256::from(255u8), v255);
+        assert_eq!(u256::from(1u8), u256::ONE);
 
         assert_eq!(u256::from(0u64), u256::ZERO);
-        assert_eq!(u256::from(1u64), v1);
-        assert_eq!(u256::from(255u64), v255);
+        assert_eq!(u256::from(1u64), u256::ONE);
         for num in [0, 1, u64::MAX - 1, u64::MAX] {
             assert_eq!(u256::from(num).try_into(), Ok(num));
         }
@@ -610,25 +519,17 @@ mod tests {
         assert_eq!(u256::MAX.into_u64_with_overflow(), (u64::MAX, true));
         assert_eq!(u256::MAX.into_u64_saturating(), u64::MAX);
 
-        assert_eq!(U256::from(u256::ZERO), U256::ZERO);
-        assert_eq!(U256::from(v1), U256::ONE);
-        assert_eq!(U256::from(u256::MAX), U256::MAX);
-        assert_eq!(u256::from(U256::ZERO), u256::ZERO);
-        assert_eq!(u256::from(U256::ONE), v1);
-        assert_eq!(u256::from(U256::MAX), u256::MAX);
-
-        assert_eq!(I256::from(u256::ZERO), I256::ZERO);
-        assert_eq!(I256::from(v1), I256::ONE);
-        assert_eq!(I256::from(u256::MAX), I256::NEG_ONE);
-        assert_eq!(u256::from(I256::ZERO), u256::ZERO);
-        assert_eq!(u256::from(I256::ONE), v1);
-        assert_eq!(u256::from(I256::MAX), u256::MAX >> v1);
-
-        assert_eq!(U512::from(u256::ZERO), U512::ZERO);
-        assert_eq!(U512::from(v1), U512::ONE);
-        assert_eq!(U512::from(u256::MAX), U512::cast_from(U256::MAX));
-        assert_eq!(u256::from(U512::ZERO), u256::ZERO);
-        assert_eq!(u256::from(U512::ONE), v1);
-        assert_eq!(u256::from(U512::MAX), u256::MAX);
+        assert_eq!(
+            Address::from(u256::ONE),
+            Address {
+                bytes: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+            }
+        );
+        assert_eq!(
+            u256::from(Address {
+                bytes: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+            }),
+            u256::ONE
+        );
     }
 }

--- a/rust/src/types/code_analysis.rs
+++ b/rust/src/types/code_analysis.rs
@@ -157,8 +157,11 @@ impl<const STEPPABLE: bool> CodeAnalysis<STEPPABLE> {
                     pc_map.add_mapping(pc - 1, analysis.len() - 1);
                 }
                 CodeByteType::Push => {
+                    let mut data = [0; 32];
                     let avail = min(data_len, code.len() - pc);
-                    let data = u256::from_be_slice(&code[pc..pc + avail]) << (data_len - avail);
+                    data[32 - data_len..32 - data_len + avail]
+                        .copy_from_slice(&code[pc..pc + avail]);
+                    let data = u256::from_be_bytes(data);
                     analysis.push(OpFnData::func(op, data));
                     pc_map.add_mapping(pc - 1, analysis.len() - 1);
 

--- a/rust/src/types/code_analysis.rs
+++ b/rust/src/types/code_analysis.rs
@@ -157,10 +157,8 @@ impl<const STEPPABLE: bool> CodeAnalysis<STEPPABLE> {
                     pc_map.add_mapping(pc - 1, analysis.len() - 1);
                 }
                 CodeByteType::Push => {
-                    let mut data = u256::ZERO;
                     let avail = min(data_len, code.len() - pc);
-                    data[32 - data_len..32 - data_len + avail]
-                        .copy_from_slice(&code[pc..pc + avail]);
+                    let data = u256::from_be_slice(&code[pc..pc + avail]) << (data_len - avail);
                     analysis.push(OpFnData::func(op, data));
                     pc_map.add_mapping(pc - 1, analysis.len() - 1);
 

--- a/rust/src/types/code_reader.rs
+++ b/rust/src/types/code_reader.rs
@@ -94,9 +94,8 @@ impl<'a, const STEPPABLE: bool> CodeReader<'a, STEPPABLE> {
         assert!(len <= 32);
 
         let data_len = min(len, self.code.len().saturating_sub(self.pc));
-        let mut data = u256::ZERO;
-        data[32 - len..32 - len + data_len]
-            .copy_from_slice(&self.code[self.pc..self.pc + data_len]);
+        let data =
+            u256::from_be_slice(&self.code[self.pc..self.pc + data_len]) << (8 * (len - data_len));
         self.pc += len;
 
         data

--- a/rust/src/types/code_reader.rs
+++ b/rust/src/types/code_reader.rs
@@ -94,8 +94,10 @@ impl<'a, const STEPPABLE: bool> CodeReader<'a, STEPPABLE> {
         assert!(len <= 32);
 
         let data_len = min(len, self.code.len().saturating_sub(self.pc));
-        let data =
-            u256::from_be_slice(&self.code[self.pc..self.pc + data_len]) << (8 * (len - data_len));
+        let mut data = [0; 32];
+        data[32 - len..32 - len + data_len]
+            .copy_from_slice(&self.code[self.pc..self.pc + data_len]);
+        let data = u256::from_be_bytes(data);
         self.pc += len;
 
         data

--- a/rust/src/types/code_reader.rs
+++ b/rust/src/types/code_reader.rs
@@ -15,7 +15,7 @@ pub struct CodeReader<'a, const STEPPABLE: bool> {
     pc: usize,
 }
 
-impl<'a, const STEPPABLE: bool> Deref for CodeReader<'a, STEPPABLE> {
+impl<const STEPPABLE: bool> Deref for CodeReader<'_, STEPPABLE> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {

--- a/rust/src/types/code_reader.rs
+++ b/rust/src/types/code_reader.rs
@@ -115,7 +115,7 @@ impl<'a, const STEPPABLE: bool> CodeReader<'a, STEPPABLE> {
         use crate::types::op_fn_data::OP_FN_DATA_SIZE;
         const MAX_CHUNKS: usize = 32usize.div_ceil(OP_FN_DATA_SIZE);
 
-        let mut data = u256::ZERO;
+        let mut data = [0; 32];
         let chunks = len.div_ceil(OP_FN_DATA_SIZE);
         for chunk in 0..chunks {
             let offset = (MAX_CHUNKS - chunks + chunk) * OP_FN_DATA_SIZE;
@@ -124,7 +124,7 @@ impl<'a, const STEPPABLE: bool> CodeReader<'a, STEPPABLE> {
             self.pc += 1;
         }
 
-        data
+        u256::from_be_bytes(data)
     }
 
     #[cfg(feature = "needs-fn-ptr-conversion")]

--- a/rust/src/types/execution_context.rs
+++ b/rust/src/types/execution_context.rs
@@ -58,7 +58,7 @@ pub trait ExecutionContextTrait {
     fn set_transient_storage(&mut self, address: &Address, key: &Uint256, value: &Uint256);
 }
 
-impl<'a> ExecutionContextTrait for ExecutionContext<'a> {
+impl ExecutionContextTrait for ExecutionContext<'_> {
     fn get_tx_context(&self) -> &ExecutionTxContext {
         self.get_tx_context()
     }

--- a/rust/src/types/hash_cache.rs
+++ b/rust/src/types/hash_cache.rs
@@ -31,7 +31,7 @@ fn sha3(data: &[u8]) -> u256 {
     let mut bytes = [0; 32];
     hasher.finalize_into((&mut bytes).into());
 
-    bytes.into()
+    u256::from_be_slice(&bytes)
 }
 
 pub fn hash(data: &[u8]) -> u256 {

--- a/rust/src/types/hash_cache.rs
+++ b/rust/src/types/hash_cache.rs
@@ -31,7 +31,7 @@ fn sha3(data: &[u8]) -> u256 {
     let mut bytes = [0; 32];
     hasher.finalize_into((&mut bytes).into());
 
-    u256::from_be_slice(&bytes)
+    u256::from_be_bytes(bytes)
 }
 
 pub fn hash(data: &[u8]) -> u256 {

--- a/rust/src/types/memory.rs
+++ b/rust/src/types/memory.rs
@@ -74,9 +74,7 @@ impl Memory {
 
     pub fn get_word(&mut self, offset: u256, gas_left: &mut Gas) -> Result<u256, FailStatus> {
         let slice = self.get_mut_slice(offset, 32u8.into(), gas_left)?;
-        let mut word = u256::ZERO;
-        word.copy_from_slice(slice);
-        Ok(word)
+        Ok(u256::from_be_slice(slice))
     }
 
     pub fn get_mut_byte(

--- a/rust/src/types/memory.rs
+++ b/rust/src/types/memory.rs
@@ -74,6 +74,8 @@ impl Memory {
 
     pub fn get_word(&mut self, offset: u256, gas_left: &mut Gas) -> Result<u256, FailStatus> {
         let slice = self.get_mut_slice(offset, 32, gas_left)?;
+        // SAFETY:
+        // The slice is 32 bytes long.
         let slice = unsafe { &*(slice.as_ptr() as *const [u8; 32]) };
         Ok(u256::from_be_bytes(*slice))
     }

--- a/rust/src/types/memory.rs
+++ b/rust/src/types/memory.rs
@@ -73,8 +73,9 @@ impl Memory {
     }
 
     pub fn get_word(&mut self, offset: u256, gas_left: &mut Gas) -> Result<u256, FailStatus> {
-        let slice = self.get_mut_slice(offset, 32u8.into(), gas_left)?;
-        Ok(u256::from_be_slice(slice))
+        let slice = self.get_mut_slice(offset, 32, gas_left)?;
+        let slice = unsafe { &*(slice.as_ptr() as *const [u8; 32]) };
+        Ok(u256::from_be_bytes(*slice))
     }
 
     pub fn get_mut_byte(

--- a/rust/src/types/mock_execution_message.rs
+++ b/rust/src/types/mock_execution_message.rs
@@ -84,7 +84,7 @@ impl From<MockExecutionMessage> for ExecutionMessage {
 }
 
 #[cfg(feature = "custom-evmc")]
-impl<'a> From<MockExecutionMessage> for ExecutionMessage<'a> {
+impl From<MockExecutionMessage> for ExecutionMessage<'_> {
     fn from(value: MockExecutionMessage) -> Self {
         Self::new(
             value.kind,


### PR DESCRIPTION
This PR changes the u256 type to hold a U256 instead of [u8; 32]. Before it was expected that the bytes in [u8; 32] are in big endian, while U256 is little endian. With this change, it is no longer necessary to convert to little endian and back when doing arithmetic operations. However, call data load, mstore, mload and push have to do the conversion now. However the benchmarks show that this is faster. Further more the conversion for push can be done in the code analysis (for feature fn-ptr-conversion-expanded-dispatch), which gets cached.


```
                   │ 2024-11-27T18:12#1207189#20-main/evmrs#performance │ 2024-11-29T08:27#5f23203#10/evmrs#performance │
                   │                       sec/op                       │       sec/op         vs base                  │
StaticOverhead/1/                                           2.664µ ± 0%           2.603µ ± 1%  -2.31% (p=0.000 n=20+10)
Inc/1/                                                      5.157µ ± 0%           5.247µ ± 1%  +1.76% (p=0.000 n=20+10)
Inc/10/                                                     5.170µ ± 0%           5.284µ ± 0%  +2.21% (p=0.000 n=20+10)
Fib/1/                                                      4.585µ ± 0%           4.611µ ± 0%  +0.58% (p=0.013 n=20+10)
Fib/5/                                                      14.18µ ± 0%           14.28µ ± 1%  +0.66% (p=0.001 n=20+10)
Fib/10/                                                     129.5µ ± 0%           129.7µ ± 0%       ~ (p=0.109 n=20+10)
Fib/15/                                                     1.231m ± 0%           1.229m ± 0%  -0.14% (p=0.000 n=20+10)
Fib/20/                                                     13.26m ± 0%           13.18m ± 0%  -0.60% (p=0.000 n=20+10)
Sha3/1/                                                     2.874µ ± 0%           2.867µ ± 1%       ~ (p=0.454 n=20+10)
Sha3/10/                                                    4.319µ ± 0%           4.252µ ± 1%  -1.56% (p=0.000 n=20+10)
Sha3/100/                                                   18.28µ ± 0%           17.28µ ± 0%  -5.48% (p=0.000 n=20+10)
Sha3/1000/                                                  188.8µ ± 0%           183.8µ ± 0%  -2.64% (p=0.000 n=20+10)
Arith/1/                                                    5.837µ ± 0%           5.926µ ± 1%  +1.52% (p=0.000 n=20+10)
Arith/10/                                                   12.09µ ± 0%           11.38µ ± 0%  -5.89% (p=0.000 n=20+10)
Arith/100/                                                  72.74µ ± 0%           68.72µ ± 0%  -5.52% (p=0.000 n=20+10)
Arith/280/                                                  212.4µ ± 0%           200.5µ ± 0%  -5.61% (p=0.000 n=20+10)
Memory/1/                                                   8.161µ ± 1%           8.165µ ± 1%       ~ (p=0.820 n=20+10)
Memory/10/                                                  13.71µ ± 0%           13.37µ ± 3%       ~ (p=0.262 n=20+10)
Memory/100/                                                 72.81µ ± 0%           66.81µ ± 0%  -8.24% (p=0.000 n=20+10)
Memory/1000/                                                616.7µ ± 0%           571.5µ ± 0%  -7.33% (p=0.000 n=20+10)
Memory/10000/                                               5.888m ± 0%           5.377m ± 0%  -8.69% (p=0.000 n=20+10)
Analysis/jumpdest/                                          2.578µ ± 1%           2.550µ ± 1%  -1.11% (p=0.003 n=20+10)
Analysis/stop/                                              2.572µ ± 0%           2.554µ ± 1%  -0.70% (p=0.001 n=20+10)
Analysis/push1/                                             2.558µ ± 0%           2.548µ ± 0%  -0.39% (p=0.019 n=20+10)
Analysis/push32/                                            2.559µ ± 0%           2.541µ ± 1%  -0.72% (p=0.008 n=20+10)
geomean                                                     26.96µ                26.38µ       -2.16%
```