### PR TITLE
evmrs: update BUILD.md and build with feature performance in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,11 @@ tosca-cpp-coverage: tosca-cpp
 
 tosca-rust:
 	cd rust; \
-	cargo build --lib --release
+	cargo build --lib --release --features performance
 
 tosca-rust-coverage:
 	cd rust; \
-	RUSTFLAGS="-C instrument-coverage" cargo build --lib --release
+	RUSTFLAGS="-C instrument-coverage" cargo build --lib --release --features performance
 
 evmone:
 	@cd third_party/evmone ; \
@@ -88,7 +88,7 @@ test-cpp: tosca-cpp
 
 test-rust:
 	cd rust; \
-	cargo test
+	cargo test --features performance
 
 test-cpp-asan: TOSCA_CPP_BUILD = Debug
 test-cpp-asan: TOSCA_CPP_ASAN = ON


### PR DESCRIPTION
In the Makefile and BUILD.md evmrs is now build with feature performance by default. Additionally the BUILD.md was updated. The optimization workflow section was removed because it only applied to adding optimizations behind feature flags. Instead the benchmarking and profiling sections now contain more information.