### PR TITLE
CT: Fix specification map

### DIFF
--- a/go/ct/spc/specification.go
+++ b/go/ct/spc/specification.go
@@ -98,9 +98,13 @@ func getAllRules() []Rule {
 		op := vm.OpCode(i)
 		if !vm.IsValid(op) {
 			rules = append(rules, Rule{
-				Name:      fmt.Sprintf("%v_invalid", op),
-				Condition: And(Eq(Status(), st.Running), Eq(Op(Pc()), op)),
-				Effect:    FailEffect(),
+				Name: fmt.Sprintf("%v_invalid", op),
+				Condition: And(
+					Eq(Status(), st.Running),
+					Eq(Op(Pc()), op),
+					AnyKnownRevision(),
+				),
+				Effect: FailEffect(),
 			})
 		}
 	}

--- a/go/ct/spc/specification_map.go
+++ b/go/ct/spc/specification_map.go
@@ -59,11 +59,10 @@ func (s *specificationMap) GetRulesFor(state *st.State) []Rule {
 	var opString string
 	if err != nil {
 		opString = "noOp"
+	} else if state.Revision == common.R99_UnknownNextRevision || state.Status != st.Running {
+		opString = "noOp"
 	} else {
 		opString = op.String()
-		if state.Revision == common.R99_UnknownNextRevision || state.Status != st.Running {
-			getRules("noOp")
-		}
 	}
 
 	getRules(opString)


### PR DESCRIPTION
Invalid instructions are only invalid for known revisions. This removes the need of having to check multiple sets of rules when selecting them are selected in the specification map.