### PR TITLE
evmrs: use ethnum

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -452,6 +452,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethnum"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+
+[[package]]
 name = "evmc-sys"
 version = "12.0.0-alpha.0"
 source = "git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions#f57b4c614cd78c4f46b3b8ccb04f583118f59a8a"
@@ -490,6 +496,7 @@ dependencies = [
  "arbitrary",
  "bnum",
  "driver",
+ "ethnum",
  "evmc-vm 12.0.0-alpha.0 (git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions)",
  "evmc-vm 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized)",
  "evmrs",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -49,6 +49,7 @@ fn-ptr-conversion-inline-dispatch = ["needs-fn-ptr-conversion"]
 
 [dependencies]
 bnum = "0.12.0"
+ethnum = "1.5.0"
 evmc-vm-tosca = { package = "evmc-vm", git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
 evmc-vm-tosca-refactor = { package = "evmc-vm", git = "https://github.com/LorenzSchueler/evmc", branch = "tosca-extensions-optimized", optional = true }
 sha3 = "0.10.8"

--- a/rust/fuzz/fuzz_targets/evmc_execute.rs
+++ b/rust/fuzz/fuzz_targets/evmc_execute.rs
@@ -51,7 +51,7 @@ impl<'a> Arbitrary<'a> for InterpreterArgs<'a> {
             ])?,
             flags: u32::arbitrary(u)?,
             depth: i32::arbitrary(u)?,
-            gas: u.int_in_range(0..=5_000_000_000)?, // see go/ct/evm_fuzz_test.go
+            gas: u.int_in_range(0..=100_000_000)?, // see go/ct/evm_fuzz_test.go
             recipient: u256::arbitrary(u)?.into(),
             sender: u256::arbitrary(u)?.into(),
             input_data: input.as_ptr(),

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -1246,7 +1246,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
         let [value, offset] = self.stack.pop()?;
 
         let dest = self.memory.get_mut_slice(offset, 32, &mut self.gas_left)?;
-        dest.copy_from_slice(value.as_le_bytes());
+        dest.copy_from_slice(&value.to_le_bytes());
         dest.reverse();
         self.code_reader.next();
         self.return_from_op()

--- a/rust/src/types/amount.rs
+++ b/rust/src/types/amount.rs
@@ -8,12 +8,10 @@ use std::{
 
 #[cfg(feature = "fuzzing")]
 use arbitrary::Arbitrary;
-use bnum::{
-    cast::CastFrom,
-    types::{I256, U256, U512},
-};
+use bnum::{cast::CastFrom, types::U512};
+use ethnum::U256;
 use evmc_vm::{Address, Uint256};
-use zerocopy::{transmute, transmute_ref};
+use zerocopy::{transmute, IntoBytes};
 
 /// This represents a 256-bit integer in native endian.
 #[allow(non_camel_case_types)]
@@ -24,13 +22,13 @@ pub struct u256(U256);
 #[cfg(feature = "fuzzing")]
 impl<'a> Arbitrary<'a> for u256 {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self(U256::from_digits(Arbitrary::arbitrary(u)?)))
+        Ok(Self(U256(Arbitrary::arbitrary(u)?)))
     }
 }
 
 impl LowerHex for u256 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let digits = self.0.digits();
+        let digits: [u64; 4] = transmute!(self.0 .0);
         if f.alternate() {
             write!(f, "0x")?;
         }
@@ -50,14 +48,14 @@ impl Display for u256 {
 
 impl From<Uint256> for u256 {
     fn from(value: Uint256) -> Self {
-        Self(U256::from_digits(transmute!(value.bytes)).to_be())
+        Self(U256(transmute!(value.bytes)).to_be())
     }
 }
 
 impl From<u256> for Uint256 {
     fn from(value: u256) -> Self {
         Uint256 {
-            bytes: transmute!(*value.0.to_be().digits()),
+            bytes: transmute!(value.0.to_be().0),
         }
     }
 }
@@ -82,7 +80,7 @@ impl From<u64> for u256 {
 
 impl From<usize> for u256 {
     fn from(value: usize) -> Self {
-        Self(U256::from(value))
+        Self(U256::from(value as u64))
     }
 }
 
@@ -105,7 +103,7 @@ impl From<&Address> for u256 {
 impl From<u256> for Address {
     fn from(value: u256) -> Self {
         let value = value.0.to_be();
-        let bytes: &[u8; 32] = transmute_ref!(value.digits());
+        let bytes = value.0.as_bytes();
         let mut addr = Address { bytes: [0; 20] };
         addr.bytes.copy_from_slice(&bytes[32 - 20..]);
         addr
@@ -130,11 +128,7 @@ impl Add for u256 {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
-        let lhs: [u128; 2] = transmute!(*self.0.digits());
-        let rhs: [u128; 2] = transmute!(*rhs.0.digits());
-        let (l, c) = lhs[0].overflowing_add(rhs[0]);
-        let h = lhs[1].wrapping_add(rhs[1]).wrapping_add(c as u128);
-        Self(U256::from_digits(transmute!([l, h])))
+        Self(self.0.wrapping_add(rhs.0))
     }
 }
 
@@ -148,11 +142,7 @@ impl Sub for u256 {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        let lhs: [u128; 2] = transmute!(*self.0.digits());
-        let rhs: [u128; 2] = transmute!(*rhs.0.digits());
-        let (l, c) = lhs[0].overflowing_sub(rhs[0]);
-        let h = lhs[1].wrapping_sub(rhs[1]).wrapping_sub(c as u128);
-        Self(U256::from_digits(transmute!([l, h])))
+        Self(self.0.wrapping_sub(rhs.0))
     }
 }
 
@@ -267,7 +257,7 @@ impl Shl for u256 {
 
     fn shl(self, rhs: Self) -> Self::Output {
         // rhs > 255
-        let rhs = rhs.as_le_bytes();
+        let rhs = rhs.to_le_bytes();
         if rhs[1..] != [0; 31] {
             return u256::ZERO;
         }
@@ -289,7 +279,7 @@ impl Shr for u256 {
 
     fn shr(self, rhs: Self) -> Self::Output {
         // rhs > 255
-        let rhs = rhs.as_le_bytes();
+        let rhs = rhs.to_le_bytes();
         if rhs[1..] != [0; 31] {
             return u256::ZERO;
         }
@@ -304,13 +294,13 @@ impl u256 {
     pub const MAX: Self = Self(U256::MAX);
 
     pub fn into_u64_with_overflow(self) -> (u64, bool) {
-        let digits = self.0.digits();
+        let digits: [u64; 4] = transmute!(self.0 .0);
         let overflow = digits[1..] != [0; 3];
         (digits[0], overflow)
     }
 
     pub fn into_u64_saturating(self) -> u64 {
-        let digits = self.0.digits();
+        let digits: [u64; 4] = transmute!(self.0 .0);
         if digits[1..] != [0; 3] {
             u64::MAX
         } else {
@@ -323,59 +313,70 @@ impl u256 {
             return u256::ZERO;
         }
 
-        Self(
-            self.0
-                .cast_signed()
-                .wrapping_div(rhs.0.cast_signed())
-                .cast_unsigned(),
-        )
+        Self(self.0.as_i256().wrapping_div(rhs.0.as_i256()).as_u256())
     }
 
     pub fn srem(self, rhs: Self) -> Self {
         if rhs == u256::ZERO {
             return u256::ZERO;
         }
-        Self(
-            self.0
-                .cast_signed()
-                .wrapping_rem(rhs.0.cast_signed())
-                .cast_unsigned(),
-        )
+        Self(self.0.as_i256().wrapping_rem(rhs.0.as_i256()).as_u256())
     }
 
+    // ethnum has no support for addmod and mulmod yet (see https://github.com/nlordell/ethnum-rs/issues/10)
     pub fn addmod(s1: Self, s2: Self, m: Self) -> Self {
         if m == u256::ZERO {
             return u256::ZERO;
         }
-        let s1 = U512::cast_from(s1.0);
-        let s2 = U512::cast_from(s2.0);
-        let m = U512::cast_from(m.0);
+        let s1 = bnum::types::U256::from_digits(transmute!(s1.0 .0));
+        let s1 = U512::cast_from(s1);
+        let s2 = bnum::types::U256::from_digits(transmute!(s2.0 .0));
+        let s2 = U512::cast_from(s2);
+        let m = bnum::types::U256::from_digits(transmute!(m.0 .0));
+        let m = U512::cast_from(m);
 
-        Self(U256::cast_from((s1 + s2).rem(m)))
+        Self(U256(transmute!(*bnum::types::U256::cast_from(
+            (s1 + s2).rem(m)
+        )
+        .digits())))
     }
 
+    // ethnum has no support for addmod and mulmod yet (see https://github.com/nlordell/ethnum-rs/issues/10)
     pub fn mulmod(s1: Self, s2: Self, m: Self) -> Self {
         if m == u256::ZERO {
             return u256::ZERO;
         }
-        let s1 = U512::cast_from(s1.0);
-        let s2 = U512::cast_from(s2.0);
-        let m = U512::cast_from(m.0);
+        let s1 = bnum::types::U256::from_digits(transmute!(s1.0 .0));
+        let s1 = U512::cast_from(s1);
+        let s2 = bnum::types::U256::from_digits(transmute!(s2.0 .0));
+        let s2 = U512::cast_from(s2);
+        let m = bnum::types::U256::from_digits(transmute!(m.0 .0));
+        let m = U512::cast_from(m);
 
-        Self(U256::cast_from((s1 * s2).rem(m)))
+        Self(U256(transmute!(*bnum::types::U256::cast_from(
+            (s1 * s2).rem(m)
+        )
+        .digits())))
     }
 
     pub fn pow(self, exp: Self) -> Self {
-        let mut res = U256::ONE;
+        let mut exp = exp.0;
+        let mut base = self.0;
+        let mut acc = U256::ONE;
 
-        for bit in (0..U256::BITS).rev().map(|bit| exp.0.bit(bit)) {
-            res = res.wrapping_mul(res);
-            if bit {
-                res = res.wrapping_mul(self.0);
+        while exp > U256::ONE {
+            if (exp & U256::ONE) == U256::ONE {
+                acc *= base;
             }
+            exp /= U256::from(2u64);
+            base = base * base;
         }
 
-        Self(res)
+        if exp == U256::ONE {
+            acc *= base;
+        }
+
+        Self(acc)
     }
 
     pub fn signextend(self, rhs: Self) -> Self {
@@ -386,7 +387,7 @@ impl u256 {
         }
 
         let byte = 31 - lhs; // lhs <= 31 so this does not underflow
-        let negative = (rhs.as_le_bytes()[lhs] & 0x80) > 0;
+        let negative = (rhs.to_le_bytes()[lhs] & 0x80) > 0;
 
         let res = if negative {
             rhs.0 | (U256::MAX << ((32 - byte) * 8))
@@ -398,14 +399,14 @@ impl u256 {
     }
 
     pub fn slt(&self, rhs: &Self) -> bool {
-        let lhs: I256 = self.0.cast_signed();
-        let rhs: I256 = rhs.0.cast_signed();
+        let lhs = self.0.as_i256();
+        let rhs = rhs.0.as_i256();
         lhs < rhs
     }
 
     pub fn sgt(&self, rhs: &Self) -> bool {
-        let lhs: I256 = self.0.cast_signed();
-        let rhs: I256 = rhs.0.cast_signed();
+        let lhs = self.0.as_i256();
+        let rhs = rhs.0.as_i256();
         lhs > rhs
     }
 
@@ -413,13 +414,13 @@ impl u256 {
         if index >= 32u8.into() {
             return u256::ZERO;
         }
-        let idx = index.as_le_bytes()[0];
-        self.as_le_bytes()[31 - idx as usize].into()
+        let idx = index.to_le_bytes()[0];
+        self.to_le_bytes()[31 - idx as usize].into()
     }
 
     pub fn sar(self, rhs: Self) -> Self {
-        let lhs: I256 = self.0.cast_signed();
-        let rhs = rhs.as_le_bytes();
+        let lhs = self.0.as_i256();
+        let rhs = rhs.to_le_bytes();
         // rhs > 255
         if rhs[1..] != [0; 31] {
             if lhs.is_negative() {
@@ -436,24 +437,24 @@ impl u256 {
         Self(shr)
     }
 
-    pub const fn bits(&self) -> u32 {
-        self.0.bits()
+    pub fn bits(&self) -> u32 {
+        256 - self.0.leading_zeros()
     }
 
     pub fn from_le_bytes(bytes: [u8; 32]) -> Self {
-        Self(U256::from_digits(transmute!(bytes)))
+        Self(U256::from_le_bytes(bytes))
     }
 
     pub fn from_be_bytes(bytes: [u8; 32]) -> Self {
-        Self(U256::from_digits(transmute!(bytes)).to_be())
+        Self(U256::from_be_bytes(bytes))
     }
 
     pub fn least_significant_byte(&self) -> u8 {
-        self.0.digits()[0] as u8
+        self.0 .0[0] as u8
     }
 
-    pub fn as_le_bytes(&self) -> &[u8; 32] {
-        transmute_ref!(self.0.digits())
+    pub fn to_le_bytes(self) -> [u8; 32] {
+        self.0.to_le_bytes()
     }
 }
 

--- a/rust/src/types/amount.rs
+++ b/rust/src/types/amount.rs
@@ -366,14 +366,14 @@ impl u256 {
 
         while exp > U256::ONE {
             if (exp & U256::ONE) == U256::ONE {
-                acc *= base;
+                acc = acc.wrapping_mul(base);
             }
             exp /= U256::from(2u64);
-            base = base * base;
+            base = base.wrapping_mul(base);
         }
 
         if exp == U256::ONE {
-            acc *= base;
+            acc = acc.wrapping_mul(base);
         }
 
         Self(acc)


### PR DESCRIPTION
This PR uses ethnum instead of bnum for the arithmetic operations, except for addmod and mulmod because those are not yet supported (see https://github.com/nlordell/ethnum-rs/issues/10).
In the Rust implementation of ethnum u128 is used as the base type which is faster than u64 as observed in #959.

ethnum also has a llvm-intrinsics feature which uses the llvm 256 bit integer type. However, even with linker-plugin-lto I did not get it to inline those functions and without inlining this is slower than the pure Rust implementation.

```
                   │ 2024-12-06T12:40#6196d42#20-main/evmrs#performance │ 2024-12-06T14:20#b22d4e4#20/evmrs#performance │
                   │                       sec/op                       │        sec/op          vs base                │
StaticOverhead/1/                                           1.753µ ± 0%             1.802µ ± 1%   +2.82% (p=0.000 n=20)
Inc/1/                                                      4.112µ ± 0%             3.723µ ± 0%   -9.45% (p=0.000 n=20)
Inc/10/                                                     4.110µ ± 0%             3.710µ ± 0%   -9.72% (p=0.000 n=20)
Fib/1/                                                      3.506µ ± 0%             3.353µ ± 1%   -4.36% (p=0.000 n=20)
Fib/5/                                                      14.25µ ± 0%             12.48µ ± 0%  -12.39% (p=0.000 n=20)
Fib/10/                                                     137.2µ ± 0%             121.2µ ± 0%  -11.67% (p=0.000 n=20)
Fib/15/                                                     1.332m ± 0%             1.170m ± 0%  -12.15% (p=0.000 n=20)
Fib/20/                                                     14.45m ± 0%             12.58m ± 0%  -12.93% (p=0.000 n=20)
Sha3/1/                                                     2.053µ ± 0%             2.123µ ± 1%   +3.43% (p=0.000 n=20)
Sha3/10/                                                    3.469µ ± 0%             3.333µ ± 0%   -3.92% (p=0.000 n=20)
Sha3/100/                                                   17.00µ ± 1%             14.92µ ± 0%  -12.27% (p=0.000 n=20)
Sha3/1000/                                                  182.8µ ± 0%             151.4µ ± 0%  -17.17% (p=0.000 n=20)
Arith/1/                                                    4.632µ ± 1%             4.580µ ± 0%   -1.11% (p=0.001 n=20)
Arith/10/                                                  10.090µ ± 1%             8.610µ ± 1%  -14.67% (p=0.000 n=20)
Arith/100/                                                  64.13µ ± 0%             49.08µ ± 0%  -23.46% (p=0.000 n=20)
Arith/280/                                                  189.0µ ± 0%             165.7µ ± 0%  -12.34% (p=0.000 n=20)
Memory/1/                                                   6.608µ ± 1%             6.254µ ± 0%   -5.35% (p=0.000 n=20)
Memory/10/                                                  11.77µ ± 1%             10.92µ ± 1%   -7.21% (p=0.000 n=20)
Memory/100/                                                 64.01µ ± 0%             56.47µ ± 0%  -11.78% (p=0.000 n=20)
Memory/1000/                                                569.3µ ± 0%             508.1µ ± 0%  -10.75% (p=0.000 n=20)
Memory/10000/                                               5.377m ± 0%             4.749m ± 0%  -11.69% (p=0.000 n=20)
Analysis/jumpdest/                                          1.758µ ± 1%             1.825µ ± 1%   +3.81% (p=0.000 n=20)
Analysis/stop/                                              1.759µ ± 1%             1.812µ ± 1%   +3.07% (p=0.000 n=20)
Analysis/push1/                                             1.755µ ± 1%             1.818µ ± 0%   +3.56% (p=0.000 n=20)
Analysis/push32/                                            1.763µ ± 1%             1.817µ ± 1%   +3.06% (p=0.000 n=20)
geomean                                                     22.60µ                  20.87µ        -7.68%
```