### PR TITLE
CT: Skip states with PC on data

### DIFF
--- a/go/ct/driver/regressions.go
+++ b/go/ct/driver/regressions.go
@@ -117,6 +117,12 @@ func doRegressionTests(context *cli.Context) error {
 			expected := state.Clone()
 			rule.Effect.Apply(expected)
 
+			// TODO: do not only skip state but change 'pc_on_data_is_ignored' rule to anyEffect
+			// Pc on data is not supported
+			if !state.Code.IsCode(int(state.Pc)) {
+				continue
+			}
+
 			result, err := evm.StepN(input.Clone(), 1)
 			if err != nil {
 				fmt.Printf("Failed to evaluate rule %v: %v\n", rule, err)

--- a/go/ct/driver/regressions.go
+++ b/go/ct/driver/regressions.go
@@ -117,7 +117,7 @@ func doRegressionTests(context *cli.Context) error {
 			expected := state.Clone()
 			rule.Effect.Apply(expected)
 
-			// TODO: do not only skip state but change 'pc_on_data_is_ignored' rule to anyEffect
+			// TODO: do not only skip state but change 'pc_on_data_is_ignored' rule to anyEffect, see #954
 			// Pc on data is not supported
 			if !state.Code.IsCode(int(state.Pc)) {
 				continue

--- a/go/ct/driver/run.go
+++ b/go/ct/driver/run.go
@@ -112,7 +112,7 @@ func doRun(context *cli.Context) error {
 			return rlz.ConsumeAbort
 		}
 
-		// TODO: do not only skip state but change 'pc_on_data_is_ignored' rule to anyEffect
+		// TODO: do not only skip state but change 'pc_on_data_is_ignored' rule to anyEffect, see #954
 		// Pc on data is not supported
 		if !state.Code.IsCode(int(state.Pc)) {
 			return rlz.ConsumeContinue

--- a/regression_inputs/pc_on_data_#918.json
+++ b/regression_inputs/pc_on_data_#918.json
@@ -1,0 +1,9 @@
+{
+  "Status": "running",
+  "Revision": "Paris",
+  "ReadOnly": true,
+  "Pc": 23,
+  "Gas": 484383188858,
+  "GasRefund": -157426747298,
+  "Code": "e00f3a6caf63c17537c0d3a10a16a47e036fcead66ebc98e"
+}


### PR DESCRIPTION
As fixed in #918, states with the program counter pointing to data should be skipped. This PR adds a regression input and adds the skipping of states to the regression driver.