### PR TITLE
Floria: Add nonce and eoa check

### DIFF
--- a/go/processor/floria/processor.go
+++ b/go/processor/floria/processor.go
@@ -147,6 +147,7 @@ func nonceCheck(transactionNonce uint64, stateNonce uint64) error {
 	return nil
 }
 
+// Only accept transactions from externally owned accounts (EOAs) and not from contracts
 func eoaCheck(sender tosca.Address, context tosca.TransactionContext) error {
 	codehash := context.GetCodeHash(sender)
 	if codehash != (tosca.Hash{}) && codehash != emptyCodeHash {


### PR DESCRIPTION
The check regarding the nonce and the non externally owned accounts have to performed in the beginning of the transaction, therefore these checks are refactored. Further, a check for the max init code size is added.