### PR TITLE
evmrs: cross platform compilation

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
 [[package]]
 name = "evmc-sys"
 version = "12.0.0-alpha.0"
-source = "git+https://github.com/LorenzSchueler/evmc?branch=lorenz%2Fcross-platform#a8afb02398f7634243e53e535cd1543dbea88da5"
+source = "git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions#e37034770c59ebfc311b050dfbe8bc9c649929a9"
 dependencies = [
  "bindgen",
 ]
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "evmc-sys"
 version = "12.0.0-alpha.0"
-source = "git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized#22946d5fa5e5edea25f2bf7a3b66ebd63ad828b3"
+source = "git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized#a8a85a570ea179ee8f875f361e2924c27a6b4ba6"
 dependencies = [
  "bindgen",
 ]
@@ -476,15 +476,15 @@ dependencies = [
 [[package]]
 name = "evmc-vm"
 version = "12.0.0-alpha.0"
-source = "git+https://github.com/LorenzSchueler/evmc?branch=lorenz%2Fcross-platform#a8afb02398f7634243e53e535cd1543dbea88da5"
+source = "git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions#e37034770c59ebfc311b050dfbe8bc9c649929a9"
 dependencies = [
- "evmc-sys 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=lorenz%2Fcross-platform)",
+ "evmc-sys 12.0.0-alpha.0 (git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions)",
 ]
 
 [[package]]
 name = "evmc-vm"
 version = "12.0.0-alpha.0"
-source = "git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized#22946d5fa5e5edea25f2bf7a3b66ebd63ad828b3"
+source = "git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized#a8a85a570ea179ee8f875f361e2924c27a6b4ba6"
 dependencies = [
  "evmc-sys 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized)",
 ]
@@ -497,7 +497,7 @@ dependencies = [
  "bnum",
  "driver",
  "ethnum",
- "evmc-vm 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=lorenz%2Fcross-platform)",
+ "evmc-vm 12.0.0-alpha.0 (git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions)",
  "evmc-vm 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized)",
  "evmrs",
  "llvm-profile-wrappers",
@@ -582,11 +582,11 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -181,9 +181,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
 dependencies = [
  "jobserver",
  "libc",
@@ -748,6 +748,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 [[package]]
 name = "llvm-profile-wrappers"
 version = "0.1.0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "log"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -207,9 +207,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.22"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69371e34337c4c984bbe322360c2547210bf632eb2814bbe78a6e87a2935bd2b"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.22"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24c1b4099818523236a8ca881d2b45db98dadfb4625cf6608c12069fcbbde1"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -460,7 +460,7 @@ checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
 [[package]]
 name = "evmc-sys"
 version = "12.0.0-alpha.0"
-source = "git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions#f57b4c614cd78c4f46b3b8ccb04f583118f59a8a"
+source = "git+https://github.com/LorenzSchueler/evmc?branch=lorenz%2Fcross-platform#a8afb02398f7634243e53e535cd1543dbea88da5"
 dependencies = [
  "bindgen",
 ]
@@ -468,7 +468,7 @@ dependencies = [
 [[package]]
 name = "evmc-sys"
 version = "12.0.0-alpha.0"
-source = "git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized#3d75575daa32e3563488361ffce84edf17109c74"
+source = "git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized#22946d5fa5e5edea25f2bf7a3b66ebd63ad828b3"
 dependencies = [
  "bindgen",
 ]
@@ -476,15 +476,15 @@ dependencies = [
 [[package]]
 name = "evmc-vm"
 version = "12.0.0-alpha.0"
-source = "git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions#f57b4c614cd78c4f46b3b8ccb04f583118f59a8a"
+source = "git+https://github.com/LorenzSchueler/evmc?branch=lorenz%2Fcross-platform#a8afb02398f7634243e53e535cd1543dbea88da5"
 dependencies = [
- "evmc-sys 12.0.0-alpha.0 (git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions)",
+ "evmc-sys 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=lorenz%2Fcross-platform)",
 ]
 
 [[package]]
 name = "evmc-vm"
 version = "12.0.0-alpha.0"
-source = "git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized#3d75575daa32e3563488361ffce84edf17109c74"
+source = "git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized#22946d5fa5e5edea25f2bf7a3b66ebd63ad828b3"
 dependencies = [
  "evmc-sys 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized)",
 ]
@@ -497,7 +497,7 @@ dependencies = [
  "bnum",
  "driver",
  "ethnum",
- "evmc-vm 12.0.0-alpha.0 (git+https://github.com/Fantom-foundation/evmc?branch=tosca-extensions)",
+ "evmc-vm 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=lorenz%2Fcross-platform)",
  "evmc-vm 12.0.0-alpha.0 (git+https://github.com/LorenzSchueler/evmc?branch=tosca-extensions-optimized)",
  "evmrs",
  "llvm-profile-wrappers",
@@ -674,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -705,9 +705,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -990,15 +990,15 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1018,18 +1018,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1176,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1187,13 +1187,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1202,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1212,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1225,15 +1224,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "web-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1362,18 +1361,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e031087b26520ba76806365896f191416ce84873ed6c6910a9ab5fe0f98f8ed3"
+checksum = "67914ab451f3bfd2e69e5e9d2ef3858484e7074d63f204fd166ec391b54de21d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568244125ba0fc91ae949b97f2852f82cb1a65c3327bd68e6edadd29e67cca26"
+checksum = "7988d73a4303ca289df03316bc490e934accf371af6bc745393cf3c2c5c4f25d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -52,8 +52,7 @@ fn-ptr-conversion-inline-dispatch = ["needs-fn-ptr-conversion"]
 [dependencies]
 bnum = "0.12.0"
 ethnum = "1.5.0"
-# evmc-vm-tosca = { package = "evmc-vm", git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
-evmc-vm-tosca = { package = "evmc-vm", git = "https://github.com/LorenzSchueler/evmc", branch = "lorenz/cross-platform" }                                # TODO
+evmc-vm-tosca = { package = "evmc-vm", git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
 evmc-vm-tosca-refactor = { package = "evmc-vm", git = "https://github.com/LorenzSchueler/evmc", branch = "tosca-extensions-optimized", optional = true }
 sha3 = "0.10.8"
 zerocopy = { version = "0.8.8", features = ["derive"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -52,7 +52,8 @@ fn-ptr-conversion-inline-dispatch = ["needs-fn-ptr-conversion"]
 [dependencies]
 bnum = "0.12.0"
 ethnum = "1.5.0"
-evmc-vm-tosca = { package = "evmc-vm", git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
+# evmc-vm-tosca = { package = "evmc-vm", git = "https://github.com/Fantom-foundation/evmc", branch = "tosca-extensions" }
+evmc-vm-tosca = { package = "evmc-vm", git = "https://github.com/LorenzSchueler/evmc", branch = "lorenz/cross-platform" }                                # TODO
 evmc-vm-tosca-refactor = { package = "evmc-vm", git = "https://github.com/LorenzSchueler/evmc", branch = "tosca-extensions-optimized", optional = true }
 sha3 = "0.10.8"
 zerocopy = { version = "0.8.8", features = ["derive"] }

--- a/rust/llvm-profile-wrappers/Cargo.toml
+++ b/rust/llvm-profile-wrappers/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[build-dependencies]
+cc = "1.2.4"

--- a/rust/llvm-profile-wrappers/build.rs
+++ b/rust/llvm-profile-wrappers/build.rs
@@ -1,36 +1,13 @@
-use std::{env, process::Command};
+use std::env;
 
 fn main() {
     let source = "src/llvm_profile_wrappers.c";
     let out_dir = env::var("OUT_DIR").unwrap();
 
-    let object_file = format!("{}/llvm_profile_wrappers.o", out_dir);
-    let output = Command::new("gcc")
-        .args(["-c", source, "-o", &object_file])
-        .output()
-        .expect("Failed to compile C code");
+    let lib_name = "llvm_profile_wrappers";
+    cc::Build::new().file(source).compile(lib_name);
 
-    if !output.status.success() {
-        panic!(
-            "C compilation failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    let static_lib = format!("{}/libllvm_profile_wrappers.a", out_dir);
-    let output = Command::new("ar")
-        .args(["crus", &static_lib, &object_file])
-        .output()
-        .expect("Failed to create static library");
-
-    if !output.status.success() {
-        panic!(
-            "Static library creation failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    println!("cargo::rerun-if-changed={}", source);
-    println!("cargo::rustc-link-lib=static=llvm_profile_wrappers");
-    println!("cargo::rustc-link-search=native={}", out_dir);
+    println!("cargo::rerun-if-changed={source}");
+    println!("cargo::rustc-link-lib=static={lib_name}");
+    println!("cargo::rustc-link-search=native={out_dir}");
 }


### PR DESCRIPTION
In order to make the c compilation work also on other platforms, this PR uses the cc crate which calls the platform c compiler instead of calling gcc directly.
It also uses a fixed up the version of evmc-vm (and evmc-sys) which now also builds on windows.