### PR TITLE
evmrs: reduce unsafe code

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -14,7 +14,7 @@ git submodule update --init --recursive
 - C/C++ toolchain, Clang >= 16 and Gcc >= 11.4
     - Ubuntu/Debian package: `clang`
     - Recommended: install `clang-format`, `clangd`, and `gdb` for development
-- Rust toolchain >= 1.81.0
+- Rust toolchain >= 1.83.0
     - [install Rust](https://rustup.rs/)
     - Recommended: install `rust-analyzer` VSCode extension
 - [mockgen](https://github.com/golang/mock)

--- a/rust/BUILD.md
+++ b/rust/BUILD.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- install Rust toolchain >= 1.81.0 from [here](https://rustup.rs/)
+- install Rust toolchain >= 1.83.0 from [here](https://rustup.rs/)
 
 ## Building `evmrs` (shared C library)
 

--- a/rust/driver/src/lib.rs
+++ b/rust/driver/src/lib.rs
@@ -14,9 +14,9 @@ use evmrs::evmc_vm::{
 
 pub mod host_interface;
 
-extern "C" {
-    fn evmc_create_evmrs() -> *mut evmc_vm_t;
-    fn evmc_create_steppable_evmrs() -> *mut evmc_vm_steppable;
+unsafe extern "C" {
+    safe fn evmc_create_evmrs() -> *mut evmc_vm_t;
+    safe fn evmc_create_steppable_evmrs() -> *mut evmc_vm_steppable;
 }
 
 pub const ZERO: Uint256 = Uint256 { bytes: [0; 32] };
@@ -63,9 +63,7 @@ impl DerefMut for Instance {
 
 impl Default for Instance {
     fn default() -> Self {
-        // SAFETY:
-        // `evmc_create_evmrs` must return a valid pointer to an `evmc_vm_t`.
-        let instance = unsafe { evmc_create_evmrs() };
+        let instance = evmc_create_evmrs();
         if instance.is_null() {
             panic!("failed to construct evmrs instance")
         }
@@ -185,9 +183,7 @@ impl DerefMut for SteppableInstance {
 
 impl Default for SteppableInstance {
     fn default() -> Self {
-        // SAFETY:
-        // `evmc_create_steppable_evmrs` must return a valid pointer to an `evmc_vm_steppable`.
-        let instance = unsafe { evmc_create_steppable_evmrs() };
+        let instance = evmc_create_steppable_evmrs();
         if instance.is_null() {
             panic!("vm instance is null")
         }

--- a/rust/llvm-profile-wrappers/src/lib.rs
+++ b/rust/llvm-profile-wrappers/src/lib.rs
@@ -1,29 +1,22 @@
-extern "C" {
-    fn llvm_profile_enabled_wrapper() -> u8;
-    fn llvm_profile_set_filename_wrapper(filename: *const std::ffi::c_char);
-    fn llvm_profile_write_file_wrapper();
-    fn llvm_profile_reset_counters_wrapper();
+unsafe extern "C" {
+    safe fn llvm_profile_enabled_wrapper() -> u8;
+    safe fn llvm_profile_set_filename_wrapper(filename: *const std::ffi::c_char);
+    safe fn llvm_profile_write_file_wrapper();
+    safe fn llvm_profile_reset_counters_wrapper();
 }
 
 pub fn llvm_profile_enabled() -> u8 {
-    unsafe { llvm_profile_enabled_wrapper() }
+    llvm_profile_enabled_wrapper()
 }
 
-/// # Safety
-/// The provided filename can be a C string to set a new name or null to reset to the default
-/// behavior.
-pub unsafe fn llvm_profile_set_filename(filename: *const std::ffi::c_char) {
-    llvm_profile_set_filename_wrapper(filename);
+pub fn llvm_profile_set_filename(filename: Option<&std::ffi::c_char>) {
+    llvm_profile_set_filename_wrapper(filename.map(|f| &raw const *f).unwrap_or(std::ptr::null()));
 }
 
 pub fn llvm_profile_write_file() {
-    unsafe {
-        llvm_profile_write_file_wrapper();
-    }
+    llvm_profile_write_file_wrapper();
 }
 
 pub fn llvm_profile_reset_counters() {
-    unsafe {
-        llvm_profile_reset_counters_wrapper();
-    }
+    llvm_profile_reset_counters_wrapper();
 }

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -296,7 +296,7 @@ static JUMPTABLE_STEPPABLE: [OpFn<true>; 256] = gen_jumptable();
 static JUMPTABLE_NON_STEPPABLE: [OpFn<false>; 256] = gen_jumptable();
 
 #[cfg(feature = "needs-jumptable")]
-pub fn jumptable_lookup<const STEPPABLE: bool>(op: u8) -> OpFn<STEPPABLE> {
+pub const fn jumptable_lookup<const STEPPABLE: bool>(op: u8) -> OpFn<STEPPABLE> {
     if STEPPABLE {
         // SAFETY:
         // STEPPABLE is true

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -7,6 +7,8 @@ use evmc_vm::{
 
 #[cfg(not(feature = "needs-fn-ptr-conversion"))]
 use crate::types::Opcode;
+#[cfg(feature = "needs-jumptable")]
+use crate::utils::GetGenericStatic;
 use crate::{
     types::{
         hash_cache, u256, CodeReader, ExecStatus, ExecutionContextTrait, ExecutionTxContext,
@@ -291,26 +293,16 @@ const fn gen_jumptable<const STEPPABLE: bool>() -> [OpFn<STEPPABLE>; 256] {
 }
 
 #[cfg(feature = "needs-jumptable")]
-static JUMPTABLE_STEPPABLE: [OpFn<true>; 256] = gen_jumptable();
-#[cfg(feature = "needs-jumptable")]
-static JUMPTABLE_NON_STEPPABLE: [OpFn<false>; 256] = gen_jumptable();
+pub struct GenericJumptable;
 
 #[cfg(feature = "needs-jumptable")]
-pub const fn jumptable_lookup<const STEPPABLE: bool>(op: u8) -> OpFn<STEPPABLE> {
-    if STEPPABLE {
-        // SAFETY:
-        // STEPPABLE is true
-        unsafe {
-            std::mem::transmute::<OpFn<true>, OpFn<STEPPABLE>>(JUMPTABLE_STEPPABLE[op as usize])
-        }
-    } else {
-        // SAFETY:
-        // STEPPABLE is false
-        unsafe {
-            std::mem::transmute::<OpFn<false>, OpFn<STEPPABLE>>(
-                JUMPTABLE_NON_STEPPABLE[op as usize],
-            )
-        }
+impl GetGenericStatic for GenericJumptable {
+    type I<const STEPPABLE: bool> = [OpFn<STEPPABLE>; 256];
+
+    fn get<const STEPPABLE: bool>() -> &'static Self::I<STEPPABLE> {
+        static JUMPTABLE_STEPPABLE: [OpFn<true>; 256] = gen_jumptable();
+        static JUMPTABLE_NON_STEPPABLE: [OpFn<false>; 256] = gen_jumptable();
+        Self::get_with_args(&JUMPTABLE_STEPPABLE, &JUMPTABLE_NON_STEPPABLE)
     }
 }
 
@@ -475,7 +467,7 @@ impl<const STEPPABLE: bool> Interpreter<'_, STEPPABLE> {
         not(feature = "needs-fn-ptr-conversion")
     ))]
     fn run_op(&mut self, op: Opcode) -> OpResult {
-        jumptable_lookup(op as u8)(self)
+        GenericJumptable::get()[op as u8 as usize](self)
     }
     #[cfg(not(feature = "needs-jumptable"))]
     fn run_op(&mut self, op: Opcode) -> OpResult {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -51,11 +51,8 @@ pub use types::{u256, ExecutionContextTrait, MockExecutionMessage, Opcode};
 
 /// Dump coverage data when compiled with `RUSTFLAGS="-C instrument-coverage"`.
 /// Otherwise this is a no-op.
-/// # Safety
-/// The provided filename can be a C string to set a new name or null to reset to the default
-/// behavior.
 #[no_mangle]
-pub unsafe extern "C" fn evmrs_dump_coverage(filename: *const std::ffi::c_char) {
+pub extern "C" fn evmrs_dump_coverage(filename: Option<&std::ffi::c_char>) {
     if llvm_profile_enabled() != 0 {
         llvm_profile_set_filename(filename);
         llvm_profile_write_file();

--- a/rust/src/types/amount.rs
+++ b/rust/src/types/amount.rs
@@ -11,7 +11,7 @@ use arbitrary::Arbitrary;
 use bnum::{cast::CastFrom, types::U512};
 use ethnum::U256;
 use evmc_vm::{Address, Uint256};
-use zerocopy::{transmute, IntoBytes};
+use zerocopy::transmute;
 
 /// This represents a 256-bit integer in native endian.
 #[allow(non_camel_case_types)]
@@ -102,8 +102,7 @@ impl From<&Address> for u256 {
 
 impl From<u256> for Address {
     fn from(value: u256) -> Self {
-        let value = value.0.to_be();
-        let bytes = value.0.as_bytes();
+        let bytes: [u8; 32] = transmute!(value.0.to_be().0);
         let mut addr = Address { bytes: [0; 20] };
         addr.bytes.copy_from_slice(&bytes[32 - 20..]);
         addr

--- a/rust/src/types/op_fn_data.rs
+++ b/rust/src/types/op_fn_data.rs
@@ -36,10 +36,18 @@ pub struct OpFnData<const STEPPABLE: bool> {
     raw: *const (),
 }
 
+#[cfg(all(
+    not(feature = "fn-ptr-conversion-expanded-dispatch"),
+    feature = "fn-ptr-conversion-inline-dispatch"
+))]
 // SAFETY:
 // OpFnData only stores function pointers or [u8; 4] so it is safe to share across threads;
 unsafe impl<const STEPPABLE: bool> Send for OpFnData<STEPPABLE> {}
 
+#[cfg(all(
+    not(feature = "fn-ptr-conversion-expanded-dispatch"),
+    feature = "fn-ptr-conversion-inline-dispatch"
+))]
 // SAFETY:
 // OpFnData only stores function pointers or [u8; 4] so it is safe to share across threads;
 unsafe impl<const STEPPABLE: bool> Sync for OpFnData<STEPPABLE> {}

--- a/rust/src/utils/generic_static.rs
+++ b/rust/src/utils/generic_static.rs
@@ -1,0 +1,22 @@
+pub trait GetGenericStatic {
+    type I<const STEPPABL: bool>;
+
+    fn get_with_args<const STEPPABLE: bool>(
+        t: &'static Self::I<true>,
+        f: &'static Self::I<false>,
+    ) -> &'static Self::I<STEPPABLE> {
+        if STEPPABLE {
+            // SAFETY:
+            // STEPPABLE is true
+            unsafe { std::mem::transmute::<&'static Self::I<true>, &'static Self::I<STEPPABLE>>(t) }
+        } else {
+            // SAFETY:
+            // STEPPABLE is false
+            unsafe {
+                std::mem::transmute::<&'static Self::I<false>, &'static Self::I<STEPPABLE>>(f)
+            }
+        }
+    }
+
+    fn get<const STEPPABLE: bool>() -> &'static Self::I<STEPPABLE>;
+}

--- a/rust/src/utils/mod.rs
+++ b/rust/src/utils/mod.rs
@@ -1,5 +1,9 @@
 mod gas;
+#[cfg(any(feature = "needs-jumptable", feature = "code-analysis-cache"))]
+mod generic_static;
 mod helpers;
 
 pub use gas::*;
+#[cfg(any(feature = "needs-jumptable", feature = "code-analysis-cache"))]
+pub use generic_static::GetGenericStatic;
 pub use helpers::*;


### PR DESCRIPTION
This PR reduces the amount of unsafe code by:
- using unsafe extern blocks (see https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html#safe-items-with-unsafe-extern). The idea here is that you only assert once (at the declaration site) that the extern functions have indeed the signature and afterwards it is then safe to call those functions.
- passing optional references instead of pointers
- consolidating the custom solution for generic statics over const bool in the trait GetGenericStatic

Note: these changes require Rust 1.82, so because we have to increase the MSRV, we might as well use 1.83.