### PR TITLE
Floria: state contract fix nonce endian

### DIFF
--- a/go/processor/floria/state_contract.go
+++ b/go/processor/floria/state_contract.go
@@ -12,8 +12,8 @@ package floria
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/Fantom-foundation/Tosca/go/tosca"
@@ -228,7 +228,7 @@ func executeStateContractIncNonce(state tosca.WorldState, sender tosca.Address, 
 
 	account := tosca.Address(input[12:32])
 	value := tosca.Value(input[32:64])
-	valueUint := binary.LittleEndian.Uint64(value[:])
+	valueUint := big.NewInt(0).SetBytes(value[:]).Uint64()
 
 	if account == sender {
 		// Origin nonce shouldn't change during his transaction

--- a/go/processor/floria/state_contract_test.go
+++ b/go/processor/floria/state_contract_test.go
@@ -265,7 +265,7 @@ func TestStateContract_executeStateIncNonce(t *testing.T) {
 			ErrExecutionReverted,
 		},
 		"successful": {
-			append(append(make([]byte, 32), increment), make([]byte, 31)...),
+			append(make([]byte, 63), increment),
 			callValueTransferGas + remainingGas,
 			address0x01,
 			nil,
@@ -357,7 +357,7 @@ func TestStateContract_HandleStatePrecompiled(t *testing.T) {
 		"incNonce": {
 			StateContractAddress(),
 			[]byte{0x79, 0xbe, 0xad, 0x38},
-			append(append(make([]byte, 32), increment), make([]byte, 31)...),
+			append(make([]byte, 63), increment),
 			true,
 			func(mock *tosca.MockWorldState) {
 				mock.EXPECT().GetNonce(tosca.Address{}).Return(uint64(5))


### PR DESCRIPTION
The nonce in the state contract has been set with the wrong endian.