### PR TITLE
Floria: Fix access list

### DIFF
--- a/go/processor/floria/processor.go
+++ b/go/processor/floria/processor.go
@@ -128,6 +128,7 @@ func setUpAccessList(transaction tosca.Transaction, context tosca.TransactionCon
 		return
 	}
 
+	context.AccessAccount(transaction.Sender)
 	if transaction.Recipient != nil {
 		context.AccessAccount(*transaction.Recipient)
 	}
@@ -138,6 +139,7 @@ func setUpAccessList(transaction tosca.Transaction, context tosca.TransactionCon
 	}
 
 	for _, accessTuple := range transaction.AccessList {
+		context.AccessAccount(accessTuple.Address)
 		for _, key := range accessTuple.Keys {
 			context.AccessStorage(accessTuple.Address, key)
 		}

--- a/go/processor/floria/processor_test.go
+++ b/go/processor/floria/processor_test.go
@@ -372,22 +372,45 @@ func TestProcessor_SetUpAccessList(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	context := tosca.NewMockTransactionContext(ctrl)
 
+	sender := tosca.Address{1}
+	recipient := tosca.Address{2}
+	accessListAddress := tosca.Address{3}
+
 	transaction := tosca.Transaction{
-		Recipient: &tosca.Address{1},
+		Sender:    sender,
+		Recipient: &recipient,
 		AccessList: []tosca.AccessTuple{
 			{
-				Address: tosca.Address{2},
+				Address: accessListAddress,
 				Keys:    []tosca.Key{{1}, {2}},
 			},
 		},
 	}
 
-	context.EXPECT().AccessAccount(*transaction.Recipient)
 	for _, contract := range getPrecompiledAddresses(tosca.R09_Berlin) {
 		context.EXPECT().AccessAccount(contract)
 	}
-	context.EXPECT().AccessStorage(tosca.Address{2}, tosca.Key{1})
-	context.EXPECT().AccessStorage(tosca.Address{2}, tosca.Key{2})
+	context.EXPECT().AccessAccount(sender)
+	context.EXPECT().AccessAccount(recipient)
+	context.EXPECT().AccessAccount(accessListAddress)
+	context.EXPECT().AccessStorage(accessListAddress, tosca.Key{1})
+	context.EXPECT().AccessStorage(accessListAddress, tosca.Key{2})
+
+	setUpAccessList(transaction, context, tosca.R09_Berlin)
+}
+
+func TestProcessor_AccessListIsNotCreatedIfTransactionHasNone(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	context := tosca.NewMockTransactionContext(ctrl)
+	// No calls to context
+
+	sender := tosca.Address{1}
+	recipient := tosca.Address{2}
+
+	transaction := tosca.Transaction{
+		Sender:    sender,
+		Recipient: &recipient,
+	}
 
 	setUpAccessList(transaction, context, tosca.R09_Berlin)
 }


### PR DESCRIPTION
For the access list introduced in the Berlin revision, the sender is always warm and the account which storage keys are warm is also marked as warm.