### PR TITLE
evmrs: impl add and sub using u128

### DIFF
--- a/rust/src/types/amount.rs
+++ b/rust/src/types/amount.rs
@@ -130,7 +130,11 @@ impl Add for u256 {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
-        Self(self.0.wrapping_add(rhs.0))
+        let lhs: [u128; 2] = transmute!(*self.0.digits());
+        let rhs: [u128; 2] = transmute!(*rhs.0.digits());
+        let (l, c) = lhs[0].overflowing_add(rhs[0]);
+        let h = lhs[1].wrapping_add(rhs[1]).wrapping_add(c as u128);
+        Self(U256::from_digits(transmute!([l, h])))
     }
 }
 
@@ -144,7 +148,11 @@ impl Sub for u256 {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        Self(self.0.wrapping_sub(rhs.0))
+        let lhs: [u128; 2] = transmute!(*self.0.digits());
+        let rhs: [u128; 2] = transmute!(*rhs.0.digits());
+        let (l, c) = lhs[0].overflowing_sub(rhs[0]);
+        let h = lhs[1].wrapping_sub(rhs[1]).wrapping_sub(c as u128);
+        Self(U256::from_digits(transmute!([l, h])))
     }
 }
 


### PR DESCRIPTION
This PR implements addition and subtraction of u256 using the addition/ subtraction of pairs of u128. Currently the addition and subtraction is done using the type U256 which implements it using u64.

This improves performance of the arithmetic benchmarks, but decreases performance of all short running benchmarks. It is not clear to me why short running benchmarks are negatively affected. Also when running e.g. StaticOverhead in isolation, the slowdown is less significant.

```
                   │ ../2024-12-04T15:51#50f8631#20-main/evmrs#performance │ 2024-12-03T08:50#eeba84d#20/evmrs#performance │ 2024-12-04T13:49#eeba84d#20/evmrs#performance │ 2024-12-04T14:06#eeba84d#20/evmrs#performance │ 2024-12-04T16:45#eeba84d#20/evmrs#performance │ 2024-12-04T16:46#eeba84d#20/evmrs#performance │
                   │                        sec/op                         │         sec/op          vs base               │         sec/op          vs base               │        sec/op         vs base                 │        sec/op         vs base                 │        sec/op         vs base                 │
StaticOverhead/1/                                              2.602µ ± 0%              2.671µ ± 1%  +2.65% (p=0.000 n=20)              2.707µ ± 0%  +4.04% (p=0.000 n=20)            2.621µ ± 0%  +0.71% (p=0.000 n=20)              2.631µ ± 1%  +1.11% (p=0.000 n=20)
Inc/1/                                                         5.283µ ± 0%              5.254µ ± 1%       ~ (p=0.066 n=20)              5.221µ ± 1%  -1.17% (p=0.000 n=20)
Inc/10/                                                        5.314µ ± 0%              5.237µ ± 0%  -1.44% (p=0.000 n=20)              5.224µ ± 0%  -1.68% (p=0.000 n=20)
Fib/1/                                                         4.611µ ± 0%              4.700µ ± 0%  +1.93% (p=0.000 n=20)              4.715µ ± 0%  +2.26% (p=0.000 n=20)
Fib/5/                                                         14.39µ ± 0%              14.23µ ± 0%  -1.09% (p=0.000 n=20)              14.21µ ± 0%  -1.27% (p=0.000 n=20)
Fib/10/                                                        129.9µ ± 0%              127.2µ ± 0%  -2.08% (p=0.000 n=20)              128.4µ ± 0%  -1.10% (p=0.000 n=20)
Fib/15/                                                        1.224m ± 0%              1.222m ± 0%  -0.21% (p=0.000 n=20)              1.214m ± 0%  -0.81% (p=0.000 n=20)
Fib/20/                                                        13.14m ± 0%              13.10m ± 0%  -0.26% (p=0.000 n=20)              13.03m ± 0%  -0.79% (p=0.000 n=20)
Sha3/1/                                                        2.858µ ± 0%              2.906µ ± 0%  +1.68% (p=0.000 n=20)              2.935µ ± 0%  +2.71% (p=0.000 n=20)
Sha3/10/                                                       4.252µ ± 0%              4.322µ ± 0%  +1.66% (p=0.000 n=20)              4.339µ ± 0%  +2.03% (p=0.000 n=20)
Sha3/100/                                                      17.89µ ± 2%              17.76µ ± 0%       ~ (p=0.857 n=20)              17.82µ ± 0%       ~ (p=0.989 n=20)
Sha3/1000/                                                     188.3µ ± 0%              180.8µ ± 0%  -4.03% (p=0.000 n=20)              183.7µ ± 0%  -2.46% (p=0.000 n=20)
Arith/1/                                                       5.843µ ± 0%              5.853µ ± 0%       ~ (p=0.533 n=20)              5.817µ ± 0%       ~ (p=0.110 n=20)                                                                                                            5.837µ ± 0%       ~ (p=0.615 n=20)
Arith/10/                                                      11.29µ ± 0%              11.19µ ± 0%  -0.86% (p=0.000 n=20)              11.11µ ± 1%  -1.56% (p=0.000 n=20)                                                                                                            11.17µ ± 0%  -1.05% (p=0.000 n=20)
Arith/100/                                                     68.15µ ± 0%              62.84µ ± 0%  -7.79% (p=0.000 n=20)              63.73µ ± 0%  -6.48% (p=0.000 n=20)                                                                                                            64.39µ ± 0%  -5.50% (p=0.000 n=20)
Arith/280/                                                     199.9µ ± 0%              188.7µ ± 0%  -5.59% (p=0.000 n=20)              187.7µ ± 0%  -6.13% (p=0.000 n=20)                                                                                                            188.3µ ± 0%  -5.81% (p=0.000 n=20)
Memory/1/                                                      8.150µ ± 1%              8.301µ ± 0%  +1.85% (p=0.000 n=20)              8.150µ ± 1%       ~ (p=0.620 n=20)
Memory/10/                                                     13.40µ ± 0%              13.43µ ± 0%       ~ (p=0.151 n=20)              13.34µ ± 1%  -0.47% (p=0.016 n=20)
Memory/100/                                                    66.65µ ± 0%              65.90µ ± 0%  -1.12% (p=0.000 n=20)              66.33µ ± 0%  -0.47% (p=0.013 n=20)
Memory/1000/                                                   574.2µ ± 0%              569.2µ ± 0%  -0.87% (p=0.000 n=20)              568.7µ ± 0%  -0.95% (p=0.000 n=20)
Memory/10000/                                                  5.402m ± 0%              5.325m ± 0%  -1.42% (p=0.000 n=20)              5.327m ± 0%  -1.39% (p=0.000 n=20)
Analysis/jumpdest/                                             2.545µ ± 0%              2.679µ ± 0%  +5.29% (p=0.000 n=20)              2.674µ ± 0%  +5.09% (p=0.000 n=20)
Analysis/stop/                                                 2.536µ ± 1%              2.656µ ± 0%  +4.71% (p=0.000 n=20)              2.680µ ± 0%  +5.66% (p=0.000 n=20)
Analysis/push1/                                                2.544µ ± 0%              2.655µ ± 0%  +4.38% (p=0.000 n=20)              2.676µ ± 0%  +5.21% (p=0.000 n=20)
Analysis/push32/                                               2.546µ ± 0%              2.651µ ± 1%  +4.14% (p=0.000 n=20)              2.672µ ± 0%  +4.95% (p=0.000 n=20)
geomean                                                        26.41µ                   26.41µ       -0.02%                             26.45µ       +0.13%                           2.621µ       +0.71%                ¹            2.631µ       +1.11%                ¹            29.82µ       -3.15%                ¹
```