### PR TITLE
evmrs: lazy load TxContext

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -8,13 +8,15 @@ on:
   push:
     branches: [ main, evmrs ]
     paths:
-      - '**.rs'
-      - 'Cargo.*'
+      - '.github/workflows/rust.yml'
+      - 'rust/**'
+      - Makefile
   pull_request:
     branches: [ main ]
     paths:
-      - '**.rs'
-      - 'Cargo.*'
+      - '.github/workflows/rust.yml'
+      - 'rust/**'
+      - Makefile
 
 env:
   CARGO_TERM_COLOR: always

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 [[package]]
 name = "evmc-sys"
 version = "12.0.0-alpha.0"
-source = "git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-execution-message-slice-output-box#0f0df157a43fbb72b458f29f5835ac46dca2f069"
+source = "git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized#3d75575daa32e3563488361ffce84edf17109c74"
 dependencies = [
  "bindgen",
 ]
@@ -478,9 +478,9 @@ dependencies = [
 [[package]]
 name = "evmc-vm"
 version = "12.0.0-alpha.0"
-source = "git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-execution-message-slice-output-box#0f0df157a43fbb72b458f29f5835ac46dca2f069"
+source = "git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized#3d75575daa32e3563488361ffce84edf17109c74"
 dependencies = [
- "evmc-sys 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-execution-message-slice-output-box)",
+ "evmc-sys 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized)",
 ]
 
 [[package]]
@@ -491,7 +491,7 @@ dependencies = [
  "bnum",
  "driver",
  "evmc-vm 12.0.0-alpha.0 (git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions)",
- "evmc-vm 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-execution-message-slice-output-box)",
+ "evmc-vm 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized)",
  "evmrs",
  "llvm-profile-wrappers",
  "lru",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -50,7 +50,7 @@ fn-ptr-conversion-inline-dispatch = ["needs-fn-ptr-conversion"]
 [dependencies]
 bnum = "0.12.0"
 evmc-vm-tosca = { package = "evmc-vm", git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
-evmc-vm-tosca-refactor = { package = "evmc-vm", git = "https://github.com/LorenzSchueler/evmc", branch = "tosca-extensions-execution-message-slice-output-box", optional = true }
+evmc-vm-tosca-refactor = { package = "evmc-vm", git = "https://github.com/LorenzSchueler/evmc", branch = "tosca-extensions-optimized", optional = true }
 sha3 = "0.10.8"
 zerocopy = { version = "0.8.8", features = ["derive"] }
 llvm-profile-wrappers = { path = "llvm-profile-wrappers" }

--- a/rust/src/types/execution_context.rs
+++ b/rust/src/types/execution_context.rs
@@ -59,6 +59,7 @@ pub trait ExecutionContextTrait {
 }
 
 impl ExecutionContextTrait for ExecutionContext<'_> {
+    #[allow(unconditional_recursion)] // this is a bug in clippy
     fn get_tx_context(&self) -> &ExecutionTxContext {
         self.get_tx_context()
     }

--- a/rust/tests/ffi.rs
+++ b/rust/tests/ffi.rs
@@ -1,8 +1,10 @@
 #![allow(unused_crate_dependencies)]
+#[cfg(not(feature = "custom-evmc"))]
+use driver::TX_CONTEXT_ZEROED;
 use driver::{
     get_tx_context_zeroed,
     host_interface::{self, null_ptr_host_interface},
-    Instance, SteppableInstance, TX_CONTEXT_ZEROED, ZERO,
+    Instance, SteppableInstance, ZERO,
 };
 use evmrs::{
     evmc_vm::{Revision, StatusCode, StepStatusCode},
@@ -14,6 +16,7 @@ fn execute_can_be_called_with_mocked_context() {
     let mut instance = Instance::default();
     let host = host_interface::mocked_host_interface();
     let mut context = MockExecutionContextTrait::new();
+    #[cfg(not(feature = "custom-evmc"))]
     context
         .expect_get_tx_context()
         .times(1)
@@ -66,6 +69,7 @@ fn step_n_can_be_called_with_mocked_context() {
     let mut instance = SteppableInstance::default();
     let host = host_interface::mocked_host_interface();
     let mut context = MockExecutionContextTrait::new();
+    #[cfg(not(feature = "custom-evmc"))]
     context
         .expect_get_tx_context()
         .times(1)


### PR DESCRIPTION
This PR bumps the evmc dependency when feature custom-evmc is enabled. The [new version](https://github.com/LorenzSchueler/evmc/commit/3d75575daa32e3563488361ffce84edf17109c74) no longer loads the TxContext eagerly but only when needed.

This improves performance of short running benchmarks by up to 30%.
```
                   │ 2024-12-04T15:51#50f8631#20-main/evmrs#performance │ 2024-12-04T17:38#cbb69de#20/evmrs#performance │
                   │                       sec/op                       │        sec/op          vs base                │
StaticOverhead/1/                                           2.602µ ± 0%             1.830µ ± 0%  -29.69% (p=0.000 n=20)
Inc/1/                                                      5.283µ ± 0%             4.240µ ± 0%  -19.74% (p=0.000 n=20)
Inc/10/                                                     5.314µ ± 0%             4.267µ ± 0%  -19.70% (p=0.000 n=20)
Fib/1/                                                      4.611µ ± 0%             3.698µ ± 0%  -19.80% (p=0.000 n=20)
Fib/5/                                                      14.39µ ± 0%             12.77µ ± 1%  -11.29% (p=0.000 n=20)
Fib/10/                                                     129.9µ ± 0%             119.9µ ± 0%   -7.65% (p=0.000 n=20)
Fib/15/                                                     1.224m ± 0%             1.156m ± 0%   -5.55% (p=0.000 n=20)
Fib/20/                                                     13.14m ± 0%             12.46m ± 0%   -5.18% (p=0.000 n=20)
Sha3/1/                                                     2.858µ ± 0%             2.139µ ± 0%  -25.13% (p=0.000 n=20)
Sha3/10/                                                    4.252µ ± 0%             3.526µ ± 0%  -17.09% (p=0.000 n=20)
Sha3/100/                                                   17.89µ ± 2%             16.55µ ± 0%   -7.50% (p=0.000 n=20)
Sha3/1000/                                                  188.3µ ± 0%             185.2µ ± 0%   -1.69% (p=0.000 n=20)
Arith/1/                                                    5.843µ ± 0%             5.048µ ± 0%  -13.61% (p=0.000 n=20)
Arith/10/                                                   11.29µ ± 0%             10.65µ ± 1%   -5.69% (p=0.000 n=20)
Arith/100/                                                  68.15µ ± 0%             68.99µ ± 0%   +1.24% (p=0.000 n=20)
Arith/280/                                                  199.9µ ± 0%             197.7µ ± 0%   -1.10% (p=0.000 n=20)
Memory/1/                                                   8.150µ ± 1%             7.012µ ± 1%  -13.97% (p=0.000 n=20)
Memory/10/                                                  13.40µ ± 0%             12.36µ ± 1%   -7.77% (p=0.000 n=20)
Memory/100/                                                 66.65µ ± 0%             66.80µ ± 1%   +0.24% (p=0.046 n=20)
Memory/1000/                                                574.2µ ± 0%             587.7µ ± 0%   +2.34% (p=0.000 n=20)
Memory/10000/                                               5.402m ± 0%             5.529m ± 0%   +2.35% (p=0.000 n=20)
Analysis/jumpdest/                                          2.545µ ± 0%             1.776µ ± 1%  -30.22% (p=0.000 n=20)
Analysis/stop/                                              2.536µ ± 1%             1.788µ ± 0%  -29.50% (p=0.000 n=20)
Analysis/push1/                                             2.544µ ± 0%             1.778µ ± 1%  -30.10% (p=0.000 n=20)
Analysis/push32/                                            2.546µ ± 0%             1.779µ ± 1%  -30.13% (p=0.000 n=20)
geomean                                                     26.41µ                  22.77µ       -13.78%
```

Additionally the paths that trigger rust ci workflows where adjusted to match those for go because before this PR did not trigger them.