### PR TITLE
evmrs: reuse memory

### DIFF
--- a/rust/src/evmc.rs
+++ b/rust/src/evmc.rs
@@ -106,7 +106,7 @@ impl SteppableEvmcVm for EvmRs {
             process::abort();
         };
         let stack = Stack::new(&stack.iter().map(|i| u256::from(*i)).collect::<Vec<_>>());
-        let memory = Memory::new(memory.to_owned());
+        let memory = Memory::new(memory);
         let interpreter = Interpreter::new_steppable(
             revision,
             message,

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -352,7 +352,7 @@ impl<'a> Interpreter<'a, false> {
             gas_refund: GasRefund::new(0),
             output: None,
             stack: Stack::new(&[]),
-            memory: Memory::new(Vec::new()),
+            memory: Memory::new(&[]),
             last_call_return_data: None,
             steps: None,
         }
@@ -1830,7 +1830,7 @@ impl<const STEPPABLE: bool> From<Interpreter<'_, STEPPABLE>> for StepResult {
             value.gas_refund.as_i64(),
             value.output,
             stack,
-            value.memory.into_inner(),
+            value.memory.as_slice().to_vec(),
             value.last_call_return_data,
         )
     }
@@ -1892,7 +1892,7 @@ mod tests {
             1,
             0,
             Stack::new(&[]),
-            Memory::new(Vec::new()),
+            Memory::new(&[]),
             None,
             None,
         );
@@ -1920,7 +1920,7 @@ mod tests {
             1,
             0,
             Stack::new(&[]),
-            Memory::new(Vec::new()),
+            Memory::new(&[]),
             None,
             None,
         )
@@ -1940,7 +1940,7 @@ mod tests {
             0,
             0,
             Stack::new(&[]),
-            Memory::new(Vec::new()),
+            Memory::new(&[]),
             None,
             Some(0),
         );
@@ -1965,7 +1965,7 @@ mod tests {
             0,
             0,
             Stack::new(&[1u8.into(), 2u8.into()]),
-            Memory::new(Vec::new()),
+            Memory::new(&[]),
             None,
             Some(1),
         );
@@ -2062,7 +2062,7 @@ mod tests {
         let mut unique_values = 1u8..;
         let mut next_value = || unique_values.next().unwrap();
 
-        let memory = vec![next_value(), next_value(), next_value(), next_value()];
+        let memory = [next_value(), next_value(), next_value(), next_value()];
         let ret_data = [next_value(), next_value()];
 
         let gas = next_value() as u64;
@@ -2134,7 +2134,7 @@ mod tests {
             0,
             0,
             Stack::new(&stack),
-            Memory::new(memory),
+            Memory::new(&memory),
             None,
             None,
         );


### PR DESCRIPTION
This PR reuses the allocation for the memory by putting it into a Mutex<Option<_>> when dropping the memory and retrieving it from there in the constructor. This is similar to #961 but for the memory instead of the stack.

```
                   │ 2024-12-05T12:53#35e66b0#20-main/evmrs#performance │ 2024-12-05T13:36#eee2456#20/evmrs#performance │
                   │                       sec/op                       │         sec/op          vs base               │
StaticOverhead/1/                                           1.891µ ± 1%              1.888µ ± 1%       ~ (p=0.394 n=20)
Inc/1/                                                      4.264µ ± 0%              4.167µ ± 0%  -2.27% (p=0.000 n=20)
Inc/10/                                                     4.243µ ± 1%              4.159µ ± 1%  -1.99% (p=0.000 n=20)
Fib/1/                                                      3.763µ ± 1%              3.628µ ± 0%  -3.59% (p=0.000 n=20)
Fib/5/                                                      12.60µ ± 1%              12.54µ ± 0%  -0.49% (p=0.014 n=20)
Fib/10/                                                     111.9µ ± 0%              111.5µ ± 0%  -0.39% (p=0.000 n=20)
Fib/15/                                                     1.109m ± 0%              1.104m ± 0%  -0.47% (p=0.000 n=20)
Fib/20/                                                     12.00m ± 0%              12.00m ± 0%       ~ (p=0.242 n=20)
Sha3/1/                                                     2.172µ ± 0%              2.169µ ± 1%       ~ (p=0.784 n=20)
Sha3/10/                                                    3.530µ ± 0%              3.579µ ± 1%  +1.39% (p=0.000 n=20)
Sha3/100/                                                   16.78µ ± 0%              16.93µ ± 1%  +0.86% (p=0.000 n=20)
Sha3/1000/                                                  177.6µ ± 0%              182.7µ ± 0%  +2.85% (p=0.000 n=20)
Arith/1/                                                    5.055µ ± 0%              4.856µ ± 1%  -3.95% (p=0.000 n=20)
Arith/10/                                                   10.50µ ± 1%              10.29µ ± 0%  -1.92% (p=0.000 n=20)
Arith/100/                                                  64.47µ ± 0%              63.95µ ± 0%  -0.81% (p=0.000 n=20)
Arith/280/                                                  192.9µ ± 0%              191.6µ ± 0%  -0.67% (p=0.000 n=20)
Memory/1/                                                   6.902µ ± 1%              6.841µ ± 1%  -0.88% (p=0.005 n=20)
Memory/10/                                                  12.46µ ± 1%              12.30µ ± 0%  -1.32% (p=0.000 n=20)
Memory/100/                                                 67.82µ ± 0%              65.81µ ± 0%  -2.97% (p=0.000 n=20)
Memory/1000/                                                593.4µ ± 0%              586.4µ ± 0%  -1.18% (p=0.000 n=20)
Memory/10000/                                               5.617m ± 0%              5.546m ± 0%  -1.25% (p=0.000 n=20)
Analysis/jumpdest/                                          1.851µ ± 1%              1.818µ ± 1%  -1.76% (p=0.000 n=20)
Analysis/stop/                                              1.843µ ± 1%              1.816µ ± 1%  -1.44% (p=0.000 n=20)
Analysis/push1/                                             1.833µ ± 1%              1.789µ ± 1%  -2.43% (p=0.000 n=20)
Analysis/push32/                                            1.827µ ± 1%              1.802µ ± 1%  -1.34% (p=0.000 n=20)
geomean                                                     22.71µ                   22.47µ       -1.07%
```