### PR TITLE
Floria: Split call into calls and creates

### DIFF
--- a/go/processor/floria/precompiled.go
+++ b/go/processor/floria/precompiled.go
@@ -16,6 +16,11 @@ import (
 	geth "github.com/ethereum/go-ethereum/core/vm"
 )
 
+func isPrecompiled(address tosca.Address, revision tosca.Revision) bool {
+	_, ok := getPrecompiledContract(address, revision)
+	return ok
+}
+
 func handlePrecompiledContract(revision tosca.Revision, input tosca.Data, address tosca.Address, gas tosca.Gas) (tosca.CallResult, bool) {
 	contract, ok := getPrecompiledContract(address, revision)
 	if !ok {

--- a/go/processor/floria/run_context.go
+++ b/go/processor/floria/run_context.go
@@ -32,75 +32,75 @@ type runContext struct {
 }
 
 func (r runContext) Call(kind tosca.CallKind, parameters tosca.CallParameters) (tosca.CallResult, error) {
+	if kind == tosca.Create || kind == tosca.Create2 {
+		return r.Creates(kind, parameters)
+	}
+	return r.Calls(kind, parameters)
+}
+
+func (r runContext) Calls(kind tosca.CallKind, parameters tosca.CallParameters) (tosca.CallResult, error) {
+	errResult := tosca.CallResult{
+		Success: false,
+		GasLeft: parameters.Gas,
+	}
 	if r.depth > MaxRecursiveDepth {
-		return tosca.CallResult{}, nil
+		return errResult, nil
 	}
 	r.depth++
 	defer func() { r.depth-- }()
 
-	codeHash := r.GetCodeHash(parameters.Recipient)
-	code := r.GetCode(parameters.Recipient)
-
-	if kind == tosca.DelegateCall || kind == tosca.CallCode {
-		code = r.GetCode(parameters.CodeAddress)
-		codeHash = r.GetCodeHash(parameters.CodeAddress)
+	if kind == tosca.Call || kind == tosca.CallCode {
+		if !canTransferValue(r, parameters.Value, parameters.Sender, &parameters.Recipient) {
+			return errResult, nil
+		}
 	}
-
+	snapshot := r.CreateSnapshot()
 	recipient := parameters.Recipient
-	var createdAddress tosca.Address
-	if kind == tosca.Create || kind == tosca.Create2 {
-		if parameters.Recipient == (tosca.Address{}) {
-			code = tosca.Code(parameters.Input)
-			codeHash = hashCode(code)
-		}
-		createdAddress = createAddress(
-			kind,
-			parameters.Sender,
-			r.GetNonce(parameters.Sender),
-			parameters.Salt,
-			codeHash,
-		)
-		if r.GetNonce(createdAddress) != 0 ||
-			(r.GetCodeHash(createdAddress) != (tosca.Hash{}) &&
-				r.GetCodeHash(createdAddress) != emptyCodeHash) {
-			return tosca.CallResult{}, nil
-		}
-
-		r.SetNonce(parameters.Sender, r.GetNonce(parameters.Sender)+1)
-		r.SetNonce(createdAddress, 1)
-		recipient = createdAddress
-	}
 
 	if kind == tosca.StaticCall {
 		r.static = true
 	}
 
-	snapshot := r.CreateSnapshot()
+	if !isPrecompiled(recipient, r.blockParameters.Revision) && !isStateContract(recipient) &&
+		!r.AccountExists(recipient) && r.blockParameters.Revision >= tosca.R09_Berlin &&
+		parameters.Value.Cmp(tosca.Value{}) == 0 {
+		return tosca.CallResult{Success: true, GasLeft: parameters.Gas}, nil
+	}
 
-	// StaticCall and DelegateCall do not transfer value
-	if kind != tosca.StaticCall && kind != tosca.DelegateCall {
-		if err := transferValue(r, parameters.Value, parameters.Sender, recipient); err != nil {
-			r.RestoreSnapshot(snapshot)
-			return tosca.CallResult{}, nil
+	if kind == tosca.Call || kind == tosca.CallCode {
+		transferValue(r, parameters.Value, parameters.Sender, recipient)
+	}
+
+	if kind == tosca.Call {
+		result, isStatePrecompiled := handleStateContract(
+			r, parameters.Sender, recipient, parameters.Input, parameters.Gas)
+		if isStatePrecompiled {
+			if !result.Success {
+				r.RestoreSnapshot(snapshot)
+				result.GasLeft = 0
+			}
+			return result, nil
 		}
 	}
 
-	output, isStatePrecompiled := handleStateContract(
-		r, parameters.Sender, parameters.Recipient, parameters.Input, parameters.Gas)
-	if isStatePrecompiled {
-		return output, nil
-	}
-	output, isPrecompiled := handlePrecompiledContract(
+	result, isPrecompiled := handlePrecompiledContract(
 		r.blockParameters.Revision, parameters.Input, recipient, parameters.Gas)
 	if isPrecompiled {
-		return output, nil
+		if !result.Success {
+			r.RestoreSnapshot(snapshot)
+			result.GasLeft = 0
+		}
+		return result, nil
 	}
 
-	if kind == tosca.Call && !r.AccountExists(recipient) {
-		return tosca.CallResult{
-			Success: true,
-			GasLeft: parameters.Gas,
-		}, nil
+	var codeHash tosca.Hash
+	var code tosca.Code
+	if kind == tosca.Call || kind == tosca.StaticCall {
+		codeHash = r.GetCodeHash(recipient)
+		code = r.GetCode(recipient)
+	} else {
+		code = r.GetCode(parameters.CodeAddress)
+		codeHash = r.GetCodeHash(parameters.CodeAddress)
 	}
 
 	interpreterParameters := tosca.Parameters{
@@ -119,24 +119,107 @@ func (r runContext) Call(kind tosca.CallKind, parameters tosca.CallParameters) (
 		Code:                  code,
 	}
 
-	result, err := r.interpreter.Run(interpreterParameters)
-	if err != nil || !result.Success {
+	callResult, err := r.interpreter.Run(interpreterParameters)
+	if (callResult.GasLeft > 0 || len(callResult.Output) > 0) && !callResult.Success {
+		// Revert
 		r.RestoreSnapshot(snapshot)
-	} else if kind == tosca.Create || kind == tosca.Create2 {
-		code := result.Output
-		if len(code) > maxCodeSize {
-			return tosca.CallResult{}, nil
-		}
-		if r.blockParameters.Revision >= tosca.R10_London && len(code) > 0 && code[0] == 0xEF {
-			return tosca.CallResult{}, nil
-		}
-		createGas := tosca.Gas(len(result.Output) * createGasCostPerByte)
-		if result.GasLeft < createGas {
-			return tosca.CallResult{}, nil
-		}
-		result.GasLeft -= createGas
+	} else if err != nil || !callResult.Success {
+		r.RestoreSnapshot(snapshot)
+		callResult.GasLeft = 0
+	}
 
-		r.SetCode(createdAddress, tosca.Code(result.Output))
+	return tosca.CallResult{
+		Output:    callResult.Output,
+		GasLeft:   callResult.GasLeft,
+		GasRefund: callResult.GasRefund,
+		Success:   callResult.Success,
+	}, err
+}
+
+func (r runContext) Creates(kind tosca.CallKind, parameters tosca.CallParameters) (tosca.CallResult, error) {
+	errResult := tosca.CallResult{
+		Success: false,
+		GasLeft: parameters.Gas,
+	}
+	if r.depth > MaxRecursiveDepth {
+		return errResult, nil
+	}
+	r.depth++
+	defer func() { r.depth-- }()
+
+	if !canTransferValue(r, parameters.Value, parameters.Sender, &parameters.Recipient) {
+		return errResult, nil
+	}
+	if err := incrementNonce(r, parameters.Sender); err != nil {
+		return errResult, nil
+	}
+
+	code := tosca.Code(parameters.Input)
+	codeHash := hashCode(code)
+
+	createdAddress := createAddress(kind, parameters.Sender, r.GetNonce(parameters.Sender)-1,
+		parameters.Salt, codeHash)
+
+	if r.blockParameters.Revision >= tosca.R09_Berlin {
+		r.AccessAccount(createdAddress)
+	}
+
+	if r.GetNonce(createdAddress) != 0 ||
+		(r.GetCodeHash(createdAddress) != (tosca.Hash{}) &&
+			r.GetCodeHash(createdAddress) != emptyCodeHash) {
+		return tosca.CallResult{}, nil
+	}
+	snapshot := r.CreateSnapshot()
+	r.SetNonce(createdAddress, 1)
+
+	transferValue(r, parameters.Value, parameters.Sender, createdAddress)
+
+	interpreterParameters := tosca.Parameters{
+		BlockParameters:       r.blockParameters,
+		TransactionParameters: r.transactionParameters,
+		Context:               r,
+		Kind:                  kind,
+		Static:                r.static,
+		Depth:                 r.depth - 1, // depth has already been incremented
+		Gas:                   parameters.Gas,
+		Recipient:             createdAddress,
+		Sender:                parameters.Sender,
+		Input:                 nil,
+		Value:                 parameters.Value,
+		CodeHash:              &codeHash,
+		Code:                  code,
+	}
+
+	result, err := r.interpreter.Run(interpreterParameters)
+	if err != nil {
+		r.RestoreSnapshot(snapshot)
+		return tosca.CallResult{}, err
+	}
+	if (result.GasLeft > 0 || len(result.Output) > 0) && !result.Success {
+		// Revert
+		r.RestoreSnapshot(snapshot)
+		return tosca.CallResult{Output: result.Output, GasLeft: result.GasLeft, CreatedAddress: createdAddress}, nil
+	}
+
+	outCode := result.Output
+	if len(outCode) > maxCodeSize {
+		result.Success = false
+	}
+	if r.blockParameters.Revision >= tosca.R10_London && len(outCode) > 0 && outCode[0] == 0xEF {
+		result.Success = false
+	}
+	createGas := tosca.Gas(len(outCode) * createGasCostPerByte)
+	if result.GasLeft < createGas {
+		result.Success = false
+	}
+	result.GasLeft -= createGas
+
+	if result.Success {
+		r.SetCode(createdAddress, tosca.Code(outCode))
+	} else {
+		r.RestoreSnapshot(snapshot)
+		result.GasLeft = 0
+		result.Output = nil
 	}
 
 	return tosca.CallResult{
@@ -145,7 +228,7 @@ func (r runContext) Call(kind tosca.CallKind, parameters tosca.CallParameters) (
 		GasRefund:      result.GasRefund,
 		Success:        result.Success,
 		CreatedAddress: createdAddress,
-	}, err
+	}, nil
 }
 
 func hashCode(code tosca.Code) tosca.Hash {
@@ -165,34 +248,62 @@ func createAddress(
 	return tosca.Address(crypto.CreateAddress2(common.Address(sender), common.Hash(salt), initHash[:]))
 }
 
+func canTransferValue(
+	context tosca.TransactionContext,
+	value tosca.Value,
+	sender tosca.Address,
+	recipient *tosca.Address,
+) bool {
+	if value == (tosca.Value{}) {
+		return true
+	}
+
+	senderBalance := context.GetBalance(sender)
+	if senderBalance.Cmp(value) < 0 {
+		return false
+	}
+
+	if recipient == nil || sender == *recipient {
+		return true
+	}
+
+	receiverBalance := context.GetBalance(*recipient)
+	updatedBalance := tosca.Add(receiverBalance, value)
+	if updatedBalance.Cmp(receiverBalance) < 0 || updatedBalance.Cmp(value) < 0 {
+		return false
+	}
+
+	return true
+}
+
+func incrementNonce(context tosca.TransactionContext, address tosca.Address) error {
+	nonce := context.GetNonce(address)
+	if nonce+1 < nonce {
+		return fmt.Errorf("nonce overflow")
+	}
+	context.SetNonce(address, nonce+1)
+	return nil
+}
+
+// Only to be called after canTransferValue
 func transferValue(
 	context tosca.TransactionContext,
 	value tosca.Value,
 	sender tosca.Address,
 	recipient tosca.Address,
-) error {
+) {
 	if value == (tosca.Value{}) {
-		return nil
+		return
+	}
+	if sender == recipient {
+		return
 	}
 
 	senderBalance := context.GetBalance(sender)
-	if senderBalance.Cmp(value) < 0 {
-		return fmt.Errorf("insufficient balance: %v < %v", senderBalance, value)
-	}
-
-	if sender == recipient {
-		return nil
-	}
-
 	receiverBalance := context.GetBalance(recipient)
 	updatedBalance := tosca.Add(receiverBalance, value)
-	if updatedBalance.Cmp(receiverBalance) < 0 || updatedBalance.Cmp(value) < 0 {
-		return fmt.Errorf("overflow: %v + %v", receiverBalance, value)
-	}
 
 	senderBalance = tosca.Sub(senderBalance, value)
 	context.SetBalance(sender, senderBalance)
 	context.SetBalance(recipient, updatedBalance)
-
-	return nil
 }

--- a/go/processor/floria/run_context_test.go
+++ b/go/processor/floria/run_context_test.go
@@ -11,6 +11,7 @@
 package floria
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -118,8 +119,8 @@ func TestCall_TransferValueInCall(t *testing.T) {
 	context.EXPECT().AccountExists(params.Recipient).Return(true)
 	context.EXPECT().CreateSnapshot()
 
-	context.EXPECT().GetBalance(params.Sender).Return(tosca.NewValue(100))
-	context.EXPECT().GetBalance(params.Recipient).Return(tosca.NewValue(0))
+	context.EXPECT().GetBalance(params.Sender).Return(tosca.NewValue(100)).Times(2)
+	context.EXPECT().GetBalance(params.Recipient).Return(tosca.NewValue(0)).Times(2)
 	context.EXPECT().SetBalance(params.Sender, tosca.NewValue(90))
 	context.EXPECT().SetBalance(params.Recipient, tosca.NewValue(10))
 
@@ -128,6 +129,54 @@ func TestCall_TransferValueInCall(t *testing.T) {
 	_, err := runContext.Call(tosca.Call, params)
 	if err != nil {
 		t.Errorf("transferValue returned an error: %v", err)
+	}
+}
+
+func TestCall_TransferValueInCreate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	context := tosca.NewMockTransactionContext(ctrl)
+	interpreter := tosca.NewMockInterpreter(ctrl)
+	runContext := runContext{
+		context,
+		interpreter,
+		tosca.BlockParameters{},
+		tosca.TransactionParameters{},
+		0,
+		false,
+	}
+
+	params := tosca.CallParameters{
+		Sender: tosca.Address{1},
+		Value:  tosca.NewValue(10),
+		Gas:    1000,
+		Input:  []byte{},
+	}
+	code := tosca.Code{}
+	createdAddress := tosca.Address(crypto.CreateAddress(common.Address(params.Sender), 0))
+
+	context.EXPECT().GetBalance(params.Sender).Return(tosca.NewValue(100))
+	context.EXPECT().GetBalance(params.Recipient).Return(tosca.NewValue(0))
+	context.EXPECT().GetNonce(params.Sender).Return(uint64(0))
+	context.EXPECT().SetNonce(params.Sender, uint64(1))
+	context.EXPECT().GetNonce((params.Sender)).Return(uint64(1))
+	context.EXPECT().GetNonce(createdAddress).Return(uint64(0))
+	context.EXPECT().GetCodeHash(createdAddress).Return(tosca.Hash{})
+	context.EXPECT().CreateSnapshot()
+	context.EXPECT().SetNonce(createdAddress, uint64(1))
+	context.EXPECT().GetBalance(params.Sender).Return(tosca.NewValue(100))
+	context.EXPECT().GetBalance(createdAddress).Return(tosca.NewValue(0))
+	context.EXPECT().SetBalance(params.Sender, tosca.NewValue(90))
+	context.EXPECT().SetBalance(createdAddress, tosca.NewValue(10))
+	context.EXPECT().SetCode(createdAddress, code)
+
+	interpreter.EXPECT().Run(gomock.Any()).Return(tosca.Result{Success: true, Output: tosca.Data(code)}, nil)
+
+	result, err := runContext.Call(tosca.Create, params)
+	if err != nil {
+		t.Errorf("transferValue returned an error: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("transferValue was not successful")
 	}
 }
 
@@ -151,12 +200,7 @@ func TestTransferValue_InCallRestoreFailed(t *testing.T) {
 		Gas:       1000,
 		Input:     []byte{},
 	}
-
-	context.EXPECT().GetCodeHash(params.Recipient).Return(tosca.Hash{})
-	context.EXPECT().GetCode(params.Recipient).Return([]byte{})
-	context.EXPECT().CreateSnapshot()
 	context.EXPECT().GetBalance(params.Sender).Return(tosca.NewValue(0))
-	context.EXPECT().RestoreSnapshot(gomock.Any())
 
 	result, err := runContext.Call(tosca.Call, params)
 	if err != nil {
@@ -192,13 +236,10 @@ func TestTransferValue_SuccessfulValueTransfer(t *testing.T) {
 			if name != "zeroValue" {
 				context.EXPECT().GetBalance(transaction.Sender).Return(senderBalance)
 				context.EXPECT().GetBalance(*transaction.Recipient).Return(recipientBalance)
-				context.EXPECT().SetBalance(transaction.Sender, tosca.Sub(senderBalance, value))
-				context.EXPECT().SetBalance(*transaction.Recipient, tosca.Add(recipientBalance, value))
 			}
 
-			err := transferValue(context, transaction.Value, transaction.Sender, *transaction.Recipient)
-			if err != nil {
-				t.Errorf("transferValue returned an error: %v", err)
+			if !canTransferValue(context, transaction.Value, transaction.Sender, transaction.Recipient) {
+				t.Errorf("Value should be possible but was not")
 			}
 		})
 	}
@@ -230,15 +271,14 @@ func TestTransferValue_FailedValueTransfer(t *testing.T) {
 			context.EXPECT().GetBalance(tosca.Address{1}).Return(transfer.senderBalance).AnyTimes()
 			context.EXPECT().GetBalance(tosca.Address{2}).Return(transfer.receiverBalance).AnyTimes()
 
-			err := transferValue(context, transfer.value, tosca.Address{1}, tosca.Address{2})
-			if err == nil {
-				t.Errorf("transferValue should have returned an error")
+			if canTransferValue(context, transfer.value, tosca.Address{1}, &tosca.Address{2}) {
+				t.Errorf("value transfer should have returned an error")
 			}
 		})
 	}
 }
 
-func TestTransferValue_SameSenderAndReceiver(t *testing.T) {
+func TestCanTransferValue_SameSenderAndReceiver(t *testing.T) {
 	tests := map[string]struct {
 		value         tosca.Value
 		expectedError bool
@@ -252,17 +292,27 @@ func TestTransferValue_SameSenderAndReceiver(t *testing.T) {
 		context := tosca.NewMockTransactionContext(ctrl)
 		context.EXPECT().GetBalance(gomock.Any()).Return(tosca.NewValue(100))
 
-		err := transferValue(context, test.value, tosca.Address{1}, tosca.Address{1})
+		canTransfer := canTransferValue(context, test.value, tosca.Address{1}, &tosca.Address{1})
 		if test.expectedError {
-			if err == nil {
-				t.Errorf("transfer value should have returned an error")
+			if canTransfer {
+				t.Errorf("transfer value should have not been possible")
 			}
 		} else {
-			if err != nil {
-				t.Errorf("transfer value returned an unexpected error: %v", err)
+			if !canTransfer {
+				t.Errorf("transfer value should have been possible")
 			}
 		}
 	}
+}
+
+func TestTransferValue_BalanceIsNotChangedWhenValueIsTransferredToTheSameAccount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	context := tosca.NewMockTransactionContext(ctrl)
+
+	address := tosca.Address{1}
+	value := tosca.NewValue(10)
+
+	transferValue(context, value, address, address)
 }
 
 func TestCreateAddress(t *testing.T) {
@@ -300,6 +350,36 @@ func TestCreateAddress(t *testing.T) {
 			result := createAddress(test.kind, test.sender, test.nonce, test.salt, test.initHash)
 			if result != want {
 				t.Errorf("Unexpected address, got: %v, want: %v", result, want)
+			}
+		})
+	}
+}
+
+func TestIncrementNonce(t *testing.T) {
+	tests := map[string]struct {
+		nonce uint64
+		err   error
+	}{
+		"zero": {
+			nonce: 0,
+			err:   nil,
+		},
+		"max": {
+			nonce: math.MaxUint64,
+			err:   fmt.Errorf("nonce overflow"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			context := tosca.NewMockTransactionContext(ctrl)
+			context.EXPECT().GetNonce(gomock.Any()).Return(test.nonce)
+			context.EXPECT().SetNonce(gomock.Any(), test.nonce+1).AnyTimes()
+
+			err := incrementNonce(context, tosca.Address{})
+			if test.err != nil && err == nil {
+				t.Errorf("incrementNonce returned an unexpected error: %v", err)
 			}
 		})
 	}

--- a/go/processor/floria/run_context_test.go
+++ b/go/processor/floria/run_context_test.go
@@ -74,7 +74,6 @@ func TestCalls_InterpreterResultIsHandledCorrectly(t *testing.T) {
 			context.EXPECT().GetCodeHash(params.Recipient).Return(tosca.Hash{})
 			context.EXPECT().GetCode(params.Recipient).Return([]byte{})
 			context.EXPECT().CreateSnapshot()
-			context.EXPECT().AccountExists(params.Recipient).Return(true)
 			context.EXPECT().RestoreSnapshot(gomock.Any()).AnyTimes()
 
 			test.setup(interpreter)
@@ -116,7 +115,6 @@ func TestCall_TransferValueInCall(t *testing.T) {
 
 	context.EXPECT().GetCodeHash(params.Recipient).Return(tosca.Hash{})
 	context.EXPECT().GetCode(params.Recipient).Return([]byte{})
-	context.EXPECT().AccountExists(params.Recipient).Return(true)
 	context.EXPECT().CreateSnapshot()
 
 	context.EXPECT().GetBalance(params.Sender).Return(tosca.NewValue(100)).Times(2)

--- a/go/processor/floria/state_contract.go
+++ b/go/processor/floria/state_contract.go
@@ -79,6 +79,10 @@ func init() {
 var ErrExecutionReverted = fmt.Errorf("execution reverted")
 var ErrOutOfGas = fmt.Errorf("out of gas")
 
+func isStateContract(address tosca.Address) bool {
+	return address == StateContractAddress()
+}
+
 // handleStateContract is a reworked version of the original function from the Opera client.
 // It is used to handle epochs and allows to set balance, copy code, swap code, set storage, and increment nonce.
 // Source: https://github.com/Fantom-foundation/Sonic/blob/main/opera/contracts/evmwriter/evm_writer.go#L24


### PR DESCRIPTION
The overlapping code between all 4 call types and 2 create types is not big enough to justify all the if checks, therefore the call function is split into calls and creates.
With this change checks required for the create instructions have been added and the call instructions have been simplified.