### PR TITLE
evmrs: disable feature tail-call

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -31,7 +31,6 @@ performance = [
     "hash-cache",
     "code-analysis-cache",
     "alloc-reuse",
-    "tail-call",
     "jumptable-dispatch",
     "fn-ptr-conversion-expanded-dispatch",
 ]


### PR DESCRIPTION
Feature tail-call only works if the tail calls are optimized away. If that does not happen for all opcode impls and enought of those opcodes get called, the program will overflow its stack and crash with a segfault. For CT this is not an issue because only a single opcode is executed. Also the Go benchmarks and tests have no issue with this. However, when running the history evmrs crashes.

Unfortunately this degrades performance quite significantly.
```
                   │ 2024-12-13T10:56#f12507f#20-main/evmrs#performance │ 2024-12-16T09:45#f12507f#20/evmrs#performance │
                   │                       sec/op                       │        sec/op          vs base                │
StaticOverhead/1/                                           1.765µ ± 1%             1.851µ ± 1%   +4.84% (p=0.000 n=20)
Inc/1/                                                      3.861µ ± 1%             4.686µ ± 0%  +21.35% (p=0.000 n=20)
Inc/10/                                                     3.861µ ± 1%             4.692µ ± 0%  +21.53% (p=0.000 n=20)
Fib/1/                                                      3.431µ ± 0%             4.094µ ± 0%  +19.34% (p=0.000 n=20)
Fib/5/                                                      12.52µ ± 2%             19.33µ ± 1%  +54.38% (p=0.000 n=20)
Fib/10/                                                     112.3µ ± 0%             206.5µ ± 0%  +83.83% (p=0.000 n=20)
Fib/15/                                                     1.085m ± 0%             2.003m ± 0%  +84.52% (p=0.000 n=20)
Fib/20/                                                     11.66m ± 0%             21.82m ± 0%  +87.09% (p=0.000 n=20)
Sha3/1/                                                     2.089µ ± 1%             2.206µ ± 1%   +5.60% (p=0.000 n=20)
Sha3/10/                                                    3.273µ ± 0%             3.419µ ± 1%   +4.45% (p=0.000 n=20)
Sha3/100/                                                   14.80µ ± 0%             15.70µ ± 1%   +6.05% (p=0.000 n=20)
Sha3/1000/                                                  149.1µ ± 0%             160.4µ ± 0%   +7.63% (p=0.000 n=20)
Arith/1/                                                    4.726µ ± 1%             5.454µ ± 0%  +15.39% (p=0.000 n=20)
Arith/10/                                                   8.463µ ± 1%            11.795µ ± 0%  +39.37% (p=0.000 n=20)
Arith/100/                                                  46.95µ ± 0%             79.84µ ± 0%  +70.08% (p=0.000 n=20)
Arith/280/                                                  152.0µ ± 0%             233.3µ ± 0%  +53.50% (p=0.000 n=20)
Memory/1/                                                   6.366µ ± 1%             7.736µ ± 0%  +21.52% (p=0.000 n=20)
Memory/10/                                                  10.97µ ± 1%             15.38µ ± 0%  +40.16% (p=0.000 n=20)
Memory/100/                                                 55.36µ ± 0%             98.10µ ± 0%  +77.22% (p=0.000 n=20)
Memory/1000/                                                498.8µ ± 0%             828.1µ ± 0%  +66.01% (p=0.000 n=20)
Memory/10000/                                               4.642m ± 0%             7.939m ± 0%  +71.05% (p=0.000 n=20)
Analysis/jumpdest/                                          1.746µ ± 1%             1.831µ ± 0%   +4.87% (p=0.000 n=20)
Analysis/stop/                                              1.748µ ± 0%             1.833µ ± 1%   +4.86% (p=0.000 n=20)
Analysis/push1/                                             1.749µ ± 1%             1.839µ ± 1%   +5.18% (p=0.000 n=20)
Analysis/push32/                                            1.746µ ± 0%             1.841µ ± 0%   +5.44% (p=0.000 n=20)
geomean                                                     20.44µ                  26.94µ       +31.82%
```