### PR TITLE
evmrs: add feature alloc-reuse and reuse multiple instances for stack and memory

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,6 +30,7 @@ performance = [
     "custom-evmc",
     "hash-cache",
     "code-analysis-cache",
+    "alloc-reuse",
     "tail-call",
     "jumptable-dispatch",
     "fn-ptr-conversion-expanded-dispatch",
@@ -40,6 +41,7 @@ custom-evmc = ["dep:evmc-vm-tosca-refactor"]
 hash-cache = ["needs-cache"]
 code-analysis-cache = ["dep:nohash-hasher", "needs-cache"]
 thread-local-cache = []
+alloc-reuse = []
 tail-call = []
 jumptable-dispatch = ["needs-jumptable"]
 # fn-ptr-conversion takes precedence over jumptable, switch (default) and fn-ptr-conversion-inline

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -11,6 +11,7 @@ custom-evmc = ["evmrs/custom-evmc"]
 hash-cache = ["evmrs/hash-cache"]
 code-analysis-cache = ["evmrs/code-analysis-cache"]
 thread-local-cache = ["evmrs/thread-local-cache"]
+alloc-reuse = ["evmrs/alloc-reuse"]
 tail-call = ["evmrs/tail-call"]
 jumptable-dispatch = ["evmrs/jumptable-dispatch"]
 fn-ptr-conversion-expanded-dispatch = [

--- a/rust/src/types/memory.rs
+++ b/rust/src/types/memory.rs
@@ -5,7 +5,7 @@ use crate::{
     utils::{word_size, Gas},
 };
 
-static REUSABLE_MEMORY: Mutex<Option<Vec<u8>>> = Mutex::new(None);
+static REUSABLE_MEMORY: Mutex<Vec<Vec<u8>>> = Mutex::new(Vec::new());
 
 #[derive(Debug)]
 pub struct Memory(Vec<u8>);
@@ -14,13 +14,13 @@ impl Drop for Memory {
     fn drop(&mut self) {
         let mut memory = Vec::new();
         std::mem::swap(&mut memory, &mut self.0);
-        *REUSABLE_MEMORY.lock().unwrap() = Some(memory);
+        REUSABLE_MEMORY.lock().unwrap().push(memory);
     }
 }
 
 impl Memory {
     pub fn new(memory: &[u8]) -> Self {
-        let mut m = REUSABLE_MEMORY.lock().unwrap().take().unwrap_or_default();
+        let mut m = REUSABLE_MEMORY.lock().unwrap().pop().unwrap_or_default();
         m.clear();
         m.extend_from_slice(memory);
         Self(m)

--- a/rust/src/types/stack.rs
+++ b/rust/src/types/stack.rs
@@ -1,12 +1,16 @@
-use std::{cmp::min, sync::Mutex};
+use std::cmp::min;
+#[cfg(feature = "alloc-reuse")]
+use std::sync::Mutex;
 
 use crate::types::{u256, FailStatus};
 
+#[cfg(feature = "alloc-reuse")]
 static REUSABLE_STACK: Mutex<Vec<Vec<u256>>> = Mutex::new(Vec::new());
 
 #[derive(Debug)]
 pub struct Stack(Vec<u256>);
 
+#[cfg(feature = "alloc-reuse")]
 impl Drop for Stack {
     fn drop(&mut self) {
         let mut stack = Vec::new();
@@ -22,6 +26,9 @@ impl Stack {
     pub fn new(inner: &[u256]) -> Self {
         let len = min(inner.len(), Self::CAPACITY);
         let inner = &inner[..len];
+        #[cfg(not(feature = "alloc-reuse"))]
+        let mut v = Vec::with_capacity(Self::CAPACITY);
+        #[cfg(feature = "alloc-reuse")]
         let mut v = REUSABLE_STACK
             .lock()
             .unwrap()

--- a/rust/src/types/stack.rs
+++ b/rust/src/types/stack.rs
@@ -2,7 +2,7 @@ use std::{cmp::min, sync::Mutex};
 
 use crate::types::{u256, FailStatus};
 
-static REUSABLE_STACK: Mutex<Option<Vec<u256>>> = Mutex::new(None);
+static REUSABLE_STACK: Mutex<Vec<Vec<u256>>> = Mutex::new(Vec::new());
 
 #[derive(Debug)]
 pub struct Stack(Vec<u256>);
@@ -11,7 +11,7 @@ impl Drop for Stack {
     fn drop(&mut self) {
         let mut stack = Vec::new();
         std::mem::swap(&mut stack, &mut self.0);
-        *REUSABLE_STACK.lock().unwrap() = Some(stack);
+        REUSABLE_STACK.lock().unwrap().push(stack);
     }
 }
 
@@ -25,7 +25,7 @@ impl Stack {
         let mut v = REUSABLE_STACK
             .lock()
             .unwrap()
-            .take()
+            .pop()
             .unwrap_or_else(|| Vec::with_capacity(Self::CAPACITY));
         v.clear();
         #[cfg(feature = "unsafe-stack")]


### PR DESCRIPTION
Currently only a single allocation for the stack and memory are reused. This PR changes that. Additionally it puts the code for reusing allocations behind the new feature alloc-reuse which is enabled when feature performance is enabled.

```
                   │ 2024-12-06T23:04#182aa20#20-main/evmrs#performance │ 2024-12-07T11:13#75e31d4#20-reuse-multiple/evmrs#performance │
                   │                       sec/op                       │                sec/op                  vs base               │
StaticOverhead/1/                                           1.782µ ± 1%                             1.764µ ± 1%  -1.04% (p=0.003 n=20)
Inc/1/                                                      3.681µ ± 1%                             3.716µ ± 0%  +0.95% (p=0.000 n=20)
Inc/10/                                                     3.677µ ± 1%                             3.728µ ± 1%  +1.39% (p=0.000 n=20)
Fib/1/                                                      3.324µ ± 1%                             3.312µ ± 0%  -0.35% (p=0.009 n=20)
Fib/5/                                                      12.29µ ± 0%                             12.37µ ± 0%  +0.65% (p=0.000 n=20)
Fib/10/                                                     120.8µ ± 0%                             120.9µ ± 0%       ~ (p=0.372 n=20)
Fib/15/                                                     1.166m ± 0%                             1.163m ± 0%  -0.26% (p=0.000 n=20)
Fib/20/                                                     12.62m ± 0%                             12.54m ± 0%  -0.62% (p=0.000 n=20)
Sha3/1/                                                     2.119µ ± 1%                             2.087µ ± 1%  -1.53% (p=0.000 n=20)
Sha3/10/                                                    3.321µ ± 0%                             3.286µ ± 0%  -1.07% (p=0.000 n=20)
Sha3/100/                                                   14.74µ ± 1%                             14.85µ ± 0%  +0.73% (p=0.000 n=20)
Sha3/1000/                                                  149.9µ ± 0%                             150.1µ ± 0%  +0.17% (p=0.002 n=20)
Arith/1/                                                    4.567µ ± 1%                             4.482µ ± 1%  -1.85% (p=0.000 n=20)
Arith/10/                                                   8.516µ ± 1%                             8.320µ ± 1%  -2.30% (p=0.000 n=20)
Arith/100/                                                  48.76µ ± 0%                             47.00µ ± 1%  -3.61% (p=0.000 n=20)
Arith/280/                                                  164.9µ ± 0%                             164.4µ ± 0%  -0.31% (p=0.000 n=20)
Memory/1/                                                   6.315µ ± 0%                             6.178µ ± 0%  -2.16% (p=0.000 n=20)
Memory/10/                                                  10.90µ ± 1%                             10.87µ ± 1%       ~ (p=0.095 n=20)
Memory/100/                                                 55.74µ ± 0%                             54.91µ ± 0%  -1.49% (p=0.000 n=20)
Memory/1000/                                                500.7µ ± 0%                             499.7µ ± 0%  -0.20% (p=0.000 n=20)
Memory/10000/                                               4.671m ± 0%                             4.661m ± 0%  -0.20% (p=0.000 n=20)
Analysis/jumpdest/                                          1.832µ ± 1%                             1.765µ ± 1%  -3.68% (p=0.000 n=20)
Analysis/stop/                                              1.792µ ± 1%                             1.767µ ± 1%  -1.40% (p=0.001 n=20)
Analysis/push1/                                             1.792µ ± 1%                             1.758µ ± 1%  -1.87% (p=0.000 n=20)
Analysis/push32/                                            1.786µ ± 1%                             1.758µ ± 1%  -1.57% (p=0.000 n=20)
geomean                                                     20.71µ                                  20.53µ       -0.88%
```